### PR TITLE
feat: add slot-based multi-llm routing

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
@@ -16,6 +16,8 @@ package com.openmemind.ai.memory.core.builder;
 import com.openmemind.ai.memory.core.DefaultMemory;
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.NoopReranker;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
@@ -25,13 +27,17 @@ import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public final class DefaultMemoryBuilder implements MemoryBuilder {
 
     private StructuredChatClient chatClient;
+    private final Map<ChatClientSlot, StructuredChatClient> slotClients =
+            new EnumMap<>(ChatClientSlot.class);
     private MemoryStore store;
     private MemoryBuffer buffer;
     private MemoryTextSearch textSearch;
@@ -42,6 +48,14 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
     @Override
     public MemoryBuilder chatClient(StructuredChatClient chatClient) {
         this.chatClient = Objects.requireNonNull(chatClient, "chatClient");
+        return this;
+    }
+
+    @Override
+    public MemoryBuilder chatClient(ChatClientSlot slot, StructuredChatClient chatClient) {
+        Objects.requireNonNull(slot, "slot");
+        Objects.requireNonNull(chatClient, "chatClient");
+        slotClients.put(slot, chatClient);
         return this;
     }
 
@@ -85,9 +99,10 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
     public Memory build() {
         validateRequiredComponents();
 
+        ChatClientRegistry registry = new ChatClientRegistry(chatClient, slotClients);
         MemoryAssemblyContext context =
                 new MemoryAssemblyContext(
-                        chatClient, store, buffer, textSearch, vector, reranker, options);
+                        registry, store, buffer, textSearch, vector, reranker, options);
         MemoryExtractionAssembly extractionAssembly =
                 new MemoryExtractionAssembler().assemble(context);
         var memoryRetriever = new MemoryRetrievalAssembler().assemble(context);
@@ -103,7 +118,7 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                 lifecycle(
                         context.memoryVector(),
                         context.textSearch(),
-                        context.chatClient(),
+                        context.chatClientRegistry().defaultClient(),
                         context.memoryStore(),
                         context.memoryBuffer(),
                         extractionAssembly.lifecycle()));

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryAssemblyContext.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryAssemblyContext.java
@@ -17,7 +17,7 @@ import com.openmemind.ai.memory.core.buffer.InsightBuffer;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
 import com.openmemind.ai.memory.core.buffer.PendingConversationBuffer;
 import com.openmemind.ai.memory.core.buffer.RecentConversationBuffer;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
