### PR TITLE
refactor: streamline java examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ JdbcMemoryAccess jdbc = JdbcStore.sqlite("./data/memind.db");
 Memory memory = Memory.builder()
         .chatClient(new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build()))
         .store(jdbc.store())
+        .buffer(jdbc.buffer())
         .textSearch(jdbc.textSearch())
         .vector(SpringAiFileVector.file("./data/vector-store.json", embeddingModel))
         .options(MemoryBuildOptions.builder()
@@ -207,6 +208,11 @@ Memory memory = Memory.builder()
         .build();
 ```
 
+The maintained Java examples wrap this assembly behind a small shared support layer. Start with
+`memind-examples/memind-example-java/README.md` and
+`memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java`
+if you want the runnable version with centralized configuration defaults.
+
 ---
 
 ## Examples
@@ -218,9 +224,17 @@ git clone https://github.com/openmemind-ai/memind.git
 cd memind
 ```
 
-Examples now live under `memind-examples/` and share one data directory at `memind-examples/data`.
+Maintained Java examples now live in `memind-examples/memind-example-java`.
 
-Configure `OPENAI_API_KEY`, then run one of the pure Java examples:
+They still read shared input data from `memind-examples/data`, while each scenario writes its own
+runtime artifacts under `target/example-runtime/<scenario>` by default.
+
+Configuration is centralized in
+`memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java`.
+Set `OPENAI_API_KEY` first, then optionally enable rerank with
+`MEMIND_EXAMPLES_RERANK_ENABLED=true` plus `RERANK_API_KEY`.
+
+Then run one of the pure Java examples:
 
 ```bash
 # Basic extract + retrieve
@@ -229,15 +243,15 @@ mvn -pl memind-examples/memind-example-java -am \
   exec:java
 ```
 
-All maintained examples now live in `memind-examples/memind-example-java`. Run them from your
-IDE, or invoke them with Maven Exec Plugin using the fully qualified class names below. They use
-the same object-first builder approach shown above.
+Run them from your IDE, or invoke them with Maven Exec Plugin using the fully qualified class
+names below. They all share the same support layer for settings, runtime assembly, and example
+output formatting.
 
 | Runtime | Example | Main Class | Description |
 |---------|---------|------------|-------------|
-| Pure Java | **QuickStart** | `com.openmemind.ai.memory.example.java.quickstart.QuickStartExample` | Object-first builder with direct Spring AI runtime objects |
-| Pure Java | **Agent Scope** | `com.openmemind.ai.memory.example.java.agent.AgentScopeMemoryExample` | Object-first agent-scope extraction with insight tree flush and targeted retrieval |
-| Pure Java | **Insight** | `com.openmemind.ai.memory.example.java.insight.InsightTreeExample` | Object-first builder with custom `MemoryBuildOptions` |
+| Pure Java | **QuickStart** | `com.openmemind.ai.memory.example.java.quickstart.QuickStartExample` | Shared runtime bootstrap plus basic `addMessages` and `retrieve` |
+| Pure Java | **Agent Scope** | `com.openmemind.ai.memory.example.java.agent.AgentScopeMemoryExample` | Shared runtime bootstrap plus agent-scope extraction, insight flush, and targeted retrieval |
+| Pure Java | **Insight** | `com.openmemind.ai.memory.example.java.insight.InsightTreeExample` | Shared runtime bootstrap plus lower-threshold insight-tree options |
 | Pure Java | **Foresight** | `com.openmemind.ai.memory.example.java.foresight.ForesightExample` | Pure Java foresight extraction and retrieval |
 | Pure Java | **Tool** | `com.openmemind.ai.memory.example.java.tool.ToolMemoryExample` | Pure Java tool call tracking and aggregated statistics |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -193,6 +193,7 @@ JdbcMemoryAccess jdbc = JdbcStore.sqlite("./data/memind.db");
 Memory memory = Memory.builder()
         .chatClient(new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build()))
         .store(jdbc.store())
+        .buffer(jdbc.buffer())
         .textSearch(jdbc.textSearch())
         .vector(SpringAiFileVector.file("./data/vector-store.json", embeddingModel))
         .options(MemoryBuildOptions.builder()
@@ -206,6 +207,10 @@ Memory memory = Memory.builder()
         .build();
 ```
 
+当前维护的 Java 示例已经把这套装配收敛到一层共享 support 代码里。想看可直接运行、且配置入口更清晰的版本，可以先看
+`memind-examples/memind-example-java/README.md` 和
+`memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java`。
+
 ---
 
 ## 示例
@@ -217,9 +222,17 @@ git clone https://github.com/openmemind-ai/memind.git
 cd memind
 ```
 
-示例现在统一放在 `memind-examples/` 下，并共享 `memind-examples/data` 这份测试数据。
+当前维护的 Java 示例统一放在 `memind-examples/memind-example-java`。
 
-配置 `OPENAI_API_KEY` 后，可以先运行纯 Java 示例：
+它们仍然共用 `memind-examples/data` 这份输入数据，但每个场景默认会把自己的运行时产物写到
+`target/example-runtime/<scenario>`。
+
+配置入口统一收敛在
+`memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java`。
+先设置 `OPENAI_API_KEY`，如果要启用 rerank，再设置
+`MEMIND_EXAMPLES_RERANK_ENABLED=true` 和 `RERANK_API_KEY`。
+
+然后就可以运行纯 Java 示例：
 
 ```bash
 # 基础提取 + 检索
@@ -228,15 +241,14 @@ mvn -pl memind-examples/memind-example-java -am \
   exec:java
 ```
 
-当前维护的示例都位于 `memind-examples/memind-example-java`，可以直接在 IDE 中运行，
-也可以使用 Maven Exec Plugin 按下面这些主类启动。它们统一使用上面的对象直连
-builder 方式。
+可以直接在 IDE 中运行，也可以使用 Maven Exec Plugin 按下面这些主类启动。
+它们统一复用同一套 settings、runtime 装配和输出格式化 support 层。
 
 | 运行方式 | 示例 | 主类 | 说明 |
 |---------|------|------|------|
-| 纯 Java | **QuickStart** | `com.openmemind.ai.memory.example.java.quickstart.QuickStartExample` | 通过对象直连 `Memory.builder()` 组装运行时 |
-| 纯 Java | **Agent Scope** | `com.openmemind.ai.memory.example.java.agent.AgentScopeMemoryExample` | 通过对象直连 builder 完成 agent scope 记忆提取、insight tree 刷新与定向检索 |
-| 纯 Java | **Insight** | `com.openmemind.ai.memory.example.java.insight.InsightTreeExample` | 通过对象直连 `Memory.builder()` 并自定义 `MemoryBuildOptions` |
+| 纯 Java | **QuickStart** | `com.openmemind.ai.memory.example.java.quickstart.QuickStartExample` | 复用共享运行时装配，演示基础 `addMessages` 和 `retrieve` |
+| 纯 Java | **Agent Scope** | `com.openmemind.ai.memory.example.java.agent.AgentScopeMemoryExample` | 复用共享运行时装配，演示 agent scope 提取、insight 刷新与定向检索 |
+| 纯 Java | **Insight** | `com.openmemind.ai.memory.example.java.insight.InsightTreeExample` | 复用共享运行时装配，并使用更低阈值的 insight tree 选项 |
 | 纯 Java | **Foresight** | `com.openmemind.ai.memory.example.java.foresight.ForesightExample` | 纯 Java 前瞻记忆提取与检索 |
 | 纯 Java | **Tool** | `com.openmemind.ai.memory.example.java.tool.ToolMemoryExample` | 纯 Java 工具调用追踪与聚合统计 |
 

--- a/memind-examples/memind-example-java/README.md
+++ b/memind-examples/memind-example-java/README.md
@@ -1,0 +1,92 @@
+# Memind Java Examples
+
+This module keeps each example as an independent `main` class so you can run a
+single scenario directly from your IDE or with Maven.
+
+## Examples
+
+- `quickstart`: basic `addMessages` + `retrieve`
+- `foresight`: foresight extraction and display
+- `insight`: multi-batch extraction with deeper synthesized retrieval
+- `agent`: agent-only extraction, insight flushing, and agent-scoped retrieval
+- `tool`: tool call reporting and tool statistics
+
+## Configuration
+
+Open
+[`src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java`](src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java)
+first.
+
+It is the single place that shows:
+
+- OpenAI defaults and override keys
+- rerank defaults and override keys
+- JDBC/store defaults and override keys
+- runtime directory defaults
+
+### Sensitive Values
+
+Prefer environment variables or system properties for secrets:
+
+- `OPENAI_API_KEY`
+- `RERANK_API_KEY` when rerank is enabled
+
+### Minimal Setup
+
+For the default SQLite-backed examples:
+
+1. Set `OPENAI_API_KEY`
+2. Optionally set `MEMIND_EXAMPLES_RERANK_ENABLED=true` and `RERANK_API_KEY`
+3. Run one of the examples below
+
+## Run From Maven
+
+Quickstart:
+
+```bash
+OPENAI_API_KEY=your-key \
+mvn -pl memind-examples/memind-example-java -am -DskipTests exec:java \
+  -Dexec.mainClass=com.openmemind.ai.memory.example.java.quickstart.QuickStartExample
+```
+
+Foresight:
+
+```bash
+OPENAI_API_KEY=your-key \
+mvn -pl memind-examples/memind-example-java -am -DskipTests exec:java \
+  -Dexec.mainClass=com.openmemind.ai.memory.example.java.foresight.ForesightExample
+```
+
+Insight Tree:
+
+```bash
+OPENAI_API_KEY=your-key \
+mvn -pl memind-examples/memind-example-java -am -DskipTests exec:java \
+  -Dexec.mainClass=com.openmemind.ai.memory.example.java.insight.InsightTreeExample
+```
+
+Agent Scope:
+
+```bash
+OPENAI_API_KEY=your-key \
+mvn -pl memind-examples/memind-example-java -am -DskipTests exec:java \
+  -Dexec.mainClass=com.openmemind.ai.memory.example.java.agent.AgentScopeMemoryExample
+```
+
+Tool Memory:
+
+```bash
+OPENAI_API_KEY=your-key \
+mvn -pl memind-examples/memind-example-java -am -DskipTests exec:java \
+  -Dexec.mainClass=com.openmemind.ai.memory.example.java.tool.ToolMemoryExample
+```
+
+## Runtime Data
+
+By default, example runtime data is written under:
+
+```text
+target/example-runtime/<scenario>
+```
+
+You can override the runtime root or JDBC URL through `ExampleSettings`.

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/agent/AgentScopeMemoryExample.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/agent/AgentScopeMemoryExample.java
@@ -14,42 +14,17 @@
 package com.openmemind.ai.memory.example.java.agent;
 
 import com.openmemind.ai.memory.core.Memory;
-import com.openmemind.ai.memory.core.builder.ExtractionCommonOptions;
-import com.openmemind.ai.memory.core.builder.ExtractionOptions;
-import com.openmemind.ai.memory.core.builder.InsightExtractionOptions;
-import com.openmemind.ai.memory.core.builder.ItemExtractionOptions;
-import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
-import com.openmemind.ai.memory.core.builder.RawDataExtractionOptions;
-import com.openmemind.ai.memory.core.builder.RetrievalOptions;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
 import com.openmemind.ai.memory.core.extraction.ExtractionConfig;
-import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildConfig;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
-import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
-import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.RetrievalRequest;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.example.java.support.ExampleDataLoader;
+import com.openmemind.ai.memory.example.java.support.ExampleMemoryOptions;
 import com.openmemind.ai.memory.example.java.support.ExamplePrinter;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
-import io.micrometer.observation.ObservationRegistry;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import com.openmemind.ai.memory.example.java.support.ExampleRuntimeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Agent-scope memory example for the pure Java integration path.
@@ -58,12 +33,15 @@ public final class AgentScopeMemoryExample {
 
     private static final Logger log = LoggerFactory.getLogger(AgentScopeMemoryExample.class);
     private static final String LANGUAGE = "Chinese";
+    private static final String SCENARIO = "agent";
 
     private AgentScopeMemoryExample() {}
 
     public static void main(String[] args) {
-        var runtime = createRuntime("agent", agentOptions());
-        run(runtime.memory(), runtime.store(), new ExampleDataLoader());
+        var runtime =
+                ExampleRuntimeFactory.create(SCENARIO, ExampleMemoryOptions.agentScopeOptions());
+        ExamplePrinter.printRuntimeSummary(SCENARIO, runtime);
+        run(runtime.memory(), runtime.store(), runtime.dataLoader());
     }
 
     private static void run(Memory memory, MemoryStore store, ExampleDataLoader loader) {
@@ -112,249 +90,4 @@ public final class AgentScopeMemoryExample {
                         .block();
         ExamplePrinter.printRetrievalResult(retrieval, System.currentTimeMillis() - startedAt);
     }
-
-    private static MemoryBuildOptions agentOptions() {
-        InsightBuildConfig defaults = MemoryBuildOptions.defaults().extraction().insight().build();
-        return MemoryBuildOptions.builder()
-                .extraction(
-                        new ExtractionOptions(
-                                ExtractionCommonOptions.defaults(),
-                                RawDataExtractionOptions.defaults(),
-                                ItemExtractionOptions.defaults(),
-                                new InsightExtractionOptions(
-                                        true,
-                                        new InsightBuildConfig(
-                                                2,
-                                                2,
-                                                defaults.concurrency(),
-                                                defaults.maxRetries()))))
-                .retrieval(RetrievalOptions.defaults())
-                .build();
-    }
-
-    private static AgentScopeRuntime createRuntime(String scenario, MemoryBuildOptions options) {
-        Path runtimeDir = resolveRuntimeDir(scenario);
-        String jdbcUrl = resolveJdbcUrl(runtimeDir);
-        prepareRuntimeLayout(runtimeDir, jdbcUrl);
-        StructuredChatClient chatClient = createChatClient();
-        EmbeddingModel embeddingModel = createEmbeddingModel();
-        JdbcMemoryAccess jdbc = createJdbcAccess(jdbcUrl);
-        MemoryStore memoryStore = jdbc.store();
-
-        Memory memory =
-                Memory.builder()
-                        .chatClient(chatClient)
-                        .store(memoryStore)
-                        .textSearch(jdbc.textSearch())
-                        .vector(
-                                SpringAiFileVector.file(
-                                        runtimeDir.resolve("vector-store.json"), embeddingModel))
-                        .reranker(createReranker())
-                        .options(options)
-                        .build();
-
-        return new AgentScopeRuntime(memory, memoryStore);
-    }
-
-    private static StructuredChatClient createChatClient() {
-        OpenAiApi openAiApi = createOpenAiApi();
-        OpenAiChatModel chatModel =
-                OpenAiChatModel.builder()
-                        .openAiApi(openAiApi)
-                        .defaultOptions(
-                                OpenAiChatOptions.builder()
-                                        .model(
-                                                resolveValue(
-                                                        "memind.examples.openai.chat-model",
-                                                        "OPENAI_CHAT_MODEL",
-                                                        "gpt-4o-mini"))
-                                        .build())
-                        .observationRegistry(ObservationRegistry.NOOP)
-                        .build();
-        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
-    }
-
-    private static EmbeddingModel createEmbeddingModel() {
-        return new OpenAiEmbeddingModel(
-                createOpenAiApi(),
-                MetadataMode.NONE,
-                OpenAiEmbeddingOptions.builder()
-                        .model(
-                                resolveValue(
-                                        "memind.examples.openai.embedding-model",
-                                        "OPENAI_EMBEDDING_MODEL",
-                                        "text-embedding-3-small"))
-                        .build());
-    }
-
-    private static Reranker createReranker() {
-        return new LlmReranker(
-                resolveValue(
-                        "memind.examples.rerank.base-url",
-                        "RERANK_BASE_URL",
-                        "https://api.openai.com"),
-                requireValue(
-                        "memind.examples.rerank.api-key",
-                        "RERANK_API_KEY",
-                        "Missing Rerank API key. Set system property "
-                                + "'memind.examples.rerank.api-key' or environment "
-                                + "variable 'RERANK_API_KEY'."),
-                resolveValue("memind.examples.rerank.model", "RERANK_MODEL", "qwen3-reranker-8b"));
-    }
-
-    private static OpenAiApi createOpenAiApi() {
-        return OpenAiApi.builder()
-                .apiKey(
-                        requireValue(
-                                "memind.examples.openai.api-key",
-                                "OPENAI_API_KEY",
-                                "Missing OpenAI API key. Set system property "
-                                        + "'memind.examples.openai.api-key' or environment "
-                                        + "variable 'OPENAI_API_KEY'."))
-                .baseUrl(
-                        resolveValue(
-                                "memind.examples.openai.base-url",
-                                "OPENAI_BASE_URL",
-                                "https://api.openai.com"))
-                .build();
-    }
-
-    private static JdbcMemoryAccess createJdbcAccess(String jdbcUrl) {
-        return switch (detectDialect(jdbcUrl)) {
-            case SQLITE -> JdbcStore.sqlite(extractSqlitePath(jdbcUrl));
-            case MYSQL ->
-                    JdbcStore.mysql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-            case POSTGRESQL ->
-                    JdbcStore.postgresql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-        };
-    }
-
-    private static Path resolveRuntimeDir(String scenario) {
-        return Path.of(
-                        resolveValue(
-                                "memind.examples.runtime-dir",
-                                "MEMIND_EXAMPLES_RUNTIME_DIR",
-                                Path.of("target", "example-runtime", scenario).toString()))
-                .toAbsolutePath()
-                .normalize();
-    }
-
-    private static String resolveJdbcUrl(Path runtimeDir) {
-        return resolveValue(
-                "memind.examples.jdbc.url",
-                "MEMIND_EXAMPLES_JDBC_URL",
-                "jdbc:sqlite:" + runtimeDir.resolve("memind.db"));
-    }
-
-    private static String requireValue(String propertyName, String envName, String message) {
-        String value = resolveValue(propertyName, envName, "");
-        if (value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static String resolveValue(String propertyName, String envName, String defaultValue) {
-        String propertyValue = System.getProperty(propertyName);
-        if (propertyValue != null && !propertyValue.isBlank()) {
-            return propertyValue;
-        }
-
-        String environmentValue = System.getenv(envName);
-        if (environmentValue != null && !environmentValue.isBlank()) {
-            return environmentValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static void prepareRuntimeLayout(Path runtimeDir, String jdbcUrl) {
-        try {
-            Files.createDirectories(runtimeDir);
-            Files.createDirectories(runtimeDir.resolve("vector-store.json").getParent());
-            ensureSqliteParentDirectory(jdbcUrl);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "Failed to prepare runtime directory: " + runtimeDir, e);
-        }
-    }
-
-    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
-        if (detectDialect(jdbcUrl) != Dialect.SQLITE) {
-            return;
-        }
-
-        String rawPath = extractSqlitePath(jdbcUrl);
-        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
-            return;
-        }
-
-        Path dbPath = Path.of(rawPath).toAbsolutePath().normalize();
-        Path parent = dbPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
-    }
-
-    private static Dialect detectDialect(String jdbcUrl) {
-        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
-        if (normalized.startsWith("jdbc:mysql:")) {
-            return Dialect.MYSQL;
-        }
-        if (normalized.startsWith("jdbc:postgresql:")) {
-            return Dialect.POSTGRESQL;
-        }
-        if (normalized.startsWith("jdbc:sqlite:")) {
-            return Dialect.SQLITE;
-        }
-        throw new IllegalArgumentException("Unsupported JDBC URL for examples: " + jdbcUrl);
-    }
-
-    private static String extractSqlitePath(String jdbcUrl) {
-        String prefix = ":sqlite:";
-        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
-        if (marker < 0) {
-            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
-        }
-
-        String rawPath = jdbcUrl.substring(marker + prefix.length());
-        if (rawPath.isBlank()) {
-            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
-        }
-        return rawPath;
-    }
-
-    private enum Dialect {
-        SQLITE,
-        MYSQL,
-        POSTGRESQL
-    }
-
-    private record AgentScopeRuntime(Memory memory, MemoryStore store) {}
 }

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/foresight/ForesightExample.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/foresight/ForesightExample.java
@@ -14,33 +14,15 @@
 package com.openmemind.ai.memory.example.java.foresight;
 
 import com.openmemind.ai.memory.core.Memory;
-import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
 import com.openmemind.ai.memory.core.extraction.ExtractionConfig;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
-import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
-import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.example.java.support.ExampleDataLoader;
+import com.openmemind.ai.memory.example.java.support.ExampleMemoryOptions;
 import com.openmemind.ai.memory.example.java.support.ExamplePrinter;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
-import io.micrometer.observation.ObservationRegistry;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import com.openmemind.ai.memory.example.java.support.ExampleRuntimeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Foresight example for the pure Java integration path.
@@ -48,11 +30,14 @@ import org.springframework.ai.openai.api.OpenAiApi;
 public final class ForesightExample {
 
     private static final Logger log = LoggerFactory.getLogger(ForesightExample.class);
+    private static final String SCENARIO = "foresight";
 
     private ForesightExample() {}
 
     public static void main(String[] args) {
-        run(createMemory("foresight", MemoryBuildOptions.defaults()), new ExampleDataLoader());
+        var runtime = ExampleRuntimeFactory.create(SCENARIO, ExampleMemoryOptions.defaultOptions());
+        ExamplePrinter.printRuntimeSummary(SCENARIO, runtime);
+        run(runtime.memory(), runtime.dataLoader());
     }
 
     private static void run(Memory memory, ExampleDataLoader loader) {
@@ -82,225 +67,5 @@ public final class ForesightExample {
         long startedAt = System.currentTimeMillis();
         var retrieval = memory.retrieve(memoryId, query, RetrievalConfig.Strategy.SIMPLE).block();
         ExamplePrinter.printRetrievalResult(retrieval, System.currentTimeMillis() - startedAt);
-    }
-
-    private static Memory createMemory(String scenario, MemoryBuildOptions options) {
-        Path runtimeDir = resolveRuntimeDir(scenario);
-        String jdbcUrl = resolveJdbcUrl(runtimeDir);
-        prepareRuntimeLayout(runtimeDir, jdbcUrl);
-        StructuredChatClient chatClient = createChatClient();
-        EmbeddingModel embeddingModel = createEmbeddingModel();
-        JdbcMemoryAccess jdbc = createJdbcAccess(jdbcUrl);
-
-        return Memory.builder()
-                .chatClient(chatClient)
-                .store(jdbc.store())
-                .textSearch(jdbc.textSearch())
-                .vector(
-                        SpringAiFileVector.file(
-                                runtimeDir.resolve("vector-store.json"), embeddingModel))
-                .reranker(createReranker())
-                .options(options)
-                .build();
-    }
-
-    private static StructuredChatClient createChatClient() {
-        OpenAiApi openAiApi = createOpenAiApi();
-        OpenAiChatModel chatModel =
-                OpenAiChatModel.builder()
-                        .openAiApi(openAiApi)
-                        .defaultOptions(
-                                OpenAiChatOptions.builder()
-                                        .model(
-                                                resolveValue(
-                                                        "memind.examples.openai.chat-model",
-                                                        "OPENAI_CHAT_MODEL",
-                                                        "gpt-4o-mini"))
-                                        .build())
-                        .observationRegistry(ObservationRegistry.NOOP)
-                        .build();
-        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
-    }
-
-    private static EmbeddingModel createEmbeddingModel() {
-        return new OpenAiEmbeddingModel(
-                createOpenAiApi(),
-                MetadataMode.NONE,
-                OpenAiEmbeddingOptions.builder()
-                        .model(
-                                resolveValue(
-                                        "memind.examples.openai.embedding-model",
-                                        "OPENAI_EMBEDDING_MODEL",
-                                        "text-embedding-3-small"))
-                        .build());
-    }
-
-    private static Reranker createReranker() {
-        return new LlmReranker(
-                resolveValue(
-                        "memind.examples.rerank.base-url",
-                        "RERANK_BASE_URL",
-                        "https://api.openai.com"),
-                requireValue(
-                        "memind.examples.rerank.api-key",
-                        "RERANK_API_KEY",
-                        "Missing Rerank API key. Set system property "
-                                + "'memind.examples.rerank.api-key' or environment "
-                                + "variable 'RERANK_API_KEY'."),
-                resolveValue("memind.examples.rerank.model", "RERANK_MODEL", "qwen3-reranker-8b"));
-    }
-
-    private static OpenAiApi createOpenAiApi() {
-        return OpenAiApi.builder()
-                .apiKey(
-                        requireValue(
-                                "memind.examples.openai.api-key",
-                                "OPENAI_API_KEY",
-                                "Missing OpenAI API key. Set system property "
-                                        + "'memind.examples.openai.api-key' or environment "
-                                        + "variable 'OPENAI_API_KEY'."))
-                .baseUrl(
-                        resolveValue(
-                                "memind.examples.openai.base-url",
-                                "OPENAI_BASE_URL",
-                                "https://api.openai.com"))
-                .build();
-    }
-
-    private static JdbcMemoryAccess createJdbcAccess(String jdbcUrl) {
-        return switch (detectDialect(jdbcUrl)) {
-            case SQLITE -> JdbcStore.sqlite(extractSqlitePath(jdbcUrl));
-            case MYSQL ->
-                    JdbcStore.mysql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-            case POSTGRESQL ->
-                    JdbcStore.postgresql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-        };
-    }
-
-    private static Path resolveRuntimeDir(String scenario) {
-        return Path.of(
-                        resolveValue(
-                                "memind.examples.runtime-dir",
-                                "MEMIND_EXAMPLES_RUNTIME_DIR",
-                                Path.of("target", "example-runtime", scenario).toString()))
-                .toAbsolutePath()
-                .normalize();
-    }
-
-    private static String resolveJdbcUrl(Path runtimeDir) {
-        return resolveValue(
-                "memind.examples.jdbc.url",
-                "MEMIND_EXAMPLES_JDBC_URL",
-                "jdbc:sqlite:" + runtimeDir.resolve("memind.db"));
-    }
-
-    private static String requireValue(String propertyName, String envName, String message) {
-        String value = resolveValue(propertyName, envName, "");
-        if (value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static String resolveValue(String propertyName, String envName, String defaultValue) {
-        String propertyValue = System.getProperty(propertyName);
-        if (propertyValue != null && !propertyValue.isBlank()) {
-            return propertyValue;
-        }
-
-        String environmentValue = System.getenv(envName);
-        if (environmentValue != null && !environmentValue.isBlank()) {
-            return environmentValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static void prepareRuntimeLayout(Path runtimeDir, String jdbcUrl) {
-        try {
-            Files.createDirectories(runtimeDir);
-            Files.createDirectories(runtimeDir.resolve("vector-store.json").getParent());
-            ensureSqliteParentDirectory(jdbcUrl);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "Failed to prepare runtime directory: " + runtimeDir, e);
-        }
-    }
-
-    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
-        if (detectDialect(jdbcUrl) != JdbcDialect.SQLITE) {
-            return;
-        }
-
-        String rawPath = extractSqlitePath(jdbcUrl);
-        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
-            return;
-        }
-
-        Path dbPath = Path.of(rawPath).toAbsolutePath().normalize();
-        Path parent = dbPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
-    }
-
-    private static String extractSqlitePath(String jdbcUrl) {
-        String prefix = ":sqlite:";
-        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
-        if (marker < 0) {
-            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
-        }
-
-        String rawPath = jdbcUrl.substring(marker + prefix.length());
-        if (rawPath.isBlank()) {
-            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
-        }
-        return rawPath;
-    }
-
-    private static JdbcDialect detectDialect(String jdbcUrl) {
-        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
-        if (normalized.contains(":sqlite:")) {
-            return JdbcDialect.SQLITE;
-        }
-        if (normalized.contains(":mysql:")) {
-            return JdbcDialect.MYSQL;
-        }
-        if (normalized.contains(":postgresql:")) {
-            return JdbcDialect.POSTGRESQL;
-        }
-        throw new IllegalStateException("Unsupported JDBC URL for pure Java example: " + jdbcUrl);
-    }
-
-    private enum JdbcDialect {
-        SQLITE,
-        MYSQL,
-        POSTGRESQL
     }
 }

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/insight/InsightTreeExample.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/insight/InsightTreeExample.java
@@ -14,40 +14,15 @@
 package com.openmemind.ai.memory.example.java.insight;
 
 import com.openmemind.ai.memory.core.Memory;
-import com.openmemind.ai.memory.core.builder.ExtractionCommonOptions;
-import com.openmemind.ai.memory.core.builder.ExtractionOptions;
-import com.openmemind.ai.memory.core.builder.InsightExtractionOptions;
-import com.openmemind.ai.memory.core.builder.ItemExtractionOptions;
-import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
-import com.openmemind.ai.memory.core.builder.RawDataExtractionOptions;
-import com.openmemind.ai.memory.core.builder.RetrievalOptions;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
 import com.openmemind.ai.memory.core.extraction.ExtractionConfig;
-import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildConfig;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
-import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
-import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.example.java.support.ExampleDataLoader;
+import com.openmemind.ai.memory.example.java.support.ExampleMemoryOptions;
 import com.openmemind.ai.memory.example.java.support.ExamplePrinter;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
-import io.micrometer.observation.ObservationRegistry;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import com.openmemind.ai.memory.example.java.support.ExampleRuntimeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Insight tree example for the pure Java integration path.
@@ -55,11 +30,15 @@ import org.springframework.ai.openai.api.OpenAiApi;
 public final class InsightTreeExample {
 
     private static final Logger log = LoggerFactory.getLogger(InsightTreeExample.class);
+    private static final String SCENARIO = "insight";
 
     private InsightTreeExample() {}
 
     public static void main(String[] args) {
-        run(createMemory("insight", insightOptions()), new ExampleDataLoader());
+        var runtime =
+                ExampleRuntimeFactory.create(SCENARIO, ExampleMemoryOptions.insightTreeOptions());
+        ExamplePrinter.printRuntimeSummary(SCENARIO, runtime);
+        run(runtime.memory(), runtime.dataLoader());
     }
 
     private static void run(Memory memory, ExampleDataLoader loader) {
@@ -88,244 +67,5 @@ public final class InsightTreeExample {
         long startedAt = System.currentTimeMillis();
         var retrieval = memory.retrieve(memoryId, query, RetrievalConfig.Strategy.DEEP).block();
         ExamplePrinter.printRetrievalResult(retrieval, System.currentTimeMillis() - startedAt);
-    }
-
-    private static MemoryBuildOptions insightOptions() {
-        InsightBuildConfig defaults = MemoryBuildOptions.defaults().extraction().insight().build();
-        return MemoryBuildOptions.builder()
-                .extraction(
-                        new ExtractionOptions(
-                                ExtractionCommonOptions.defaults(),
-                                RawDataExtractionOptions.defaults(),
-                                ItemExtractionOptions.defaults(),
-                                new InsightExtractionOptions(
-                                        true,
-                                        new InsightBuildConfig(
-                                                2,
-                                                2,
-                                                defaults.concurrency(),
-                                                defaults.maxRetries()))))
-                .retrieval(RetrievalOptions.defaults())
-                .build();
-    }
-
-    private static Memory createMemory(String scenario, MemoryBuildOptions options) {
-        Path runtimeDir = resolveRuntimeDir(scenario);
-        String jdbcUrl = resolveJdbcUrl(runtimeDir);
-        prepareRuntimeLayout(runtimeDir, jdbcUrl);
-        StructuredChatClient chatClient = createChatClient();
-        EmbeddingModel embeddingModel = createEmbeddingModel();
-        JdbcMemoryAccess jdbc = createJdbcAccess(jdbcUrl);
-
-        return Memory.builder()
-                .chatClient(chatClient)
-                .store(jdbc.store())
-                .textSearch(jdbc.textSearch())
-                .vector(
-                        SpringAiFileVector.file(
-                                runtimeDir.resolve("vector-store.json"), embeddingModel))
-                .reranker(createReranker())
-                .options(options)
-                .build();
-    }
-
-    private static StructuredChatClient createChatClient() {
-        OpenAiApi openAiApi = createOpenAiApi();
-        OpenAiChatModel chatModel =
-                OpenAiChatModel.builder()
-                        .openAiApi(openAiApi)
-                        .defaultOptions(
-                                OpenAiChatOptions.builder()
-                                        .model(
-                                                resolveValue(
-                                                        "memind.examples.openai.chat-model",
-                                                        "OPENAI_CHAT_MODEL",
-                                                        "gpt-4o-mini"))
-                                        .build())
-                        .observationRegistry(ObservationRegistry.NOOP)
-                        .build();
-        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
-    }
-
-    private static EmbeddingModel createEmbeddingModel() {
-        return new OpenAiEmbeddingModel(
-                createOpenAiApi(),
-                MetadataMode.NONE,
-                OpenAiEmbeddingOptions.builder()
-                        .model(
-                                resolveValue(
-                                        "memind.examples.openai.embedding-model",
-                                        "OPENAI_EMBEDDING_MODEL",
-                                        "text-embedding-3-small"))
-                        .build());
-    }
-
-    private static Reranker createReranker() {
-        return new LlmReranker(
-                resolveValue(
-                        "memind.examples.rerank.base-url",
-                        "RERANK_BASE_URL",
-                        "https://api.openai.com"),
-                requireValue(
-                        "memind.examples.rerank.api-key",
-                        "RERANK_API_KEY",
-                        "Missing Rerank API key. Set system property "
-                                + "'memind.examples.rerank.api-key' or environment "
-                                + "variable 'RERANK_API_KEY'."),
-                resolveValue("memind.examples.rerank.model", "RERANK_MODEL", "qwen3-reranker-8b"));
-    }
-
-    private static OpenAiApi createOpenAiApi() {
-        return OpenAiApi.builder()
-                .apiKey(
-                        requireValue(
-                                "memind.examples.openai.api-key",
-                                "OPENAI_API_KEY",
-                                "Missing OpenAI API key. Set system property "
-                                        + "'memind.examples.openai.api-key' or environment "
-                                        + "variable 'OPENAI_API_KEY'."))
-                .baseUrl(
-                        resolveValue(
-                                "memind.examples.openai.base-url",
-                                "OPENAI_BASE_URL",
-                                "https://api.openai.com"))
-                .build();
-    }
-
-    private static JdbcMemoryAccess createJdbcAccess(String jdbcUrl) {
-        return switch (detectDialect(jdbcUrl)) {
-            case SQLITE -> JdbcStore.sqlite(extractSqlitePath(jdbcUrl));
-            case MYSQL ->
-                    JdbcStore.mysql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-            case POSTGRESQL ->
-                    JdbcStore.postgresql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-        };
-    }
-
-    private static Path resolveRuntimeDir(String scenario) {
-        return Path.of(
-                        resolveValue(
-                                "memind.examples.runtime-dir",
-                                "MEMIND_EXAMPLES_RUNTIME_DIR",
-                                Path.of("target", "example-runtime", scenario).toString()))
-                .toAbsolutePath()
-                .normalize();
-    }
-
-    private static String resolveJdbcUrl(Path runtimeDir) {
-        return resolveValue(
-                "memind.examples.jdbc.url",
-                "MEMIND_EXAMPLES_JDBC_URL",
-                "jdbc:sqlite:" + runtimeDir.resolve("memind.db"));
-    }
-
-    private static String requireValue(String propertyName, String envName, String message) {
-        String value = resolveValue(propertyName, envName, "");
-        if (value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static String resolveValue(String propertyName, String envName, String defaultValue) {
-        String propertyValue = System.getProperty(propertyName);
-        if (propertyValue != null && !propertyValue.isBlank()) {
-            return propertyValue;
-        }
-
-        String environmentValue = System.getenv(envName);
-        if (environmentValue != null && !environmentValue.isBlank()) {
-            return environmentValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static void prepareRuntimeLayout(Path runtimeDir, String jdbcUrl) {
-        try {
-            Files.createDirectories(runtimeDir);
-            Files.createDirectories(runtimeDir.resolve("vector-store.json").getParent());
-            ensureSqliteParentDirectory(jdbcUrl);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "Failed to prepare runtime directory: " + runtimeDir, e);
-        }
-    }
-
-    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
-        if (detectDialect(jdbcUrl) != JdbcDialect.SQLITE) {
-            return;
-        }
-
-        String rawPath = extractSqlitePath(jdbcUrl);
-        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
-            return;
-        }
-
-        Path dbPath = Path.of(rawPath).toAbsolutePath().normalize();
-        Path parent = dbPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
-    }
-
-    private static String extractSqlitePath(String jdbcUrl) {
-        String prefix = ":sqlite:";
-        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
-        if (marker < 0) {
-            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
-        }
-
-        String rawPath = jdbcUrl.substring(marker + prefix.length());
-        if (rawPath.isBlank()) {
-            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
-        }
-        return rawPath;
-    }
-
-    private static JdbcDialect detectDialect(String jdbcUrl) {
-        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
-        if (normalized.contains(":sqlite:")) {
-            return JdbcDialect.SQLITE;
-        }
-        if (normalized.contains(":mysql:")) {
-            return JdbcDialect.MYSQL;
-        }
-        if (normalized.contains(":postgresql:")) {
-            return JdbcDialect.POSTGRESQL;
-        }
-        throw new IllegalStateException("Unsupported JDBC URL for pure Java example: " + jdbcUrl);
-    }
-
-    private enum JdbcDialect {
-        SQLITE,
-        MYSQL,
-        POSTGRESQL
     }
 }

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/quickstart/QuickStartExample.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/quickstart/QuickStartExample.java
@@ -14,33 +14,15 @@
 package com.openmemind.ai.memory.example.java.quickstart;
 
 import com.openmemind.ai.memory.core.Memory;
-import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
 import com.openmemind.ai.memory.core.extraction.ExtractionConfig;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
-import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
-import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.example.java.support.ExampleDataLoader;
+import com.openmemind.ai.memory.example.java.support.ExampleMemoryOptions;
 import com.openmemind.ai.memory.example.java.support.ExamplePrinter;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
-import io.micrometer.observation.ObservationRegistry;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import com.openmemind.ai.memory.example.java.support.ExampleRuntimeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Quick start example for the pure Java integration path.
@@ -48,11 +30,14 @@ import org.springframework.ai.openai.api.OpenAiApi;
 public final class QuickStartExample {
 
     private static final Logger log = LoggerFactory.getLogger(QuickStartExample.class);
+    private static final String SCENARIO = "quickstart";
 
     private QuickStartExample() {}
 
     public static void main(String[] args) {
-        run(createMemory("quickstart", MemoryBuildOptions.defaults()), new ExampleDataLoader());
+        var runtime = ExampleRuntimeFactory.create(SCENARIO, ExampleMemoryOptions.defaultOptions());
+        ExamplePrinter.printRuntimeSummary(SCENARIO, runtime);
+        run(runtime.memory(), runtime.dataLoader());
     }
 
     private static void run(Memory memory, ExampleDataLoader loader) {
@@ -77,225 +62,5 @@ public final class QuickStartExample {
         long startedAt = System.currentTimeMillis();
         var retrieval = memory.retrieve(memoryId, query, RetrievalConfig.Strategy.SIMPLE).block();
         ExamplePrinter.printRetrievalResult(retrieval, System.currentTimeMillis() - startedAt);
-    }
-
-    private static Memory createMemory(String scenario, MemoryBuildOptions options) {
-        Path runtimeDir = resolveRuntimeDir(scenario);
-        String jdbcUrl = resolveJdbcUrl(runtimeDir);
-        prepareRuntimeLayout(runtimeDir, jdbcUrl);
-        StructuredChatClient chatClient = createChatClient();
-        EmbeddingModel embeddingModel = createEmbeddingModel();
-        JdbcMemoryAccess jdbc = createJdbcAccess(jdbcUrl);
-
-        return Memory.builder()
-                .chatClient(chatClient)
-                .store(jdbc.store())
-                .textSearch(jdbc.textSearch())
-                .vector(
-                        SpringAiFileVector.file(
-                                runtimeDir.resolve("vector-store.json"), embeddingModel))
-                .reranker(createReranker())
-                .options(options)
-                .build();
-    }
-
-    private static StructuredChatClient createChatClient() {
-        OpenAiApi openAiApi = createOpenAiApi();
-        OpenAiChatModel chatModel =
-                OpenAiChatModel.builder()
-                        .openAiApi(openAiApi)
-                        .defaultOptions(
-                                OpenAiChatOptions.builder()
-                                        .model(
-                                                resolveValue(
-                                                        "memind.examples.openai.chat-model",
-                                                        "OPENAI_CHAT_MODEL",
-                                                        "gpt-4o-mini"))
-                                        .build())
-                        .observationRegistry(ObservationRegistry.NOOP)
-                        .build();
-        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
-    }
-
-    private static EmbeddingModel createEmbeddingModel() {
-        return new OpenAiEmbeddingModel(
-                createOpenAiApi(),
-                MetadataMode.NONE,
-                OpenAiEmbeddingOptions.builder()
-                        .model(
-                                resolveValue(
-                                        "memind.examples.openai.embedding-model",
-                                        "OPENAI_EMBEDDING_MODEL",
-                                        "text-embedding-3-small"))
-                        .build());
-    }
-
-    private static Reranker createReranker() {
-        return new LlmReranker(
-                resolveValue(
-                        "memind.examples.rerank.base-url",
-                        "RERANK_BASE_URL",
-                        "https://api.openai.com"),
-                requireValue(
-                        "memind.examples.rerank.api-key",
-                        "RERANK_API_KEY",
-                        "Missing Rerank API key. Set system property "
-                                + "'memind.examples.rerank.api-key' or environment "
-                                + "variable 'RERANK_API_KEY'."),
-                resolveValue("memind.examples.rerank.model", "RERANK_MODEL", "qwen3-reranker-8b"));
-    }
-
-    private static OpenAiApi createOpenAiApi() {
-        return OpenAiApi.builder()
-                .apiKey(
-                        requireValue(
-                                "memind.examples.openai.api-key",
-                                "OPENAI_API_KEY",
-                                "Missing OpenAI API key. Set system property "
-                                        + "'memind.examples.openai.api-key' or environment "
-                                        + "variable 'OPENAI_API_KEY'."))
-                .baseUrl(
-                        resolveValue(
-                                "memind.examples.openai.base-url",
-                                "OPENAI_BASE_URL",
-                                "https://api.openai.com"))
-                .build();
-    }
-
-    private static JdbcMemoryAccess createJdbcAccess(String jdbcUrl) {
-        return switch (detectDialect(jdbcUrl)) {
-            case SQLITE -> JdbcStore.sqlite(extractSqlitePath(jdbcUrl));
-            case MYSQL ->
-                    JdbcStore.mysql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-            case POSTGRESQL ->
-                    JdbcStore.postgresql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-        };
-    }
-
-    private static Path resolveRuntimeDir(String scenario) {
-        return Path.of(
-                        resolveValue(
-                                "memind.examples.runtime-dir",
-                                "MEMIND_EXAMPLES_RUNTIME_DIR",
-                                Path.of("target", "example-runtime", scenario).toString()))
-                .toAbsolutePath()
-                .normalize();
-    }
-
-    private static String resolveJdbcUrl(Path runtimeDir) {
-        return resolveValue(
-                "memind.examples.jdbc.url",
-                "MEMIND_EXAMPLES_JDBC_URL",
-                "jdbc:sqlite:" + runtimeDir.resolve("memind.db"));
-    }
-
-    private static String requireValue(String propertyName, String envName, String message) {
-        String value = resolveValue(propertyName, envName, "");
-        if (value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static String resolveValue(String propertyName, String envName, String defaultValue) {
-        String propertyValue = System.getProperty(propertyName);
-        if (propertyValue != null && !propertyValue.isBlank()) {
-            return propertyValue;
-        }
-
-        String environmentValue = System.getenv(envName);
-        if (environmentValue != null && !environmentValue.isBlank()) {
-            return environmentValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static void prepareRuntimeLayout(Path runtimeDir, String jdbcUrl) {
-        try {
-            Files.createDirectories(runtimeDir);
-            Files.createDirectories(runtimeDir.resolve("vector-store.json").getParent());
-            ensureSqliteParentDirectory(jdbcUrl);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "Failed to prepare runtime directory: " + runtimeDir, e);
-        }
-    }
-
-    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
-        if (detectDialect(jdbcUrl) != JdbcDialect.SQLITE) {
-            return;
-        }
-
-        String rawPath = extractSqlitePath(jdbcUrl);
-        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
-            return;
-        }
-
-        Path dbPath = Path.of(rawPath).toAbsolutePath().normalize();
-        Path parent = dbPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
-    }
-
-    private static String extractSqlitePath(String jdbcUrl) {
-        String prefix = ":sqlite:";
-        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
-        if (marker < 0) {
-            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
-        }
-
-        String rawPath = jdbcUrl.substring(marker + prefix.length());
-        if (rawPath.isBlank()) {
-            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
-        }
-        return rawPath;
-    }
-
-    private static JdbcDialect detectDialect(String jdbcUrl) {
-        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
-        if (normalized.contains(":sqlite:")) {
-            return JdbcDialect.SQLITE;
-        }
-        if (normalized.contains(":mysql:")) {
-            return JdbcDialect.MYSQL;
-        }
-        if (normalized.contains(":postgresql:")) {
-            return JdbcDialect.POSTGRESQL;
-        }
-        throw new IllegalStateException("Unsupported JDBC URL for pure Java example: " + jdbcUrl);
-    }
-
-    private enum JdbcDialect {
-        SQLITE,
-        MYSQL,
-        POSTGRESQL
     }
 }

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleMemoryOptions.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleMemoryOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import com.openmemind.ai.memory.core.builder.ExtractionCommonOptions;
+import com.openmemind.ai.memory.core.builder.ExtractionOptions;
+import com.openmemind.ai.memory.core.builder.InsightExtractionOptions;
+import com.openmemind.ai.memory.core.builder.ItemExtractionOptions;
+import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
+import com.openmemind.ai.memory.core.builder.RawDataExtractionOptions;
+import com.openmemind.ai.memory.core.builder.RetrievalOptions;
+import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildConfig;
+
+public final class ExampleMemoryOptions {
+
+    private ExampleMemoryOptions() {}
+
+    public static MemoryBuildOptions defaultOptions() {
+        return MemoryBuildOptions.defaults();
+    }
+
+    public static MemoryBuildOptions insightTreeOptions() {
+        return buildInsightPreset();
+    }
+
+    public static MemoryBuildOptions agentScopeOptions() {
+        return buildInsightPreset();
+    }
+
+    private static MemoryBuildOptions buildInsightPreset() {
+        InsightBuildConfig defaults = MemoryBuildOptions.defaults().extraction().insight().build();
+        return MemoryBuildOptions.builder()
+                .extraction(
+                        new ExtractionOptions(
+                                ExtractionCommonOptions.defaults(),
+                                RawDataExtractionOptions.defaults(),
+                                ItemExtractionOptions.defaults(),
+                                new InsightExtractionOptions(
+                                        true,
+                                        new InsightBuildConfig(
+                                                2,
+                                                2,
+                                                defaults.concurrency(),
+                                                defaults.maxRetries()))))
+                .retrieval(RetrievalOptions.defaults())
+                .build();
+    }
+}

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExamplePrinter.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExamplePrinter.java
@@ -44,6 +44,21 @@ public final class ExamplePrinter {
         log.info("═══════════════════════════════════════════════════════");
     }
 
+    public static void printRuntimeSummary(String scenario, ExampleRuntime runtime) {
+        log.info("");
+        log.info("═══════════════════════════════════════════════════════");
+        log.info("  Scenario      : {}", scenario);
+        log.info("  Runtime Dir   : {}", runtime.runtimeDir());
+        log.info("  JDBC Dialect  : {}", runtime.jdbcDialect());
+        log.info("  JDBC URL      : {}", runtime.settings().store().jdbcUrl());
+        log.info("  Chat Model    : {}", runtime.settings().openAi().chatModel());
+        log.info("  Embed Model   : {}", runtime.settings().openAi().embeddingModel());
+        log.info(
+                "  Rerank        : {}",
+                runtime.settings().rerank().enabled() ? "enabled" : "disabled");
+        log.info("═══════════════════════════════════════════════════════");
+    }
+
     public static void printExtractionResult(ExtractionResult result) {
         log.info("  status       : {}", result.status());
         log.info("  duration     : {}ms", result.duration().toMillis());

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleRuntime.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleRuntime.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import com.openmemind.ai.memory.core.Memory;
+import com.openmemind.ai.memory.core.store.MemoryStore;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public record ExampleRuntime(
+        Memory memory,
+        MemoryStore store,
+        ExampleDataLoader dataLoader,
+        ExampleSettings settings,
+        Path runtimeDir,
+        String jdbcDialect)
+        implements AutoCloseable {
+
+    public ExampleRuntime {
+        Objects.requireNonNull(memory, "memory");
+        Objects.requireNonNull(store, "store");
+        Objects.requireNonNull(dataLoader, "dataLoader");
+        Objects.requireNonNull(settings, "settings");
+        Objects.requireNonNull(runtimeDir, "runtimeDir");
+        Objects.requireNonNull(jdbcDialect, "jdbcDialect");
+    }
+
+    @Override
+    public void close() throws Exception {
+        memory.close();
+    }
+}

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleRuntimeFactory.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleRuntimeFactory.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import com.openmemind.ai.memory.core.Memory;
+import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
+import com.openmemind.ai.memory.core.llm.rerank.NoopReranker;
+import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
+import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
+import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
+import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
+import io.micrometer.observation.ObservationRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+
+public final class ExampleRuntimeFactory {
+
+    private ExampleRuntimeFactory() {}
+
+    public static ExampleRuntime create(String scenario, MemoryBuildOptions options) {
+        return create(scenario, options, ExampleSettings.load(scenario));
+    }
+
+    static ExampleRuntime create(
+            String scenario, MemoryBuildOptions options, ExampleSettings settings) {
+        Objects.requireNonNull(scenario, "scenario");
+        Objects.requireNonNull(options, "options");
+        Objects.requireNonNull(settings, "settings");
+
+        try {
+            Path runtimeDir = prepareRuntimeLayout(scenario, settings);
+            String jdbcDialect = detectDialect(settings.store().jdbcUrl());
+            JdbcMemoryAccess jdbc = createJdbcAccess(settings.store());
+            EmbeddingModel embeddingModel = createEmbeddingModel(settings.openAi());
+
+            Memory memory =
+                    Memory.builder()
+                            .chatClient(createChatClient(settings.openAi()))
+                            .store(jdbc.store())
+                            .buffer(jdbc.buffer())
+                            .textSearch(jdbc.textSearch())
+                            .vector(
+                                    SpringAiFileVector.file(
+                                            runtimeDir.resolve(
+                                                    settings.runtime().vectorStoreFileName()),
+                                            embeddingModel))
+                            .reranker(createReranker(settings.rerank()))
+                            .options(options)
+                            .build();
+
+            return new ExampleRuntime(
+                    memory,
+                    jdbc.store(),
+                    new ExampleDataLoader(),
+                    settings,
+                    runtimeDir,
+                    jdbcDialect);
+        } catch (Exception exception) {
+            throw new IllegalStateException(
+                    "Failed to create Java example runtime for scenario: " + scenario, exception);
+        }
+    }
+
+    static Path prepareRuntimeLayout(String scenario, ExampleSettings settings) throws Exception {
+        Path runtimeDir = settings.runtime().scenarioRuntimeDir(scenario);
+        Files.createDirectories(runtimeDir);
+        Files.createDirectories(
+                runtimeDir.resolve(settings.runtime().vectorStoreFileName()).getParent());
+        ensureSqliteParentDirectory(settings.store().jdbcUrl());
+        return runtimeDir;
+    }
+
+    static String detectDialect(String jdbcUrl) {
+        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
+        if (normalized.contains(":sqlite:")) {
+            return "sqlite";
+        }
+        if (normalized.contains(":mysql:")) {
+            return "mysql";
+        }
+        if (normalized.contains(":postgresql:")) {
+            return "postgresql";
+        }
+        throw new IllegalStateException("Unsupported JDBC URL for pure Java example: " + jdbcUrl);
+    }
+
+    private static StructuredChatClient createChatClient(ExampleSettings.OpenAiSettings settings) {
+        OpenAiChatModel chatModel =
+                OpenAiChatModel.builder()
+                        .openAiApi(createOpenAiApi(settings))
+                        .defaultOptions(
+                                OpenAiChatOptions.builder().model(settings.chatModel()).build())
+                        .observationRegistry(ObservationRegistry.NOOP)
+                        .build();
+        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
+    }
+
+    private static EmbeddingModel createEmbeddingModel(ExampleSettings.OpenAiSettings settings) {
+        return new OpenAiEmbeddingModel(
+                createOpenAiApi(settings),
+                MetadataMode.NONE,
+                OpenAiEmbeddingOptions.builder().model(settings.embeddingModel()).build());
+    }
+
+    private static OpenAiApi createOpenAiApi(ExampleSettings.OpenAiSettings settings) {
+        return OpenAiApi.builder().apiKey(settings.apiKey()).baseUrl(settings.baseUrl()).build();
+    }
+
+    private static JdbcMemoryAccess createJdbcAccess(ExampleSettings.StoreSettings settings) {
+        return switch (detectDialect(settings.jdbcUrl())) {
+            case "sqlite" -> JdbcStore.sqlite(extractSqlitePath(settings.jdbcUrl()));
+            case "mysql" ->
+                    JdbcStore.mysql(settings.jdbcUrl(), settings.username(), settings.password());
+            case "postgresql" ->
+                    JdbcStore.postgresql(
+                            settings.jdbcUrl(), settings.username(), settings.password());
+            default ->
+                    throw new IllegalStateException("Unsupported JDBC URL: " + settings.jdbcUrl());
+        };
+    }
+
+    private static Reranker createReranker(ExampleSettings.RerankSettings settings) {
+        if (!settings.enabled()) {
+            return new NoopReranker();
+        }
+        if (settings.apiKey().isBlank()) {
+            throw new IllegalStateException(
+                    "Rerank is enabled but no API key was configured. Set system property "
+                            + "'memind.examples.rerank.api-key' or environment variable "
+                            + "'RERANK_API_KEY'.");
+        }
+        return new LlmReranker(settings.baseUrl(), settings.apiKey(), settings.model());
+    }
+
+    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
+        if (!"sqlite".equals(detectDialect(jdbcUrl))) {
+            return;
+        }
+
+        String rawPath = extractSqlitePath(jdbcUrl);
+        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
+            return;
+        }
+
+        Path parent = Path.of(rawPath).toAbsolutePath().normalize().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+    }
+
+    private static String extractSqlitePath(String jdbcUrl) {
+        String prefix = ":sqlite:";
+        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
+        if (marker < 0) {
+            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
+        }
+        String rawPath = jdbcUrl.substring(marker + prefix.length());
+        if (rawPath.isBlank()) {
+            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
+        }
+        return rawPath;
+    }
+}

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleSettings.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Centralized configuration surface for the pure Java examples.
+ *
+ * <p>Non-sensitive defaults live here so users can discover what is configurable in one place.
+ * Sensitive values such as API keys still prefer system properties and environment variables.
+ */
+public final class ExampleSettings {
+
+    private static final String DEFAULT_OPENAI_BASE_URL = "https://api.openai.com";
+    private static final String DEFAULT_CHAT_MODEL = "gpt-4o-mini";
+    private static final String DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+    private static final String DEFAULT_RERANK_MODEL = "qwen3-reranker-8b";
+    private static final String DEFAULT_VECTOR_STORE_FILE_NAME = "vector-store.json";
+    private static final String DEFAULT_SQLITE_FILE_NAME = "memind.db";
+
+    private final OpenAiSettings openAi;
+    private final RerankSettings rerank;
+    private final StoreSettings store;
+    private final RuntimeSettings runtime;
+
+    private ExampleSettings(
+            OpenAiSettings openAi,
+            RerankSettings rerank,
+            StoreSettings store,
+            RuntimeSettings runtime) {
+        this.openAi = Objects.requireNonNull(openAi, "openAi");
+        this.rerank = Objects.requireNonNull(rerank, "rerank");
+        this.store = Objects.requireNonNull(store, "store");
+        this.runtime = Objects.requireNonNull(runtime, "runtime");
+    }
+
+    public static ExampleSettings load(String scenario) {
+        return load(scenario, ValueResolver.system());
+    }
+
+    static ExampleSettings load(String scenario, ValueResolver resolver) {
+        Objects.requireNonNull(scenario, "scenario");
+        Objects.requireNonNull(resolver, "resolver");
+
+        RuntimeSettings runtime =
+                new RuntimeSettings(
+                        resolveRuntimeRootDir(resolver),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.vector-store.file-name",
+                                "MEMIND_EXAMPLES_VECTOR_STORE_FILE_NAME",
+                                DEFAULT_VECTOR_STORE_FILE_NAME),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.sqlite.file-name",
+                                "MEMIND_EXAMPLES_SQLITE_FILE_NAME",
+                                DEFAULT_SQLITE_FILE_NAME));
+
+        return new ExampleSettings(
+                new OpenAiSettings(
+                        requireValue(
+                                resolver,
+                                "memind.examples.openai.api-key",
+                                "OPENAI_API_KEY",
+                                "Missing OpenAI API key. Set system property "
+                                        + "'memind.examples.openai.api-key' or environment "
+                                        + "variable 'OPENAI_API_KEY'."),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.openai.base-url",
+                                "OPENAI_BASE_URL",
+                                DEFAULT_OPENAI_BASE_URL),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.openai.chat-model",
+                                "OPENAI_CHAT_MODEL",
+                                DEFAULT_CHAT_MODEL),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.openai.embedding-model",
+                                "OPENAI_EMBEDDING_MODEL",
+                                DEFAULT_EMBEDDING_MODEL)),
+                new RerankSettings(
+                        Boolean.parseBoolean(
+                                resolveValue(
+                                        resolver,
+                                        "memind.examples.rerank.enabled",
+                                        "MEMIND_EXAMPLES_RERANK_ENABLED",
+                                        "false")),
+                        resolveValue(
+                                resolver, "memind.examples.rerank.api-key", "RERANK_API_KEY", ""),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.rerank.base-url",
+                                "RERANK_BASE_URL",
+                                DEFAULT_OPENAI_BASE_URL),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.rerank.model",
+                                "RERANK_MODEL",
+                                DEFAULT_RERANK_MODEL)),
+                new StoreSettings(
+                        resolveJdbcUrl(resolver, runtime, scenario),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.jdbc.username",
+                                "MEMIND_EXAMPLES_JDBC_USERNAME",
+                                ""),
+                        resolveValue(
+                                resolver,
+                                "memind.examples.jdbc.password",
+                                "MEMIND_EXAMPLES_JDBC_PASSWORD",
+                                "")),
+                runtime);
+    }
+
+    public OpenAiSettings openAi() {
+        return openAi;
+    }
+
+    public RerankSettings rerank() {
+        return rerank;
+    }
+
+    public StoreSettings store() {
+        return store;
+    }
+
+    public RuntimeSettings runtime() {
+        return runtime;
+    }
+
+    private static Path resolveRuntimeRootDir(ValueResolver resolver) {
+        return Path.of(
+                        resolveValue(
+                                resolver,
+                                "memind.examples.runtime-root-dir",
+                                "MEMIND_EXAMPLES_RUNTIME_ROOT_DIR",
+                                Path.of("target", "example-runtime").toString()))
+                .toAbsolutePath()
+                .normalize();
+    }
+
+    private static String resolveJdbcUrl(
+            ValueResolver resolver, RuntimeSettings runtime, String scenario) {
+        return resolveValue(
+                resolver,
+                "memind.examples.jdbc.url",
+                "MEMIND_EXAMPLES_JDBC_URL",
+                "jdbc:sqlite:" + runtime.scenarioSqlitePath(scenario));
+    }
+
+    private static String requireValue(
+            ValueResolver resolver, String propertyName, String envName, String errorMessage) {
+        String value = resolveValue(resolver, propertyName, envName, "");
+        if (value.isBlank()) {
+            throw new IllegalStateException(errorMessage);
+        }
+        return value;
+    }
+
+    private static String resolveValue(
+            ValueResolver resolver, String propertyName, String envName, String defaultValue) {
+        String propertyValue = trimToNull(resolver.systemProperty(propertyName));
+        if (propertyValue != null) {
+            return propertyValue;
+        }
+
+        String environmentValue = trimToNull(resolver.environmentVariable(envName));
+        if (environmentValue != null) {
+            return environmentValue;
+        }
+
+        return defaultValue;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    public record OpenAiSettings(
+            String apiKey, String baseUrl, String chatModel, String embeddingModel) {}
+
+    public record RerankSettings(boolean enabled, String apiKey, String baseUrl, String model) {}
+
+    public record StoreSettings(String jdbcUrl, String username, String password) {}
+
+    public record RuntimeSettings(
+            Path runtimeRootDir, String vectorStoreFileName, String sqliteFileName) {
+
+        public RuntimeSettings {
+            Objects.requireNonNull(runtimeRootDir, "runtimeRootDir");
+            Objects.requireNonNull(vectorStoreFileName, "vectorStoreFileName");
+            Objects.requireNonNull(sqliteFileName, "sqliteFileName");
+        }
+
+        public Path scenarioRuntimeDir(String scenario) {
+            return runtimeRootDir.resolve(scenario).toAbsolutePath().normalize();
+        }
+
+        public Path scenarioVectorStorePath(String scenario) {
+            return scenarioRuntimeDir(scenario).resolve(vectorStoreFileName);
+        }
+
+        public Path scenarioSqlitePath(String scenario) {
+            return scenarioRuntimeDir(scenario).resolve(sqliteFileName);
+        }
+    }
+
+    interface ValueResolver {
+
+        String systemProperty(String key);
+
+        String environmentVariable(String key);
+
+        static ValueResolver system() {
+            return new ValueResolver() {
+                @Override
+                public String systemProperty(String key) {
+                    return System.getProperty(key);
+                }
+
+                @Override
+                public String environmentVariable(String key) {
+                    return System.getenv(key);
+                }
+            };
+        }
+    }
+}

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/tool/ToolMemoryExample.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/tool/ToolMemoryExample.java
@@ -14,31 +14,13 @@
 package com.openmemind.ai.memory.example.java.tool;
 
 import com.openmemind.ai.memory.core.Memory;
-import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
-import com.openmemind.ai.memory.core.llm.StructuredChatClient;
-import com.openmemind.ai.memory.core.llm.rerank.LlmReranker;
-import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.example.java.support.ExampleDataLoader;
+import com.openmemind.ai.memory.example.java.support.ExampleMemoryOptions;
 import com.openmemind.ai.memory.example.java.support.ExamplePrinter;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiFileVector;
-import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcMemoryAccess;
-import com.openmemind.ai.memory.plugin.jdbc.JdbcStore;
-import io.micrometer.observation.ObservationRegistry;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Locale;
+import com.openmemind.ai.memory.example.java.support.ExampleRuntimeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Tool memory example for the pure Java integration path.
@@ -46,11 +28,14 @@ import org.springframework.ai.openai.api.OpenAiApi;
 public final class ToolMemoryExample {
 
     private static final Logger log = LoggerFactory.getLogger(ToolMemoryExample.class);
+    private static final String SCENARIO = "tool";
 
     private ToolMemoryExample() {}
 
     public static void main(String[] args) {
-        run(createMemory("tool", MemoryBuildOptions.defaults()), new ExampleDataLoader());
+        var runtime = ExampleRuntimeFactory.create(SCENARIO, ExampleMemoryOptions.defaultOptions());
+        ExamplePrinter.printRuntimeSummary(SCENARIO, runtime);
+        run(runtime.memory(), runtime.dataLoader());
     }
 
     private static void run(Memory memory, ExampleDataLoader loader) {
@@ -70,225 +55,5 @@ public final class ToolMemoryExample {
 
         log.info("  ── all tool stats ──");
         ExamplePrinter.printAllToolStats(memory.getAllToolStats(memoryId).block());
-    }
-
-    private static Memory createMemory(String scenario, MemoryBuildOptions options) {
-        Path runtimeDir = resolveRuntimeDir(scenario);
-        String jdbcUrl = resolveJdbcUrl(runtimeDir);
-        prepareRuntimeLayout(runtimeDir, jdbcUrl);
-        StructuredChatClient chatClient = createChatClient();
-        EmbeddingModel embeddingModel = createEmbeddingModel();
-        JdbcMemoryAccess jdbc = createJdbcAccess(jdbcUrl);
-
-        return Memory.builder()
-                .chatClient(chatClient)
-                .store(jdbc.store())
-                .textSearch(jdbc.textSearch())
-                .vector(
-                        SpringAiFileVector.file(
-                                runtimeDir.resolve("vector-store.json"), embeddingModel))
-                .reranker(createReranker())
-                .options(options)
-                .build();
-    }
-
-    private static StructuredChatClient createChatClient() {
-        OpenAiApi openAiApi = createOpenAiApi();
-        OpenAiChatModel chatModel =
-                OpenAiChatModel.builder()
-                        .openAiApi(openAiApi)
-                        .defaultOptions(
-                                OpenAiChatOptions.builder()
-                                        .model(
-                                                resolveValue(
-                                                        "memind.examples.openai.chat-model",
-                                                        "OPENAI_CHAT_MODEL",
-                                                        "gpt-4o-mini"))
-                                        .build())
-                        .observationRegistry(ObservationRegistry.NOOP)
-                        .build();
-        return new SpringAiStructuredChatClient(ChatClient.builder(chatModel).build());
-    }
-
-    private static EmbeddingModel createEmbeddingModel() {
-        return new OpenAiEmbeddingModel(
-                createOpenAiApi(),
-                MetadataMode.NONE,
-                OpenAiEmbeddingOptions.builder()
-                        .model(
-                                resolveValue(
-                                        "memind.examples.openai.embedding-model",
-                                        "OPENAI_EMBEDDING_MODEL",
-                                        "text-embedding-3-small"))
-                        .build());
-    }
-
-    private static Reranker createReranker() {
-        return new LlmReranker(
-                resolveValue(
-                        "memind.examples.rerank.base-url",
-                        "RERANK_BASE_URL",
-                        "https://api.openai.com"),
-                requireValue(
-                        "memind.examples.rerank.api-key",
-                        "RERANK_API_KEY",
-                        "Missing Rerank API key. Set system property "
-                                + "'memind.examples.rerank.api-key' or environment "
-                                + "variable 'RERANK_API_KEY'."),
-                resolveValue("memind.examples.rerank.model", "RERANK_MODEL", "qwen3-reranker-8b"));
-    }
-
-    private static OpenAiApi createOpenAiApi() {
-        return OpenAiApi.builder()
-                .apiKey(
-                        requireValue(
-                                "memind.examples.openai.api-key",
-                                "OPENAI_API_KEY",
-                                "Missing OpenAI API key. Set system property "
-                                        + "'memind.examples.openai.api-key' or environment "
-                                        + "variable 'OPENAI_API_KEY'."))
-                .baseUrl(
-                        resolveValue(
-                                "memind.examples.openai.base-url",
-                                "OPENAI_BASE_URL",
-                                "https://api.openai.com"))
-                .build();
-    }
-
-    private static JdbcMemoryAccess createJdbcAccess(String jdbcUrl) {
-        return switch (detectDialect(jdbcUrl)) {
-            case SQLITE -> JdbcStore.sqlite(extractSqlitePath(jdbcUrl));
-            case MYSQL ->
-                    JdbcStore.mysql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-            case POSTGRESQL ->
-                    JdbcStore.postgresql(
-                            jdbcUrl,
-                            requireValue(
-                                    "memind.examples.jdbc.username",
-                                    "MEMIND_EXAMPLES_JDBC_USERNAME",
-                                    "Missing JDBC username. Set system property "
-                                            + "'memind.examples.jdbc.username' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_USERNAME'."),
-                            requireValue(
-                                    "memind.examples.jdbc.password",
-                                    "MEMIND_EXAMPLES_JDBC_PASSWORD",
-                                    "Missing JDBC password. Set system property "
-                                            + "'memind.examples.jdbc.password' or environment "
-                                            + "variable 'MEMIND_EXAMPLES_JDBC_PASSWORD'."));
-        };
-    }
-
-    private static Path resolveRuntimeDir(String scenario) {
-        return Path.of(
-                        resolveValue(
-                                "memind.examples.runtime-dir",
-                                "MEMIND_EXAMPLES_RUNTIME_DIR",
-                                Path.of("target", "example-runtime", scenario).toString()))
-                .toAbsolutePath()
-                .normalize();
-    }
-
-    private static String resolveJdbcUrl(Path runtimeDir) {
-        return resolveValue(
-                "memind.examples.jdbc.url",
-                "MEMIND_EXAMPLES_JDBC_URL",
-                "jdbc:sqlite:" + runtimeDir.resolve("memind.db"));
-    }
-
-    private static String requireValue(String propertyName, String envName, String message) {
-        String value = resolveValue(propertyName, envName, "");
-        if (value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static String resolveValue(String propertyName, String envName, String defaultValue) {
-        String propertyValue = System.getProperty(propertyName);
-        if (propertyValue != null && !propertyValue.isBlank()) {
-            return propertyValue;
-        }
-
-        String environmentValue = System.getenv(envName);
-        if (environmentValue != null && !environmentValue.isBlank()) {
-            return environmentValue;
-        }
-
-        return defaultValue;
-    }
-
-    private static void prepareRuntimeLayout(Path runtimeDir, String jdbcUrl) {
-        try {
-            Files.createDirectories(runtimeDir);
-            Files.createDirectories(runtimeDir.resolve("vector-store.json").getParent());
-            ensureSqliteParentDirectory(jdbcUrl);
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "Failed to prepare runtime directory: " + runtimeDir, e);
-        }
-    }
-
-    private static void ensureSqliteParentDirectory(String jdbcUrl) throws Exception {
-        if (detectDialect(jdbcUrl) != JdbcDialect.SQLITE) {
-            return;
-        }
-
-        String rawPath = extractSqlitePath(jdbcUrl);
-        if (rawPath.isBlank() || ":memory:".equals(rawPath) || "file::memory:".equals(rawPath)) {
-            return;
-        }
-
-        Path dbPath = Path.of(rawPath).toAbsolutePath().normalize();
-        Path parent = dbPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
-    }
-
-    private static String extractSqlitePath(String jdbcUrl) {
-        String prefix = ":sqlite:";
-        int marker = jdbcUrl.toLowerCase(Locale.ROOT).indexOf(prefix);
-        if (marker < 0) {
-            throw new IllegalStateException("Unsupported SQLite JDBC URL: " + jdbcUrl);
-        }
-
-        String rawPath = jdbcUrl.substring(marker + prefix.length());
-        if (rawPath.isBlank()) {
-            throw new IllegalStateException("SQLite JDBC URL must contain a database path");
-        }
-        return rawPath;
-    }
-
-    private static JdbcDialect detectDialect(String jdbcUrl) {
-        String normalized = jdbcUrl.toLowerCase(Locale.ROOT);
-        if (normalized.contains(":sqlite:")) {
-            return JdbcDialect.SQLITE;
-        }
-        if (normalized.contains(":mysql:")) {
-            return JdbcDialect.MYSQL;
-        }
-        if (normalized.contains(":postgresql:")) {
-            return JdbcDialect.POSTGRESQL;
-        }
-        throw new IllegalStateException("Unsupported JDBC URL for pure Java example: " + jdbcUrl);
-    }
-
-    private enum JdbcDialect {
-        SQLITE,
-        MYSQL,
-        POSTGRESQL
     }
 }

--- a/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleMemoryOptionsTest.java
+++ b/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleMemoryOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
+import org.junit.jupiter.api.Test;
+
+class ExampleMemoryOptionsTest {
+
+    @Test
+    void defaultOptionsMatchLibraryDefaults() {
+        assertThat(ExampleMemoryOptions.defaultOptions())
+                .usingRecursiveComparison()
+                .isEqualTo(MemoryBuildOptions.defaults());
+    }
+
+    @Test
+    void insightTreeOptionsUseLowerInsightThresholds() {
+        var options = ExampleMemoryOptions.insightTreeOptions();
+
+        assertThat(options.extraction().insight().enabled()).isTrue();
+        assertThat(options.extraction().insight().build().groupingThreshold()).isEqualTo(2);
+        assertThat(options.extraction().insight().build().buildThreshold()).isEqualTo(2);
+    }
+
+    @Test
+    void agentScopeOptionsMirrorInsightPresetForNow() {
+        var options = ExampleMemoryOptions.agentScopeOptions();
+
+        assertThat(options.extraction().insight().enabled()).isTrue();
+        assertThat(options.extraction().insight().build().groupingThreshold()).isEqualTo(2);
+        assertThat(options.extraction().insight().build().buildThreshold()).isEqualTo(2);
+    }
+}

--- a/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleRuntimeFactoryTest.java
+++ b/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleRuntimeFactoryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ExampleRuntimeFactoryTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void prepareRuntimeLayoutCreatesScenarioDirectoryAndSqliteParent() throws Exception {
+        ExampleSettings settings =
+                ExampleSettings.load(
+                        "quickstart",
+                        new MapValueResolver(
+                                Map.of(
+                                        "memind.examples.openai.api-key",
+                                        "key",
+                                        "memind.examples.runtime-root-dir",
+                                        tempDir.toString()),
+                                Map.of()));
+
+        Path runtimeDir = ExampleRuntimeFactory.prepareRuntimeLayout("quickstart", settings);
+        Path sqlitePath =
+                Path.of(settings.store().jdbcUrl().substring("jdbc:sqlite:".length()))
+                        .toAbsolutePath()
+                        .normalize();
+
+        assertThat(runtimeDir)
+                .isEqualTo(tempDir.resolve("quickstart").toAbsolutePath().normalize());
+        assertThat(Files.isDirectory(runtimeDir)).isTrue();
+        assertThat(Files.isDirectory(sqlitePath.getParent())).isTrue();
+    }
+
+    @Test
+    void detectDialectSupportsTheThreeDocumentedJdbcFlavors() {
+        assertThat(ExampleRuntimeFactory.detectDialect("jdbc:sqlite:/tmp/demo.db"))
+                .isEqualTo("sqlite");
+        assertThat(ExampleRuntimeFactory.detectDialect("jdbc:mysql://localhost:3306/demo"))
+                .isEqualTo("mysql");
+        assertThat(ExampleRuntimeFactory.detectDialect("jdbc:postgresql://localhost:5432/demo"))
+                .isEqualTo("postgresql");
+    }
+
+    @Test
+    void createBuildsRuntimeWithSqliteDependencies() throws Exception {
+        ExampleSettings settings =
+                ExampleSettings.load(
+                        "quickstart",
+                        new MapValueResolver(
+                                Map.of(
+                                        "memind.examples.openai.api-key",
+                                        "key",
+                                        "memind.examples.runtime-root-dir",
+                                        tempDir.toString()),
+                                Map.of()));
+
+        try (ExampleRuntime runtime =
+                ExampleRuntimeFactory.create(
+                        "quickstart", ExampleMemoryOptions.defaultOptions(), settings)) {
+            assertThat(runtime.memory()).isNotNull();
+            assertThat(runtime.store()).isNotNull();
+            assertThat(runtime.dataLoader()).isNotNull();
+            assertThat(runtime.settings()).isSameAs(settings);
+            assertThat(runtime.runtimeDir())
+                    .isEqualTo(tempDir.resolve("quickstart").toAbsolutePath().normalize());
+            assertThat(runtime.jdbcDialect()).isEqualTo("sqlite");
+        }
+    }
+
+    record MapValueResolver(Map<String, String> properties, Map<String, String> environment)
+            implements ExampleSettings.ValueResolver {
+
+        @Override
+        public String systemProperty(String key) {
+            return properties.get(key);
+        }
+
+        @Override
+        public String environmentVariable(String key) {
+            return environment.get(key);
+        }
+    }
+}

--- a/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleSettingsTest.java
+++ b/memind-examples/memind-example-java/src/test/java/com/openmemind/ai/memory/example/java/support/ExampleSettingsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.example.java.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ExampleSettingsTest {
+
+    @Test
+    void loadUsesDefaultsAndScenarioSpecificSqlitePath() {
+        ExampleSettings settings =
+                ExampleSettings.load(
+                        "quickstart",
+                        new MapValueResolver(
+                                Map.of("memind.examples.openai.api-key", "test-openai-key"),
+                                Map.of()));
+
+        assertThat(settings.openAi().apiKey()).isEqualTo("test-openai-key");
+        assertThat(settings.openAi().baseUrl()).isEqualTo("https://api.openai.com");
+        assertThat(settings.openAi().chatModel()).isEqualTo("gpt-4o-mini");
+        assertThat(settings.openAi().embeddingModel()).isEqualTo("text-embedding-3-small");
+        assertThat(settings.rerank().enabled()).isFalse();
+        assertThat(settings.store().jdbcUrl())
+                .isEqualTo(
+                        "jdbc:sqlite:"
+                                + Path.of("target", "example-runtime", "quickstart", "memind.db")
+                                        .toAbsolutePath()
+                                        .normalize());
+        assertThat(settings.runtime().runtimeRootDir())
+                .isEqualTo(Path.of("target", "example-runtime").toAbsolutePath().normalize());
+        assertThat(settings.runtime().vectorStoreFileName()).isEqualTo("vector-store.json");
+    }
+
+    @Test
+    void loadPrefersSystemPropertiesOverEnvironmentValues() {
+        ExampleSettings settings =
+                ExampleSettings.load(
+                        "tool",
+                        new MapValueResolver(
+                                Map.of(
+                                        "memind.examples.openai.api-key", "property-openai-key",
+                                        "memind.examples.openai.chat-model", "property-chat",
+                                        "memind.examples.rerank.enabled", "true",
+                                        "memind.examples.rerank.api-key", "property-rerank-key"),
+                                Map.of(
+                                        "OPENAI_API_KEY", "env-openai-key",
+                                        "OPENAI_CHAT_MODEL", "env-chat",
+                                        "RERANK_API_KEY", "env-rerank-key")));
+
+        assertThat(settings.openAi().apiKey()).isEqualTo("property-openai-key");
+        assertThat(settings.openAi().chatModel()).isEqualTo("property-chat");
+        assertThat(settings.rerank().enabled()).isTrue();
+        assertThat(settings.rerank().apiKey()).isEqualTo("property-rerank-key");
+    }
+
+    @Test
+    void loadFailsFastWhenOpenAiKeyIsMissing() {
+        assertThatThrownBy(
+                        () ->
+                                ExampleSettings.load(
+                                        "quickstart", new MapValueResolver(Map.of(), Map.of())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("OPENAI_API_KEY");
+    }
+
+    record MapValueResolver(Map<String, String> properties, Map<String, String> environment)
+            implements ExampleSettings.ValueResolver {
+
+        @Override
+        public String systemProperty(String key) {
+            return properties.get(key);
+        }
+
+        @Override
+        public String environmentVariable(String key) {
+            return environment.get(key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared Java example runtime assembly, settings resolution, and scenario-specific memory option presets
- simplify the five example entrypoints so each focuses on its scenario flow while reusing the same support layer
- refresh the module README plus root English/Chinese README sections so example setup and IDE/Maven usage are clearer

## Test Plan
- [x] `mvn test`