@@ -25,7 +25,7 @@ import com.openmemind.ai.memory.core.vector.MemoryVector;
 import java.util.Objects;
 
 record MemoryAssemblyContext(
-        StructuredChatClient chatClient,
+        ChatClientRegistry chatClientRegistry,
         MemoryStore memoryStore,
         MemoryBuffer memoryBuffer,
         MemoryTextSearch textSearch,
@@ -34,7 +34,7 @@ record MemoryAssemblyContext(
         MemoryBuildOptions options) {
 
     MemoryAssemblyContext {
-        Objects.requireNonNull(chatClient, "chatClient");
+        Objects.requireNonNull(chatClientRegistry, "chatClientRegistry");
         Objects.requireNonNull(memoryStore, "memoryStore");
         Objects.requireNonNull(memoryStore.rawDataOperations(), "memoryStore.rawDataOperations()");
         Objects.requireNonNull(memoryStore.itemOperations(), "memoryStore.itemOperations()");

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryBuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryBuilder.java
@@ -15,6 +15,7 @@ package com.openmemind.ai.memory.core.builder;
 
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.store.MemoryStore;
@@ -27,6 +28,8 @@ import com.openmemind.ai.memory.core.vector.MemoryVector;
 public interface MemoryBuilder {
 
     MemoryBuilder chatClient(StructuredChatClient chatClient);
+
+    MemoryBuilder chatClient(ChatClientSlot slot, StructuredChatClient chatClient);
 
     MemoryBuilder store(MemoryStore store);
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryExtractionAssembler.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryExtractionAssembler.java
@@ -45,7 +45,8 @@ import com.openmemind.ai.memory.core.extraction.rawdata.chunk.ConversationChunke
 import com.openmemind.ai.memory.core.extraction.rawdata.chunk.LlmConversationChunker;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ConversationContentProcessor;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ToolCallContentProcessor;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.utils.IdUtils;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -56,10 +57,12 @@ import java.util.stream.Collectors;
 final class MemoryExtractionAssembler {
 
     MemoryExtractionAssembly assemble(MemoryAssemblyContext context) {
-        StructuredChatClient chatClient = context.chatClient();
-        CaptionGenerator captionGenerator = new LlmConversationCaptionGenerator(chatClient);
+        ChatClientRegistry registry = context.chatClientRegistry();
+        CaptionGenerator captionGenerator =
+                new LlmConversationCaptionGenerator(
+                        registry.resolve(ChatClientSlot.CAPTION_GENERATOR));
         List<RawContentProcessor<?>> processors =
-                createProcessors(chatClient, captionGenerator, context.options());
+                createProcessors(registry, captionGenerator, context.options());
         RawDataLayer rawDataLayer =
                 new RawDataLayer(
                         processors,
@@ -67,7 +70,7 @@ final class MemoryExtractionAssembler {
                         context.memoryStore(),
                         context.memoryVector());
 
-        MemoryItemExtractor itemExtractor = createMemoryItemExtractor(chatClient, processors);
+        MemoryItemExtractor itemExtractor = createMemoryItemExtractor(registry, processors);
         MemoryItemDeduplicator deduplicator =
                 new CompositeDeduplicator(
                         List.of(new HashBasedDeduplicator(context.memoryStore())));
@@ -81,8 +84,11 @@ final class MemoryExtractionAssembler {
                         null,
                         conversationCategories());
 
-        InsightGenerator insightGenerator = new LlmInsightGenerator(chatClient);
-        InsightGroupClassifier insightGroupClassifier = new LlmInsightGroupClassifier(chatClient);
+        InsightGenerator insightGenerator =
+                new LlmInsightGenerator(registry.resolve(ChatClientSlot.INSIGHT_GENERATOR));
+        InsightGroupClassifier insightGroupClassifier =
+                new LlmInsightGroupClassifier(
+                        registry.resolve(ChatClientSlot.INSIGHT_GROUP_CLASSIFIER));
         BubbleTrackerStore bubbleTrackerStore = new BubbleTracker();
         InsightTreeReorganizer insightTreeReorganizer =
                 new InsightTreeReorganizer(
@@ -111,7 +117,9 @@ final class MemoryExtractionAssembler {
                         unsupportedInsightTypes(processors));
 
         ContextCommitDetector contextCommitDetector =
-                new LlmContextCommitDetector(context.options().boundaryDetector(), chatClient);
+                new LlmContextCommitDetector(
+                        context.options().boundaryDetector(),
+                        registry.resolve(ChatClientSlot.CONTEXT_COMMIT_DETECTOR));
         MemoryExtractionPipeline pipeline =
                 new MemoryExtractor(
                         rawDataLayer,
@@ -125,12 +133,13 @@ final class MemoryExtractionAssembler {
     }
 
     private List<RawContentProcessor<?>> createProcessors(
-            StructuredChatClient chatClient,
+            ChatClientRegistry registry,
             CaptionGenerator captionGenerator,
             MemoryBuildOptions options) {
         ConversationChunker conversationChunker = new ConversationChunker();
         LlmConversationChunker llmConversationChunker =
-                new LlmConversationChunker(chatClient, conversationChunker);
+                new LlmConversationChunker(
+                        registry.resolve(ChatClientSlot.CONVERSATION_CHUNKER), conversationChunker);
 
         ConversationContentProcessor conversationProcessor =
                 new ConversationContentProcessor(
@@ -140,13 +149,15 @@ final class MemoryExtractionAssembler {
                         captionGenerator,
                         null);
         ToolCallContentProcessor toolCallProcessor =
-                new ToolCallContentProcessor(new LlmToolCallItemExtractionStrategy(chatClient));
+                new ToolCallContentProcessor(
+                        new LlmToolCallItemExtractionStrategy(
+                                registry.resolve(ChatClientSlot.TOOL_CALL_EXTRACTION)));
 
         return List.of(conversationProcessor, toolCallProcessor);
     }
 
     private MemoryItemExtractor createMemoryItemExtractor(
-            StructuredChatClient chatClient, List<RawContentProcessor<?>> processors) {
+            ChatClientRegistry registry, List<RawContentProcessor<?>> processors) {
         var strategies = new HashMap<String, ItemExtractionStrategy>();
         for (var processor : processors) {
             if (processor.itemExtractionStrategy() != null) {
@@ -154,7 +165,9 @@ final class MemoryExtractionAssembler {
             }
         }
 
-        var defaultStrategy = new LlmItemExtractionStrategy(chatClient, conversationCategories());
+        var defaultStrategy =
+                new LlmItemExtractionStrategy(
+                        registry.resolve(ChatClientSlot.ITEM_EXTRACTION), conversationCategories());
         return new DefaultMemoryItemExtractor(defaultStrategy, strategies);
     }
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
@@ -13,7 +13,8 @@
  */
 package com.openmemind.ai.memory.core.builder;
 
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.cache.CaffeineRetrievalCache;
 import com.openmemind.ai.memory.core.retrieval.cache.RetrievalCache;
@@ -31,16 +32,19 @@ import com.openmemind.ai.memory.core.retrieval.tier.LlmInsightTypeRouter;
 final class MemoryRetrievalAssembler {
 
     DefaultMemoryRetriever assemble(MemoryAssemblyContext context) {
-        StructuredChatClient chatClient = context.chatClient();
-        InsightTypeRouter insightTypeRouter = new LlmInsightTypeRouter(chatClient);
+        ChatClientRegistry registry = context.chatClientRegistry();
+        InsightTypeRouter insightTypeRouter =
+                new LlmInsightTypeRouter(registry.resolve(ChatClientSlot.INSIGHT_TYPE_ROUTER));
         InsightTierRetriever insightTierRetriever =
                 new InsightTierRetriever(
                         context.memoryStore(), context.memoryVector(), insightTypeRouter);
         ItemTierRetriever itemTierRetriever =
                 new ItemTierRetriever(
                         context.memoryStore(), context.memoryVector(), context.textSearch());
-        SufficiencyGate sufficiencyGate = new LlmSufficiencyGate(chatClient);
-        TypedQueryExpander typedQueryExpander = new LlmTypedQueryExpander(chatClient);
+        SufficiencyGate sufficiencyGate =
+                new LlmSufficiencyGate(registry.resolve(ChatClientSlot.SUFFICIENCY_GATE));
+        TypedQueryExpander typedQueryExpander =
+                new LlmTypedQueryExpander(registry.resolve(ChatClientSlot.QUERY_EXPANDER));
         DeepRetrievalStrategy deepRetrievalStrategy =
                 new DeepRetrievalStrategy(
                         insightTierRetriever,

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/llm/ChatClientRegistry.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/llm/ChatClientRegistry.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.llm;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Resolves a {@link StructuredChatClient} for a given {@link ChatClientSlot}.
+ *
+ * <p>Each slot can be bound to a specific client. Unbound slots fall back to
+ * the default client. Immutable after construction.
+ */
+public final class ChatClientRegistry {
+
+    private final StructuredChatClient defaultClient;
+    private final Map<ChatClientSlot, StructuredChatClient> slotClients;
+
+    public ChatClientRegistry(
+            StructuredChatClient defaultClient,
+            Map<ChatClientSlot, StructuredChatClient> slotClients) {
+        this.defaultClient = Objects.requireNonNull(defaultClient, "defaultClient");
+        this.slotClients = Map.copyOf(Objects.requireNonNull(slotClients, "slotClients"));
+    }
+
+    public StructuredChatClient resolve(ChatClientSlot slot) {
+        return slotClients.getOrDefault(slot, defaultClient);
+    }
+
+    public StructuredChatClient defaultClient() {
+        return defaultClient;
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/llm/ChatClientSlot.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/llm/ChatClientSlot.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.llm;
+
+/**
+ * Identifies each LLM call site in the memind pipeline.
+ *
+ * <p>Used with {@link ChatClientRegistry} to bind different
+ * {@link StructuredChatClient} instances to specific pipeline components.
+ */
+public enum ChatClientSlot {
+    ITEM_EXTRACTION,
+    TOOL_CALL_EXTRACTION,
+    CONVERSATION_CHUNKER,
+    CAPTION_GENERATOR,
+    CONTEXT_COMMIT_DETECTOR,
+    INSIGHT_GENERATOR,
+    INSIGHT_GROUP_CLASSIFIER,
+    QUERY_EXPANDER,
+    SUFFICIENCY_GATE,
+    INSIGHT_TYPE_ROUTER,
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/MemoryAssemblersTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/MemoryAssemblersTest.java
@@ -24,15 +24,32 @@ import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.context.CommitDetectorConfig;
 import com.openmemind.ai.memory.core.extraction.context.LlmContextCommitDetector;
 import com.openmemind.ai.memory.core.extraction.insight.InsightLayer;
+import com.openmemind.ai.memory.core.extraction.insight.generator.LlmInsightGenerator;
+import com.openmemind.ai.memory.core.extraction.insight.group.LlmInsightGroupClassifier;
 import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildScheduler;
+import com.openmemind.ai.memory.core.extraction.item.MemoryItemLayer;
+import com.openmemind.ai.memory.core.extraction.item.extractor.DefaultMemoryItemExtractor;
+import com.openmemind.ai.memory.core.extraction.item.strategy.LlmItemExtractionStrategy;
+import com.openmemind.ai.memory.core.extraction.item.strategy.LlmToolCallItemExtractionStrategy;
 import com.openmemind.ai.memory.core.extraction.rawdata.RawDataLayer;
 import com.openmemind.ai.memory.core.extraction.rawdata.caption.CaptionGenerator;
+import com.openmemind.ai.memory.core.extraction.rawdata.caption.LlmConversationCaptionGenerator;
+import com.openmemind.ai.memory.core.extraction.rawdata.chunk.LlmConversationChunker;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.ConversationContent;
+import com.openmemind.ai.memory.core.extraction.rawdata.content.ToolCallContent;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ConversationContentProcessor;
+import com.openmemind.ai.memory.core.extraction.rawdata.processor.ToolCallContentProcessor;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.NoopReranker;
 import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
+import com.openmemind.ai.memory.core.retrieval.deep.LlmTypedQueryExpander;
+import com.openmemind.ai.memory.core.retrieval.strategy.DeepRetrievalStrategy;
 import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategies;
+import com.openmemind.ai.memory.core.retrieval.sufficiency.LlmSufficiencyGate;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.LlmInsightTypeRouter;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
@@ -84,13 +101,8 @@ class MemoryAssemblersTest {
     void extractionAssemblerUsesMemoryBufferAndBoundaryOptions() {
         CommitDetectorConfig boundaryDetector = new CommitDetectorConfig(6, 2048, 4);
         MemoryAssemblyContext context =
-                new MemoryAssemblyContext(
-                        CHAT_CLIENT,
-                        MEMORY_STORE,
-                        MEMORY_BUFFER,
-                        TEXT_SEARCH,
-                        MEMORY_VECTOR,
-                        new NoopReranker(),
+                context(
+                        Map.of(),
                         MemoryBuildOptions.builder().boundaryDetector(boundaryDetector).build());
 
         MemoryExtractionAssembly assembly = new MemoryExtractionAssembler().assemble(context);
@@ -125,15 +137,7 @@ class MemoryAssemblersTest {
 
     @Test
     void retrievalAssemblerRegistersBuiltInStrategiesAndUsesDataStore() {
-        MemoryAssemblyContext context =
-                new MemoryAssemblyContext(
-                        CHAT_CLIENT,
-                        MEMORY_STORE,
-                        MEMORY_BUFFER,
-                        TEXT_SEARCH,
-                        MEMORY_VECTOR,
-                        new NoopReranker(),
-                        MemoryBuildOptions.defaults());
+        MemoryAssemblyContext context = context();
 
         DefaultMemoryRetriever retriever = new MemoryRetrievalAssembler().assemble(context);
 
@@ -162,6 +166,147 @@ class MemoryAssemblersTest {
                         MemoryCategory.DIRECTIVE,
                         MemoryCategory.PLAYBOOK,
                         MemoryCategory.RESOLUTION);
+    }
+
+    @Test
+    void extractionAssemblerRoutesSlotSpecificClients() {
+        StructuredChatClient captionClient = proxy(StructuredChatClient.class);
+        StructuredChatClient chunkerClient = proxy(StructuredChatClient.class);
+        StructuredChatClient toolCallClient = proxy(StructuredChatClient.class);
+        StructuredChatClient itemClient = proxy(StructuredChatClient.class);
+        StructuredChatClient insightClient = proxy(StructuredChatClient.class);
+        StructuredChatClient groupClient = proxy(StructuredChatClient.class);
+        StructuredChatClient boundaryClient = proxy(StructuredChatClient.class);
+
+        MemoryExtractionAssembly assembly =
+                new MemoryExtractionAssembler()
+                        .assemble(
+                                context(
+                                        Map.of(
+                                                ChatClientSlot.CAPTION_GENERATOR, captionClient,
+                                                ChatClientSlot.CONVERSATION_CHUNKER, chunkerClient,
+                                                ChatClientSlot.TOOL_CALL_EXTRACTION, toolCallClient,
+                                                ChatClientSlot.ITEM_EXTRACTION, itemClient,
+                                                ChatClientSlot.INSIGHT_GENERATOR, insightClient,
+                                                ChatClientSlot.INSIGHT_GROUP_CLASSIFIER,
+                                                        groupClient,
+                                                ChatClientSlot.CONTEXT_COMMIT_DETECTOR,
+                                                        boundaryClient),
+                                        MemoryBuildOptions.defaults()));
+
+        MemoryExtractor extractor = (MemoryExtractor) assembly.pipeline();
+        RawDataLayer rawDataLayer = readField(extractor, "rawDataStep", RawDataLayer.class);
+        LlmConversationCaptionGenerator captionGenerator =
+                readField(
+                        rawDataLayer,
+                        "defaultCaptionGenerator",
+                        LlmConversationCaptionGenerator.class);
+        @SuppressWarnings("unchecked")
+        Map<Class<?>, Object> processors = readField(rawDataLayer, "processors", Map.class);
+        ConversationContentProcessor conversationProcessor =
+                (ConversationContentProcessor) processors.get(ConversationContent.class);
+        ToolCallContentProcessor toolCallProcessor =
+                (ToolCallContentProcessor) processors.get(ToolCallContent.class);
+        LlmConversationChunker llmChunker =
+                readField(
+                        conversationProcessor,
+                        "llmConversationChunker",
+                        LlmConversationChunker.class);
+        LlmToolCallItemExtractionStrategy toolCallStrategy =
+                readField(
+                        toolCallProcessor,
+                        "itemExtractionStrategy",
+                        LlmToolCallItemExtractionStrategy.class);
+        MemoryItemLayer memoryItemLayer =
+                readField(extractor, "memoryItemStep", MemoryItemLayer.class);
+        DefaultMemoryItemExtractor itemExtractor =
+                readField(memoryItemLayer, "extractor", DefaultMemoryItemExtractor.class);
+        LlmItemExtractionStrategy itemStrategy =
+                readField(itemExtractor, "defaultStrategy", LlmItemExtractionStrategy.class);
+        InsightBuildScheduler scheduler =
+                readField(assembly.insightLayer(), "scheduler", InsightBuildScheduler.class);
+        LlmInsightGenerator insightGenerator =
+                readField(scheduler, "generator", LlmInsightGenerator.class);
+        LlmInsightGroupClassifier insightGroupClassifier =
+                readField(scheduler, "groupClassifier", LlmInsightGroupClassifier.class);
+        LlmContextCommitDetector boundaryDetector =
+                readField(extractor, "contextCommitDetector", LlmContextCommitDetector.class);
+
+        assertThat(readField(captionGenerator, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(captionClient);
+        assertThat(readField(llmChunker, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(chunkerClient);
+        assertThat(readField(toolCallStrategy, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(toolCallClient);
+        assertThat(readField(itemStrategy, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(itemClient);
+        assertThat(readField(insightGenerator, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(insightClient);
+        assertThat(
+                        readField(
+                                insightGroupClassifier,
+                                "structuredChatClient",
+                                StructuredChatClient.class))
+                .isSameAs(groupClient);
+        assertThat(readField(boundaryDetector, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(boundaryClient);
+    }
+
+    @Test
+    void retrievalAssemblerRoutesSlotSpecificClients() {
+        StructuredChatClient routerClient = proxy(StructuredChatClient.class);
+        StructuredChatClient sufficiencyClient = proxy(StructuredChatClient.class);
+        StructuredChatClient queryExpanderClient = proxy(StructuredChatClient.class);
+
+        DefaultMemoryRetriever retriever =
+                new MemoryRetrievalAssembler()
+                        .assemble(
+                                context(
+                                        Map.of(
+                                                ChatClientSlot.INSIGHT_TYPE_ROUTER, routerClient,
+                                                ChatClientSlot.SUFFICIENCY_GATE, sufficiencyClient,
+                                                ChatClientSlot.QUERY_EXPANDER, queryExpanderClient),
+                                        MemoryBuildOptions.defaults()));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> strategies = readField(retriever, "strategies", Map.class);
+        DeepRetrievalStrategy deepStrategy =
+                (DeepRetrievalStrategy) strategies.get(RetrievalStrategies.DEEP_RETRIEVAL);
+        InsightTierRetriever insightRetriever =
+                readField(deepStrategy, "insightRetriever", InsightTierRetriever.class);
+        LlmInsightTypeRouter insightTypeRouter =
+                readField(insightRetriever, "router", LlmInsightTypeRouter.class);
+        LlmSufficiencyGate sufficiencyGate =
+                readField(deepStrategy, "sufficiencyGate", LlmSufficiencyGate.class);
+        LlmTypedQueryExpander typedQueryExpander =
+                readField(deepStrategy, "typedQueryExpander", LlmTypedQueryExpander.class);
+
+        assertThat(readField(insightTypeRouter, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(routerClient);
+        assertThat(readField(sufficiencyGate, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(sufficiencyClient);
+        assertThat(
+                        readField(
+                                typedQueryExpander,
+                                "structuredChatClient",
+                                StructuredChatClient.class))
+                .isSameAs(queryExpanderClient);
+    }
+
+    private static MemoryAssemblyContext context() {
+        return context(Map.of(), MemoryBuildOptions.defaults());
+    }
+
+    private static MemoryAssemblyContext context(
+            Map<ChatClientSlot, StructuredChatClient> slotClients, MemoryBuildOptions options) {
+        return new MemoryAssemblyContext(
+                new ChatClientRegistry(CHAT_CLIENT, slotClients),
+                MEMORY_STORE,
+                MEMORY_BUFFER,
+                TEXT_SEARCH,
+                MEMORY_VECTOR,
+                new NoopReranker(),
+                options);
     }
 
     @SuppressWarnings("unchecked")

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/internal/DefaultMemoryBuilderTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/internal/DefaultMemoryBuilderTest.java
@@ -28,11 +28,19 @@ import com.openmemind.ai.memory.core.data.MemoryId;
 import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.context.CommitDetectorConfig;
 import com.openmemind.ai.memory.core.extraction.context.LlmContextCommitDetector;
+import com.openmemind.ai.memory.core.extraction.item.MemoryItemLayer;
+import com.openmemind.ai.memory.core.extraction.item.extractor.DefaultMemoryItemExtractor;
+import com.openmemind.ai.memory.core.extraction.item.strategy.LlmItemExtractionStrategy;
 import com.openmemind.ai.memory.core.extraction.rawdata.RawDataLayer;
 import com.openmemind.ai.memory.core.extraction.rawdata.caption.CaptionGenerator;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.ConversationContent;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ConversationContentProcessor;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
+import com.openmemind.ai.memory.core.retrieval.deep.LlmTypedQueryExpander;
+import com.openmemind.ai.memory.core.retrieval.strategy.DeepRetrievalStrategy;
+import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategies;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
@@ -187,6 +195,49 @@ class DefaultMemoryBuilderTest {
     void defaultBuildOptionsExposeBoundaryDetectorDefaults() {
         assertThat(MemoryBuildOptions.defaults().boundaryDetector())
                 .isEqualTo(CommitDetectorConfig.defaults());
+    }
+
+    @Test
+    void buildRoutesSlotSpecificClients() {
+        TrackingChatClient defaultChatClient = new TrackingChatClient();
+        TrackingChatClient itemExtractionClient = new TrackingChatClient();
+        TrackingChatClient queryExpanderClient = new TrackingChatClient();
+
+        DefaultMemory memory =
+                (DefaultMemory)
+                        Memory.builder()
+                                .chatClient(defaultChatClient)
+                                .chatClient(ChatClientSlot.ITEM_EXTRACTION, itemExtractionClient)
+                                .chatClient(ChatClientSlot.QUERY_EXPANDER, queryExpanderClient)
+                                .store(MEMORY_STORE)
+                                .buffer(MEMORY_BUFFER)
+                                .vector(MEMORY_VECTOR)
+                                .build();
+
+        MemoryExtractor extractor = readField(memory, "extractor", MemoryExtractor.class);
+        MemoryItemLayer memoryItemLayer =
+                readField(extractor, "memoryItemStep", MemoryItemLayer.class);
+        DefaultMemoryItemExtractor itemExtractor =
+                readField(memoryItemLayer, "extractor", DefaultMemoryItemExtractor.class);
+        LlmItemExtractionStrategy itemStrategy =
+                readField(itemExtractor, "defaultStrategy", LlmItemExtractionStrategy.class);
+        DefaultMemoryRetriever retriever =
+                readField(memory, "retriever", DefaultMemoryRetriever.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> strategies = readField(retriever, "strategies", Map.class);
+        DeepRetrievalStrategy deepStrategy =
+                (DeepRetrievalStrategy) strategies.get(RetrievalStrategies.DEEP_RETRIEVAL);
+        LlmTypedQueryExpander typedQueryExpander =
+                readField(deepStrategy, "typedQueryExpander", LlmTypedQueryExpander.class);
+
+        assertThat(readField(itemStrategy, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(itemExtractionClient);
+        assertThat(
+                        readField(
+                                typedQueryExpander,
+                                "structuredChatClient",
+                                StructuredChatClient.class))
+                .isSameAs(queryExpanderClient);
     }
 
     @Test

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/llm/ChatClientRegistryTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/llm/ChatClientRegistryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.llm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class ChatClientRegistryTest {
+
+    private final StructuredChatClient defaultClient = new StubClient("default");
+    private final StructuredChatClient smartClient = new StubClient("smart");
+    private final StructuredChatClient fastClient = new StubClient("fast");
+
+    @Test
+    void resolveReturnsBoundClientForSlot() {
+        var registry =
+                new ChatClientRegistry(
+                        defaultClient, Map.of(ChatClientSlot.ITEM_EXTRACTION, smartClient));
+
+        assertThat(registry.resolve(ChatClientSlot.ITEM_EXTRACTION)).isSameAs(smartClient);
+    }
+
+    @Test
+    void resolveFallsBackToDefaultForUnboundSlot() {
+        var registry =
+                new ChatClientRegistry(
+                        defaultClient, Map.of(ChatClientSlot.ITEM_EXTRACTION, smartClient));
+
+        assertThat(registry.resolve(ChatClientSlot.QUERY_EXPANDER)).isSameAs(defaultClient);
+    }
+
+    @Test
+    void resolveReturnsDefaultWhenNoSlotsBound() {
+        var registry = new ChatClientRegistry(defaultClient, Map.of());
+
+        assertThat(registry.resolve(ChatClientSlot.INSIGHT_GENERATOR)).isSameAs(defaultClient);
+    }
+
+    @Test
+    void multipleSlotsBoundToSameClient() {
+        var registry =
+                new ChatClientRegistry(
+                        defaultClient,
+                        Map.of(
+                                ChatClientSlot.ITEM_EXTRACTION, smartClient,
+                                ChatClientSlot.INSIGHT_GENERATOR, smartClient,
+                                ChatClientSlot.QUERY_EXPANDER, fastClient));
+
+        assertThat(registry.resolve(ChatClientSlot.ITEM_EXTRACTION)).isSameAs(smartClient);
+        assertThat(registry.resolve(ChatClientSlot.INSIGHT_GENERATOR)).isSameAs(smartClient);
+        assertThat(registry.resolve(ChatClientSlot.QUERY_EXPANDER)).isSameAs(fastClient);
+        assertThat(registry.resolve(ChatClientSlot.SUFFICIENCY_GATE)).isSameAs(defaultClient);
+    }
+
+    @Test
+    void constructorRejectsNullDefaultClient() {
+        assertThatThrownBy(() -> new ChatClientRegistry(null, Map.of()))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullSlotClients() {
+        assertThatThrownBy(() -> new ChatClientRegistry(defaultClient, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void defaultClientAccessor() {
+        var registry = new ChatClientRegistry(defaultClient, Map.of());
+
+        assertThat(registry.defaultClient()).isSameAs(defaultClient);
+    }
+
+    private static final class StubClient implements StructuredChatClient {
+
+        private final String name;
+
+        private StubClient(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Mono<String> call(List<ChatMessage> messages) {
+            return Mono.just(name);
+        }
+
+        @Override
+        public <T> Mono<T> call(List<ChatMessage> messages, Class<T> responseType) {
+            return Mono.empty();
+        }
+
+        @Override
+        public String toString() {
+            return "StubClient[" + name + "]";
+        }
+    }
+}

--- a/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryAutoConfiguration.java
+++ b/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryAutoConfiguration.java
@@ -18,7 +18,8 @@ import com.openmemind.ai.memory.autoconfigure.retrieval.MemoryRetrievalAutoConfi
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
 import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.stats.DefaultToolStatsService;
 import com.openmemind.ai.memory.core.stats.ToolStatsService;
 import com.openmemind.ai.memory.core.store.MemoryStore;
@@ -39,6 +40,7 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration
 @AutoConfigureAfter({
+    MemoryLlmAutoConfiguration.class,
     MemoryExtractionAutoConfiguration.class,
     MemoryRetrievalAutoConfiguration.class
 })
@@ -53,20 +55,31 @@ public class MemoryAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Memory.class)
     @ConditionalOnBean({
-        StructuredChatClient.class,
+        ChatClientRegistry.class,
         MemoryStore.class,
         MemoryBuffer.class,
         MemoryVector.class
     })
     public Memory memind(
-            StructuredChatClient chatClient,
+            ChatClientRegistry chatClientRegistry,
             MemoryStore store,
             MemoryBuffer buffer,
             MemoryVector vector,
             ObjectProvider<MemoryTextSearch> textSearchProvider,
             ObjectProvider<MemoryBuildOptions> buildOptionsProvider) {
         var builder =
-                Memory.builder().chatClient(chatClient).store(store).buffer(buffer).vector(vector);
+                Memory.builder()
+                        .chatClient(chatClientRegistry.defaultClient())
+                        .store(store)
+                        .buffer(buffer)
+                        .vector(vector);
+
+        for (ChatClientSlot slot : ChatClientSlot.values()) {
+            var client = chatClientRegistry.resolve(slot);
+            if (client != chatClientRegistry.defaultClient()) {
+                builder.chatClient(slot, client);
+            }
+        }
 
         MemoryTextSearch textSearch = textSearchProvider.getIfAvailable();
         if (textSearch != null) {

--- a/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmAutoConfiguration.java
+++ b/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmAutoConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.autoconfigure;
+
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for multi-LLM routing via {@link ChatClientRegistry}.
+ */
+@AutoConfiguration
+@AutoConfigureAfter(
+        name =
+                "com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.SpringAiLlmAutoConfiguration")
+@EnableConfigurationProperties(MemoryLlmProperties.class)
+public class MemoryLlmAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(StructuredChatClient.class)
+    public ChatClientRegistry chatClientRegistry(
+            Map<String, StructuredChatClient> allClients,
+            MemoryLlmProperties properties,
+            ConfigurableListableBeanFactory beanFactory) {
+
+        StructuredChatClient defaultClient = resolveDefaultClient(allClients, beanFactory);
+        Map<ChatClientSlot, StructuredChatClient> slotClients = new EnumMap<>(ChatClientSlot.class);
+
+        for (var entry : properties.getSlots().entrySet()) {
+            ChatClientSlot slot = parseSlot(entry.getKey());
+            StructuredChatClient client = allClients.get(entry.getValue());
+            if (client == null) {
+                throw new IllegalArgumentException(
+                        "No StructuredChatClient bean named '"
+                                + entry.getValue()
+                                + "' found for slot "
+                                + slot
+                                + ". Available beans: "
+                                + allClients.keySet());
+            }
+            slotClients.put(slot, client);
+        }
+
+        return new ChatClientRegistry(defaultClient, slotClients);
+    }
+
+    private static ChatClientSlot parseSlot(String rawSlotName) {
+        String slotName = rawSlotName.toUpperCase().replace("-", "_");
+        try {
+            return ChatClientSlot.valueOf(slotName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Unknown ChatClientSlot: '"
+                            + rawSlotName
+                            + "'. Valid slots: "
+                            + Arrays.toString(ChatClientSlot.values()),
+                    e);
+        }
+    }
+
+    private static StructuredChatClient resolveDefaultClient(
+            Map<String, StructuredChatClient> allClients,
+            ConfigurableListableBeanFactory beanFactory) {
+        String primaryBeanName = null;
+        for (String beanName : allClients.keySet()) {
+            if (beanFactory.containsBeanDefinition(beanName)
+                    && beanFactory.getBeanDefinition(beanName).isPrimary()) {
+                if (primaryBeanName != null) {
+                    throw new IllegalStateException(
+                            "Multiple @Primary StructuredChatClient beans found: "
+                                    + allClients.keySet());
+                }
+                primaryBeanName = beanName;
+            }
+        }
+        if (primaryBeanName != null) {
+            return allClients.get(primaryBeanName);
+        }
+        if (allClients.containsKey("structuredChatClient")) {
+            return allClients.get("structuredChatClient");
+        }
+        if (allClients.containsKey("structuredLlmClient")) {
+            return allClients.get("structuredLlmClient");
+        }
+        if (allClients.size() == 1) {
+            return allClients.values().iterator().next();
+        }
+        throw new IllegalStateException(
+                "Unable to determine the default StructuredChatClient bean. Mark one bean"
+                        + " as @Primary or expose a bean named 'structuredChatClient'."
+                        + " Available beans: "
+                        + allClients.keySet());
+    }
+}

--- a/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmProperties.java
+++ b/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.autoconfigure;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for multi-LLM routing.
+ *
+ * <p>Maps {@code memind.llm.slots.<slot-name>} to the bean name of a
+ * {@link com.openmemind.ai.memory.core.llm.StructuredChatClient}.
+ */
+@ConfigurationProperties(prefix = "memind.llm")
+public class MemoryLlmProperties {
+
+    private Map<String, String> slots = new HashMap<>();
+
+    public Map<String, String> getSlots() {
+        return slots;
+    }
+
+    public void setSlots(Map<String, String> slots) {
+        this.slots = slots;
+    }
+}

--- a/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/extraction/MemoryExtractionAutoConfiguration.java
+++ b/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/extraction/MemoryExtractionAutoConfiguration.java
@@ -53,7 +53,8 @@ import com.openmemind.ai.memory.core.extraction.rawdata.chunk.ConversationChunki
 import com.openmemind.ai.memory.core.extraction.rawdata.chunk.LlmConversationChunker;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ConversationContentProcessor;
 import com.openmemind.ai.memory.core.extraction.rawdata.processor.ToolCallContentProcessor;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.utils.IdUtils;
@@ -131,8 +132,12 @@ public class MemoryExtractionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ContextCommitDetector boundaryDetector(CommitDetectorConfig commitDetectorConfig) {
-        return new LlmContextCommitDetector(commitDetectorConfig);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public ContextCommitDetector boundaryDetector(
+            CommitDetectorConfig commitDetectorConfig, ChatClientRegistry chatClientRegistry) {
+        return new LlmContextCommitDetector(
+                commitDetectorConfig,
+                chatClientRegistry.resolve(ChatClientSlot.CONTEXT_COMMIT_DETECTOR));
     }
 
     @Bean
@@ -143,23 +148,25 @@ public class MemoryExtractionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public CaptionGenerator captionGenerator(StructuredChatClient structuredChatClient) {
-        return new LlmConversationCaptionGenerator(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public CaptionGenerator captionGenerator(ChatClientRegistry chatClientRegistry) {
+        return new LlmConversationCaptionGenerator(
+                chatClientRegistry.resolve(ChatClientSlot.CAPTION_GENERATOR));
     }
 
     // ─── Content Processors (individually overridable) ───
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
+    @ConditionalOnBean(ChatClientRegistry.class)
     @ConditionalOnProperty(
             name = "memind.extraction.chunking.strategy",
             havingValue = "LLM",
             matchIfMissing = true)
-    public LlmConversationChunker llmConversationChunker(
-            ConversationChunkingConfig config, StructuredChatClient structuredChatClient) {
-        return new LlmConversationChunker(structuredChatClient, new ConversationChunker());
+    public LlmConversationChunker llmConversationChunker(ChatClientRegistry chatClientRegistry) {
+        return new LlmConversationChunker(
+                chatClientRegistry.resolve(ChatClientSlot.CONVERSATION_CHUNKER),
+                new ConversationChunker());
     }
 
     @Bean
@@ -179,11 +186,12 @@ public class MemoryExtractionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(name = "toolCallContentProcessor")
-    @ConditionalOnBean(StructuredChatClient.class)
+    @ConditionalOnBean(ChatClientRegistry.class)
     public ToolCallContentProcessor toolCallContentProcessor(
-            StructuredChatClient structuredChatClient) {
+            ChatClientRegistry chatClientRegistry) {
         return new ToolCallContentProcessor(
-                new LlmToolCallItemExtractionStrategy(structuredChatClient));
+                new LlmToolCallItemExtractionStrategy(
+                        chatClientRegistry.resolve(ChatClientSlot.TOOL_CALL_EXTRACTION)));
     }
 
     @Bean
@@ -199,9 +207,9 @@ public class MemoryExtractionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
+    @ConditionalOnBean(ChatClientRegistry.class)
     public MemoryItemExtractor memoryItemExtractor(
-            StructuredChatClient structuredChatClient, List<RawContentProcessor<?>> processors) {
+            ChatClientRegistry chatClientRegistry, List<RawContentProcessor<?>> processors) {
         // Build strategy map from processors that provide their own extraction strategy
         var strategies = new HashMap<String, ItemExtractionStrategy>();
         for (var p : processors) {
@@ -219,7 +227,9 @@ public class MemoryExtractionAutoConfiguration {
                         MemoryCategory.PLAYBOOK,
                         MemoryCategory.RESOLUTION);
         var defaultStrategy =
-                new LlmItemExtractionStrategy(structuredChatClient, conversationCategories);
+                new LlmItemExtractionStrategy(
+                        chatClientRegistry.resolve(ChatClientSlot.ITEM_EXTRACTION),
+                        conversationCategories);
         return new DefaultMemoryItemExtractor(defaultStrategy, strategies);
     }
 
@@ -261,17 +271,18 @@ public class MemoryExtractionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public InsightGenerator insightGenerator(StructuredChatClient structuredChatClient) {
-        return new LlmInsightGenerator(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public InsightGenerator insightGenerator(ChatClientRegistry chatClientRegistry) {
+        return new LlmInsightGenerator(
+                chatClientRegistry.resolve(ChatClientSlot.INSIGHT_GENERATOR));
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public InsightGroupClassifier insightGroupClassifier(
-            StructuredChatClient structuredChatClient) {
-        return new LlmInsightGroupClassifier(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public InsightGroupClassifier insightGroupClassifier(ChatClientRegistry chatClientRegistry) {
+        return new LlmInsightGroupClassifier(
+                chatClientRegistry.resolve(ChatClientSlot.INSIGHT_GROUP_CLASSIFIER));
     }
 
     @Bean

--- a/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/retrieval/MemoryRetrievalAutoConfiguration.java
+++ b/memind-spring-boot-starter/src/main/java/com/openmemind/ai/memory/autoconfigure/retrieval/MemoryRetrievalAutoConfiguration.java
@@ -14,7 +14,8 @@
 package com.openmemind.ai.memory.autoconfigure.retrieval;
 
 import com.openmemind.ai.memory.autoconfigure.MemoryRetrievalProperties;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
@@ -175,9 +176,10 @@ public class MemoryRetrievalAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public InsightTypeRouter insightTypeRouter(StructuredChatClient structuredChatClient) {
-        return new LlmInsightTypeRouter(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public InsightTypeRouter insightTypeRouter(ChatClientRegistry chatClientRegistry) {
+        return new LlmInsightTypeRouter(
+                chatClientRegistry.resolve(ChatClientSlot.INSIGHT_TYPE_ROUTER));
     }
 
     @Bean
@@ -210,16 +212,16 @@ public class MemoryRetrievalAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public SufficiencyGate sufficiencyGate(StructuredChatClient structuredChatClient) {
-        return new LlmSufficiencyGate(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public SufficiencyGate sufficiencyGate(ChatClientRegistry chatClientRegistry) {
+        return new LlmSufficiencyGate(chatClientRegistry.resolve(ChatClientSlot.SUFFICIENCY_GATE));
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(StructuredChatClient.class)
-    public TypedQueryExpander typedQueryExpander(StructuredChatClient structuredChatClient) {
-        return new LlmTypedQueryExpander(structuredChatClient);
+    @ConditionalOnBean(ChatClientRegistry.class)
+    public TypedQueryExpander typedQueryExpander(ChatClientRegistry chatClientRegistry) {
+        return new LlmTypedQueryExpander(chatClientRegistry.resolve(ChatClientSlot.QUERY_EXPANDER));
     }
 
     @Bean

--- a/memind-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/memind-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
+com.openmemind.ai.memory.autoconfigure.MemoryLlmAutoConfiguration
 com.openmemind.ai.memory.autoconfigure.extraction.MemoryExtractionAutoConfiguration
 com.openmemind.ai.memory.autoconfigure.retrieval.MemoryRetrievalAutoConfiguration
 com.openmemind.ai.memory.autoconfigure.MemoryAutoConfiguration

--- a/memind-spring-boot-starter/src/test/java/com/openmemind/ai/memory/autoconfigure/MemoryAutoConfigurationTest.java
+++ b/memind-spring-boot-starter/src/test/java/com/openmemind/ai/memory/autoconfigure/MemoryAutoConfigurationTest.java
@@ -15,6 +15,7 @@ package com.openmemind.ai.memory.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.openmemind.ai.memory.core.DefaultMemory;
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.buffer.ConversationBuffer;
 import com.openmemind.ai.memory.core.buffer.InMemoryConversationBuffer;
@@ -24,8 +25,16 @@ import com.openmemind.ai.memory.core.buffer.InsightBuffer;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
 import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
 import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
+import com.openmemind.ai.memory.core.extraction.item.MemoryItemLayer;
+import com.openmemind.ai.memory.core.extraction.item.extractor.DefaultMemoryItemExtractor;
+import com.openmemind.ai.memory.core.extraction.item.strategy.LlmItemExtractionStrategy;
 import com.openmemind.ai.memory.core.llm.ChatMessage;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
+import com.openmemind.ai.memory.core.retrieval.deep.LlmTypedQueryExpander;
+import com.openmemind.ai.memory.core.retrieval.strategy.DeepRetrievalStrategy;
+import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategies;
 import com.openmemind.ai.memory.core.store.InMemoryMemoryStore;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
@@ -39,6 +48,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -47,7 +57,10 @@ class MemoryAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner =
             new ApplicationContextRunner()
-                    .withConfiguration(AutoConfigurations.of(MemoryAutoConfiguration.class));
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    MemoryLlmAutoConfiguration.class,
+                                    MemoryAutoConfiguration.class));
 
     @Test
     @DisplayName("Create Memory from builder runtime inputs only")
@@ -104,6 +117,66 @@ class MemoryAutoConfigurationTest {
                         context -> {
                             assertThat(context).hasNotFailed();
                             assertThat(context).doesNotHaveBean(Memory.class);
+                        });
+    }
+
+    @Test
+    @DisplayName("Route slot-specific clients from ChatClientRegistry into built memory")
+    void routesSlotSpecificClientsFromRegistryIntoBuiltMemory() {
+        contextRunner
+                .withUserConfiguration(MultiClientRuntimeConfig.class)
+                .withPropertyValues(
+                        "memind.llm.slots.item-extraction=smartClient",
+                        "memind.llm.slots.query-expander=fastClient")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            DefaultMemory memory = (DefaultMemory) context.getBean(Memory.class);
+                            StructuredChatClient smartClient =
+                                    context.getBean("smartClient", StructuredChatClient.class);
+                            StructuredChatClient fastClient =
+                                    context.getBean("fastClient", StructuredChatClient.class);
+
+                            MemoryExtractor extractor =
+                                    readField(memory, "extractor", MemoryExtractor.class);
+                            MemoryItemLayer memoryItemLayer =
+                                    readField(extractor, "memoryItemStep", MemoryItemLayer.class);
+                            DefaultMemoryItemExtractor itemExtractor =
+                                    readField(
+                                            memoryItemLayer,
+                                            "extractor",
+                                            DefaultMemoryItemExtractor.class);
+                            LlmItemExtractionStrategy itemStrategy =
+                                    readField(
+                                            itemExtractor,
+                                            "defaultStrategy",
+                                            LlmItemExtractionStrategy.class);
+                            DefaultMemoryRetriever retriever =
+                                    readField(memory, "retriever", DefaultMemoryRetriever.class);
+                            @SuppressWarnings("unchecked")
+                            java.util.Map<String, Object> strategies =
+                                    readField(retriever, "strategies", java.util.Map.class);
+                            DeepRetrievalStrategy deepStrategy =
+                                    (DeepRetrievalStrategy)
+                                            strategies.get(RetrievalStrategies.DEEP_RETRIEVAL);
+                            LlmTypedQueryExpander typedQueryExpander =
+                                    readField(
+                                            deepStrategy,
+                                            "typedQueryExpander",
+                                            LlmTypedQueryExpander.class);
+
+                            assertThat(
+                                            readField(
+                                                    itemStrategy,
+                                                    "structuredChatClient",
+                                                    StructuredChatClient.class))
+                                    .isSameAs(smartClient);
+                            assertThat(
+                                            readField(
+                                                    typedQueryExpander,
+                                                    "structuredChatClient",
+                                                    StructuredChatClient.class))
+                                    .isSameAs(fastClient);
                         });
     }
 
@@ -190,6 +263,27 @@ class MemoryAutoConfigurationTest {
         }
     }
 
+    @Configuration(proxyBeanMethods = false)
+    static class MultiClientRuntimeConfig extends RequiredRuntimeConfig {
+
+        @Bean
+        @Primary
+        @Override
+        StructuredChatClient structuredChatClient() {
+            return new NoopStructuredChatClient();
+        }
+
+        @Bean
+        StructuredChatClient smartClient() {
+            return new NoopStructuredChatClient();
+        }
+
+        @Bean
+        StructuredChatClient fastClient() {
+            return new NoopStructuredChatClient();
+        }
+    }
+
     private static final class NoopStructuredChatClient implements StructuredChatClient {
 
         @Override
@@ -245,6 +339,18 @@ class MemoryAutoConfigurationTest {
         @Override
         public Mono<List<List<Float>>> embedAll(List<String> texts) {
             return Mono.just(List.of());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T readField(Object target, String fieldName, Class<T> fieldType) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) fieldType.cast(field.get(target));
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(
+                    "Failed to read field '" + fieldName + "' from " + target.getClass(), e);
         }
     }
 }

--- a/memind-spring-boot-starter/src/test/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmAutoConfigurationTest.java
+++ b/memind-spring-boot-starter/src/test/java/com/openmemind/ai/memory/autoconfigure/MemoryLlmAutoConfigurationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import reactor.core.publisher.Mono;
+
+@DisplayName("Memory LLM auto-configuration")
+class MemoryLlmAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(MemoryLlmAutoConfiguration.class));
+
+    @Test
+    @DisplayName("Create ChatClientRegistry from default and slot-specific client beans")
+    void createsChatClientRegistryFromNamedClients() {
+        contextRunner
+                .withUserConfiguration(MultiClientConfig.class)
+                .withPropertyValues(
+                        "memind.llm.slots.item-extraction=smartClient",
+                        "memind.llm.slots.query-expander=fastClient")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context).hasSingleBean(ChatClientRegistry.class);
+
+                            ChatClientRegistry registry = context.getBean(ChatClientRegistry.class);
+                            StructuredChatClient defaultClient =
+                                    context.getBean(
+                                            "structuredChatClient", StructuredChatClient.class);
+                            StructuredChatClient smartClient =
+                                    context.getBean("smartClient", StructuredChatClient.class);
+                            StructuredChatClient fastClient =
+                                    context.getBean("fastClient", StructuredChatClient.class);
+
+                            assertThat(registry.defaultClient()).isSameAs(defaultClient);
+                            assertThat(registry.resolve(ChatClientSlot.ITEM_EXTRACTION))
+                                    .isSameAs(smartClient);
+                            assertThat(registry.resolve(ChatClientSlot.QUERY_EXPANDER))
+                                    .isSameAs(fastClient);
+                            assertThat(registry.resolve(ChatClientSlot.INSIGHT_GENERATOR))
+                                    .isSameAs(defaultClient);
+                        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MultiClientConfig {
+
+        @Bean
+        @Primary
+        StructuredChatClient structuredChatClient() {
+            return new NoopStructuredChatClient();
+        }
+
+        @Bean
+        StructuredChatClient smartClient() {
+            return new NoopStructuredChatClient();
+        }
+
+        @Bean
+        StructuredChatClient fastClient() {
+            return new NoopStructuredChatClient();
+        }
+    }
+
+    private static final class NoopStructuredChatClient implements StructuredChatClient {
+
+        @Override
+        public Mono<String> call(List<com.openmemind.ai.memory.core.llm.ChatMessage> messages) {
+            return Mono.empty();
+        }
+
+        @Override
+        public <T> Mono<T> call(
+                List<com.openmemind.ai.memory.core.llm.ChatMessage> messages,
+                Class<T> responseType) {
+            return Mono.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ChatClientSlot` and `ChatClientRegistry` so each LLM call site can resolve a slot-specific `StructuredChatClient`
- wire slot-based routing through the core builder, extraction pipeline, retrieval pipeline, and add routing-focused tests
- add Spring Boot multi-LLM properties and auto-configuration so named `StructuredChatClient` beans can be bound per slot while preserving a default client path

## Test Plan
- [x] `mvn test -pl memind-core -Dtest="ChatClientRegistryTest,MemoryAssemblersTest,DefaultMemoryBuilderTest" -q`
- [x] `mvn compile -pl memind-core -q`
- [x] `mvn test -pl memind-core -q`
- [x] `mvn test -pl memind-spring-boot-starter -am -Dtest="MemoryLlmAutoConfigurationTest,MemoryAutoConfigurationTest" -q`
- [x] `mvn clean verify -q`
- [x] `mvn compile -pl memind-examples/memind-example-spring-boot -am -q`
- [x] `mvn compile -pl memind-examples/memind-example-java -am -q`
