### PR TITLE
Improve memory observability tracing

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
@@ -16,6 +16,7 @@ package com.openmemind.ai.memory.core.builder;
 import com.openmemind.ai.memory.core.DefaultMemory;
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.buffer.MemoryBuffer;
+import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
 import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
@@ -26,10 +27,13 @@ import com.openmemind.ai.memory.core.plugin.RawDataPlugin;
 import com.openmemind.ai.memory.core.prompt.PromptRegistry;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
 import com.openmemind.ai.memory.core.resource.ResourceFetcher;
+import com.openmemind.ai.memory.core.retrieval.MemoryRetriever;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.NoopMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryRetriever;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -185,7 +189,11 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                         sanitization.memoryThreadForcedDisableReason());
         MemoryExtractionAssembly extractionAssembly =
                 new MemoryExtractionAssembler().assemble(context);
-        var memoryRetriever = new MemoryRetrievalAssembler().assemble(context);
+        MemoryExtractor pipeline =
+                tracingExtractor(extractionAssembly.pipeline(), context.memoryObserver());
+        MemoryRetriever memoryRetriever =
+                tracingRetriever(
+                        new MemoryRetrievalAssembler().assemble(context), context.memoryObserver());
         AutoCloseable lifecycle =
                 externallyManaged
                         ? lifecycle(extractionAssembly.lifecycle())
@@ -197,7 +205,7 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                                 context.memoryBuffer(),
                                 extractionAssembly.lifecycle());
         return new DefaultMemory(
-                extractionAssembly.pipeline(),
+                pipeline,
                 memoryRetriever,
                 context.memoryStore(),
                 context.memoryBuffer(),
@@ -206,6 +214,20 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                 lifecycle,
                 effectiveOptions,
                 extractionAssembly.memoryThreadLayer());
+    }
+
+    private MemoryExtractor tracingExtractor(MemoryExtractor extractor, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver || extractor instanceof TracingMemoryExtractor) {
+            return extractor;
+        }
+        return new TracingMemoryExtractor(extractor, observer);
+    }
+
+    private MemoryRetriever tracingRetriever(MemoryRetriever retriever, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver || retriever instanceof TracingMemoryRetriever) {
+            return retriever;
+        }
+        return new TracingMemoryRetriever(retriever, observer);
     }
 
     MemoryBuildOptions buildOptions() {

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
@@ -24,25 +24,40 @@ import com.openmemind.ai.memory.core.retrieval.deep.TypedQueryExpander;
 import com.openmemind.ai.memory.core.retrieval.graph.DefaultGraphItemChannel;
 import com.openmemind.ai.memory.core.retrieval.graph.DefaultRetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.graph.GraphExpansionEngine;
+import com.openmemind.ai.memory.core.retrieval.graph.GraphItemChannel;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.query.LlmLongQueryCondenser;
 import com.openmemind.ai.memory.core.retrieval.query.LongQueryCondenser;
+import com.openmemind.ai.memory.core.retrieval.scoring.DefaultRetrievalResultMerger;
+import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.strategy.DeepRetrievalStrategy;
 import com.openmemind.ai.memory.core.retrieval.strategy.DeepStrategyConfig;
 import com.openmemind.ai.memory.core.retrieval.strategy.SimpleRetrievalStrategy;
 import com.openmemind.ai.memory.core.retrieval.strategy.SimpleStrategyConfig;
 import com.openmemind.ai.memory.core.retrieval.sufficiency.LlmSufficiencyGate;
 import com.openmemind.ai.memory.core.retrieval.sufficiency.SufficiencyGate;
+import com.openmemind.ai.memory.core.retrieval.temporal.DefaultTemporalConstraintExtractor;
+import com.openmemind.ai.memory.core.retrieval.temporal.DefaultTemporalItemChannel;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannel;
 import com.openmemind.ai.memory.core.retrieval.thread.DefaultMemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistConfigMapper;
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.thread.NoOpMemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTypeRouter;
 import com.openmemind.ai.memory.core.retrieval.tier.ItemTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.LlmInsightTypeRouter;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.NoopMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingGraphItemChannel;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightTierRetriever;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingItemTierRetriever;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryThreadAssistant;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalGraphAssistant;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalResultMerger;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingTemporalItemChannel;
 
 final class MemoryRetrievalAssembler {
 
@@ -52,12 +67,18 @@ final class MemoryRetrievalAssembler {
                 new LlmInsightTypeRouter(
                         registry.resolve(ChatClientSlot.INSIGHT_TYPE_ROUTER),
                         context.promptRegistry());
-        InsightTierRetriever insightTierRetriever =
-                new InsightTierRetriever(
-                        context.memoryStore(), context.memoryVector(), insightTypeRouter);
-        ItemTierRetriever itemTierRetriever =
-                new ItemTierRetriever(
-                        context.memoryStore(), context.memoryVector(), context.textSearch());
+        InsightTierSearch insightTierRetriever =
+                tracingInsightTierRetriever(
+                        new InsightTierRetriever(
+                                context.memoryStore(), context.memoryVector(), insightTypeRouter),
+                        context.memoryObserver());
+        ItemTierSearch itemTierRetriever =
+                tracingItemTierRetriever(
+                        new ItemTierRetriever(
+                                context.memoryStore(),
+                                context.memoryVector(),
+                                context.textSearch()),
+                        context.memoryObserver());
         SufficiencyGate sufficiencyGate =
                 new LlmSufficiencyGate(
                         registry.resolve(ChatClientSlot.SUFFICIENCY_GATE),
@@ -67,8 +88,14 @@ final class MemoryRetrievalAssembler {
                         registry.resolve(ChatClientSlot.QUERY_EXPANDER), context.promptRegistry());
         var graphExpansionEngine = new GraphExpansionEngine(context.memoryStore());
         RetrievalGraphAssistant graphAssistant = buildGraphAssistant(context, graphExpansionEngine);
-        var graphItemChannel = new DefaultGraphItemChannel(graphExpansionEngine);
+        GraphItemChannel graphItemChannel =
+                tracingGraphItemChannel(
+                        new DefaultGraphItemChannel(graphExpansionEngine),
+                        context.memoryObserver());
         MemoryThreadAssistant memoryThreadAssistant = buildMemoryThreadAssistant(context);
+        RetrievalResultMerger resultMerger =
+                tracingRetrievalResultMerger(
+                        DefaultRetrievalResultMerger.INSTANCE, context.memoryObserver());
         SimpleStrategyConfig simpleStrategyConfig = simpleStrategyConfig(context.options());
         DeepStrategyConfig deepStrategyConfig = deepStrategyConfig(context.options());
         DeepRetrievalStrategy deepRetrievalStrategy =
@@ -81,7 +108,8 @@ final class MemoryRetrievalAssembler {
                         context.memoryStore(),
                         deepStrategyConfig,
                         graphAssistant,
-                        memoryThreadAssistant);
+                        memoryThreadAssistant,
+                        resultMerger);
         SimpleRetrievalStrategy simpleRetrievalStrategy =
                 new SimpleRetrievalStrategy(
                         insightTierRetriever,
@@ -91,11 +119,12 @@ final class MemoryRetrievalAssembler {
                         simpleStrategyConfig,
                         graphAssistant,
                         memoryThreadAssistant,
-                        new com.openmemind.ai.memory.core.retrieval.temporal
-                                .DefaultTemporalConstraintExtractor(),
-                        new com.openmemind.ai.memory.core.retrieval.temporal
-                                .DefaultTemporalItemChannel(context.memoryStore()),
+                        new DefaultTemporalConstraintExtractor(),
+                        tracingTemporalItemChannel(
+                                new DefaultTemporalItemChannel(context.memoryStore()),
+                                context.memoryObserver()),
                         graphItemChannel,
+                        resultMerger,
                         java.time.Clock.systemDefaultZone());
 
         RetrievalCache retrievalCache = new CaffeineRetrievalCache();
@@ -123,6 +152,50 @@ final class MemoryRetrievalAssembler {
             MemoryAssemblyContext context, GraphExpansionEngine graphExpansionEngine) {
         return new TracingRetrievalGraphAssistant(
                 new DefaultRetrievalGraphAssistant(graphExpansionEngine), context.memoryObserver());
+    }
+
+    private InsightTierSearch tracingInsightTierRetriever(
+            InsightTierSearch retriever, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver
+                || retriever instanceof TracingInsightTierRetriever) {
+            return retriever;
+        }
+        return new TracingInsightTierRetriever(retriever, observer);
+    }
+
+    private ItemTierSearch tracingItemTierRetriever(
+            ItemTierSearch retriever, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver
+                || retriever instanceof TracingItemTierRetriever) {
+            return retriever;
+        }
+        return new TracingItemTierRetriever(retriever, observer);
+    }
+
+    private GraphItemChannel tracingGraphItemChannel(
+            GraphItemChannel channel, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver || channel instanceof TracingGraphItemChannel) {
+            return channel;
+        }
+        return new TracingGraphItemChannel(channel, observer);
+    }
+
+    private TemporalItemChannel tracingTemporalItemChannel(
+            TemporalItemChannel channel, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver
+                || channel instanceof TracingTemporalItemChannel) {
+            return channel;
+        }
+        return new TracingTemporalItemChannel(channel, observer);
+    }
+
+    private RetrievalResultMerger tracingRetrievalResultMerger(
+            RetrievalResultMerger merger, MemoryObserver observer) {
+        if (observer instanceof NoopMemoryObserver
+                || merger instanceof TracingRetrievalResultMerger) {
+            return merger;
+        }
+        return new TracingRetrievalResultMerger(merger, observer);
     }
 
     private MemoryThreadAssistant buildMemoryThreadAssistant(MemoryAssemblyContext context) {

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/scoring/DefaultRetrievalResultMerger.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/scoring/DefaultRetrievalResultMerger.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.scoring;
+
+import java.util.List;
+import reactor.core.publisher.Mono;
+
+/** Default adapter around {@link ResultMerger}. */
+public final class DefaultRetrievalResultMerger implements RetrievalResultMerger {
+
+    public static final DefaultRetrievalResultMerger INSTANCE = new DefaultRetrievalResultMerger();
+
+    private DefaultRetrievalResultMerger() {}
+
+    @Override
+    public Mono<List<ScoredResult>> merge(
+            ScoringConfig scoring, List<List<ScoredResult>> rankedLists, double... weights) {
+        return Mono.fromSupplier(() -> ResultMerger.merge(scoring, rankedLists, weights));
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/scoring/RetrievalResultMerger.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/scoring/RetrievalResultMerger.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.scoring;
+
+import java.util.List;
+import reactor.core.publisher.Mono;
+
+/** Strategy-facing retrieval result fusion contract. */
+public interface RetrievalResultMerger {
+
+    Mono<List<ScoredResult>> merge(
+            ScoringConfig scoring, List<List<ScoredResult>> rankedLists, double... weights);
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/strategy/DeepRetrievalStrategy.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/strategy/DeepRetrievalStrategy.java
@@ -23,17 +23,19 @@ import com.openmemind.ai.memory.core.retrieval.graph.NoOpRetrievalGraphAssistant
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistResult;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.DefaultRetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.scoring.RawDataAggregator;
 import com.openmemind.ai.memory.core.retrieval.scoring.ResultMerger;
+import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.TimeDecay;
 import com.openmemind.ai.memory.core.retrieval.sufficiency.SufficiencyGate;
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistResult;
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.thread.NoOpMemoryThreadAssistant;
-import com.openmemind.ai.memory.core.retrieval.tier.InsightTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTreeExpander;
-import com.openmemind.ai.memory.core.retrieval.tier.ItemTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
 import com.openmemind.ai.memory.core.store.MemoryStore;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
@@ -71,8 +73,8 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
 
     private static final Logger log = LoggerFactory.getLogger(DeepRetrievalStrategy.class);
 
-    private final InsightTierRetriever insightRetriever;
-    private final ItemTierRetriever itemRetriever;
+    private final InsightTierSearch insightRetriever;
+    private final ItemTierSearch itemRetriever;
     private final SufficiencyGate sufficiencyGate;
     private final TypedQueryExpander typedQueryExpander;
     private final Reranker reranker;
@@ -81,14 +83,15 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
     private final DeepStrategyConfig defaultStrategyConfig;
     private final RetrievalGraphAssistant graphAssistant;
     private final MemoryThreadAssistant memoryThreadAssistant;
+    private final RetrievalResultMerger resultMerger;
 
     /** Tier2 initial retrieval result */
     private record Tier2InitResult(
             List<TextSearchResult> bm25ProbeResults, TierResult vectorResult) {}
 
     public DeepRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             SufficiencyGate sufficiencyGate,
             TypedQueryExpander typedQueryExpander,
             Reranker reranker,
@@ -106,8 +109,8 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
     }
 
     public DeepRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             SufficiencyGate sufficiencyGate,
             TypedQueryExpander typedQueryExpander,
             Reranker reranker,
@@ -123,12 +126,13 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
                 memoryStore,
                 DeepStrategyConfig.defaults(),
                 graphAssistant,
-                memoryThreadAssistant);
+                memoryThreadAssistant,
+                DefaultRetrievalResultMerger.INSTANCE);
     }
 
     public DeepRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             SufficiencyGate sufficiencyGate,
             TypedQueryExpander typedQueryExpander,
             Reranker reranker,
@@ -147,8 +151,8 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
     }
 
     public DeepRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             SufficiencyGate sufficiencyGate,
             TypedQueryExpander typedQueryExpander,
             Reranker reranker,
@@ -156,6 +160,30 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
             DeepStrategyConfig defaultStrategyConfig,
             RetrievalGraphAssistant graphAssistant,
             MemoryThreadAssistant memoryThreadAssistant) {
+        this(
+                insightRetriever,
+                itemRetriever,
+                sufficiencyGate,
+                typedQueryExpander,
+                reranker,
+                memoryStore,
+                defaultStrategyConfig,
+                graphAssistant,
+                memoryThreadAssistant,
+                DefaultRetrievalResultMerger.INSTANCE);
+    }
+
+    public DeepRetrievalStrategy(
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
+            SufficiencyGate sufficiencyGate,
+            TypedQueryExpander typedQueryExpander,
+            Reranker reranker,
+            MemoryStore memoryStore,
+            DeepStrategyConfig defaultStrategyConfig,
+            RetrievalGraphAssistant graphAssistant,
+            MemoryThreadAssistant memoryThreadAssistant,
+            RetrievalResultMerger resultMerger) {
         this.insightRetriever =
                 Objects.requireNonNull(insightRetriever, "insightRetriever must not be null");
         this.itemRetriever =
@@ -177,6 +205,8 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
                 memoryThreadAssistant != null
                         ? memoryThreadAssistant
                         : NoOpMemoryThreadAssistant.INSTANCE;
+        this.resultMerger =
+                resultMerger != null ? resultMerger : DefaultRetrievalResultMerger.INSTANCE;
     }
 
     @Override
@@ -493,34 +523,36 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
             }
         }
 
-        // Single-level RRF merge
-        List<ScoredResult> merged;
-        if (rankedLists.isEmpty()) {
-            merged = List.of();
-        } else if (rankedLists.size() == 1) {
-            merged = rankedLists.get(0);
-        } else {
-            double[] weights = weightsList.stream().mapToDouble(Double::doubleValue).toArray();
-            merged = ResultMerger.merge(baseConfig.scoring(), rankedLists, weights);
-        }
+        return mergeRankedLists(baseConfig, rankedLists, weightsList)
+                .flatMap(
+                        merged -> {
+                            // BM25-only results backfill occurredAt
+                            merged =
+                                    RawDataAggregator.backfillOccurredAt(
+                                            merged, context.memoryId(), memoryStore);
 
-        // BM25-only results backfill occurredAt
-        merged = RawDataAggregator.backfillOccurredAt(merged, context.memoryId(), memoryStore);
+                            // BM25-only results apply time decay
+                            merged =
+                                    TimeDecay.applyToBm25Only(
+                                            merged, context, baseConfig.scoring());
+                            merged =
+                                    merged.stream()
+                                            .sorted(
+                                                    Comparator.comparingDouble(
+                                                                    ScoredResult::finalScore)
+                                                            .reversed())
+                                            .toList();
 
-        // BM25-only results apply time decay
-        merged = TimeDecay.applyToBm25Only(merged, context, baseConfig.scoring());
-        merged =
-                merged.stream()
-                        .sorted(Comparator.comparingDouble(ScoredResult::finalScore).reversed())
-                        .toList();
+                            int directWindowSize = baseConfig.tier2().topK();
+                            List<ScoredResult> directWindow =
+                                    merged.size() > directWindowSize
+                                            ? merged.subList(0, directWindowSize)
+                                            : merged;
 
-        int directWindowSize = baseConfig.tier2().topK();
-        List<ScoredResult> directWindow =
-                merged.size() > directWindowSize ? merged.subList(0, directWindowSize) : merged;
+                            log.debug("RRF merged truncation: {} candidates", directWindow.size());
 
-        log.debug("RRF merged truncation: {} candidates", directWindow.size());
-
-        return applyMemoryThreadAssist(context, baseConfig, directWindow)
+                            return applyMemoryThreadAssist(context, baseConfig, directWindow);
+                        })
                 .flatMap(candidatePool -> applyGraphAssist(context, baseConfig, candidatePool))
                 .flatMap(
                         candidatePool -> {
@@ -547,6 +579,20 @@ public class DeepRetrievalStrategy implements RetrievalStrategy {
                                                 context);
                                     });
                         });
+    }
+
+    private Mono<List<ScoredResult>> mergeRankedLists(
+            RetrievalConfig baseConfig,
+            List<List<ScoredResult>> rankedLists,
+            List<Double> weightsList) {
+        if (rankedLists.isEmpty()) {
+            return Mono.just(List.of());
+        }
+        if (rankedLists.size() == 1) {
+            return Mono.just(rankedLists.getFirst());
+        }
+        double[] weights = weightsList.stream().mapToDouble(Double::doubleValue).toArray();
+        return resultMerger.merge(baseConfig.scoring(), rankedLists, weights);
     }
 
     /**

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/strategy/SimpleRetrievalStrategy.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/strategy/SimpleRetrievalStrategy.java
@@ -21,8 +21,10 @@ import com.openmemind.ai.memory.core.retrieval.graph.NoOpRetrievalGraphAssistant
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistResult;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.DefaultRetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.scoring.RawDataAggregator;
 import com.openmemind.ai.memory.core.retrieval.scoring.ResultMerger;
+import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.TimeDecay;
 import com.openmemind.ai.memory.core.retrieval.temporal.DefaultTemporalConstraintExtractor;
@@ -33,9 +35,9 @@ import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelResul
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistResult;
 import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.thread.NoOpMemoryThreadAssistant;
-import com.openmemind.ai.memory.core.retrieval.tier.InsightTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTreeExpander;
-import com.openmemind.ai.memory.core.retrieval.tier.ItemTierRetriever;
+import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
 import com.openmemind.ai.memory.core.retrieval.truncation.AdaptiveTruncator;
 import com.openmemind.ai.memory.core.store.MemoryStore;
@@ -68,8 +70,8 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
 
     private static final Logger log = LoggerFactory.getLogger(SimpleRetrievalStrategy.class);
 
-    private final InsightTierRetriever insightRetriever;
-    private final ItemTierRetriever itemRetriever;
+    private final InsightTierSearch insightRetriever;
+    private final ItemTierSearch itemRetriever;
     private final MemoryTextSearch textSearch; // nullable
     private final MemoryStore memoryStore; // nullable
     private final SimpleStrategyConfig defaultStrategyConfig;
@@ -79,11 +81,12 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
     private final TemporalItemChannel temporalItemChannel;
     private final GraphItemChannel
             graphItemChannel; // nullable: preserves legacy graph assistant behavior
+    private final RetrievalResultMerger resultMerger;
     private final Clock clock;
 
     public SimpleRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             MemoryTextSearch textSearch,
             MemoryStore memoryStore,
             SimpleStrategyConfig defaultStrategyConfig,
@@ -100,12 +103,13 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
                 new DefaultTemporalConstraintExtractor(),
                 new DefaultTemporalItemChannel(memoryStore),
                 null,
+                DefaultRetrievalResultMerger.INSTANCE,
                 Clock.systemDefaultZone());
     }
 
     public SimpleRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             MemoryTextSearch textSearch,
             MemoryStore memoryStore,
             SimpleStrategyConfig defaultStrategyConfig,
@@ -114,6 +118,7 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
             TemporalConstraintExtractor temporalConstraintExtractor,
             TemporalItemChannel temporalItemChannel,
             GraphItemChannel graphItemChannel,
+            RetrievalResultMerger resultMerger,
             Clock clock) {
         this.insightRetriever =
                 Objects.requireNonNull(insightRetriever, "insightRetriever must not be null");
@@ -140,12 +145,14 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
                         ? temporalItemChannel
                         : new DefaultTemporalItemChannel(memoryStore);
         this.graphItemChannel = graphItemChannel;
+        this.resultMerger =
+                resultMerger != null ? resultMerger : DefaultRetrievalResultMerger.INSTANCE;
         this.clock = clock != null ? clock : Clock.systemDefaultZone();
     }
 
     public SimpleRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             MemoryTextSearch textSearch,
             MemoryStore memoryStore,
             RetrievalGraphAssistant graphAssistant,
@@ -161,8 +168,8 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
     }
 
     public SimpleRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             MemoryTextSearch textSearch,
             MemoryStore memoryStore,
             RetrievalGraphAssistant graphAssistant) {
@@ -177,8 +184,8 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
     }
 
     public SimpleRetrievalStrategy(
-            InsightTierRetriever insightRetriever,
-            ItemTierRetriever itemRetriever,
+            InsightTierSearch insightRetriever,
+            ItemTierSearch itemRetriever,
             MemoryTextSearch textSearch,
             MemoryStore memoryStore) {
         this(
@@ -260,46 +267,54 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
                             TemporalItemChannelResult temporalResult = tuple.getT4();
 
                             // Item vector + BM25 + Temporal -> Weighted RRF merge
-                            List<ScoredResult> mergedItems =
-                                    mergeItemResults(
+                            return mergeItemResults(
                                             itemVectorResult.results(),
                                             bm25Results,
                                             temporalResult.items(),
                                             config,
-                                            simpleConfig);
-
-                            // BM25-only results backfill occurredAt
-                            mergedItems =
-                                    RawDataAggregator.backfillOccurredAt(
-                                            mergedItems, context.memoryId(), memoryStore);
-
-                            // BM25-only results apply time decay
-                            mergedItems =
-                                    TimeDecay.applyToBm25Only(
-                                            mergedItems, context, config.scoring());
-                            mergedItems =
-                                    mergedItems.stream()
-                                            .sorted(
-                                                    Comparator.comparingDouble(
-                                                                    ScoredResult::finalScore)
-                                                            .reversed())
-                                            .toList();
-
-                            var directItems = mergedItems;
-                            return applyMemoryThreadAssist(
-                                            context, config, simpleConfig, directItems)
+                                            simpleConfig)
                                     .flatMap(
-                                            candidatePool ->
-                                                    applyGraphPhase(
-                                                                    context,
-                                                                    config,
-                                                                    simpleConfig,
-                                                                    candidatePool)
-                                                            .map(
-                                                                    items ->
-                                                                            new PipelineInputs(
-                                                                                    insightResult,
-                                                                                    items)));
+                                            mergedItems -> {
+                                                // BM25-only results backfill occurredAt
+                                                mergedItems =
+                                                        RawDataAggregator.backfillOccurredAt(
+                                                                mergedItems,
+                                                                context.memoryId(),
+                                                                memoryStore);
+
+                                                // BM25-only results apply time decay
+                                                mergedItems =
+                                                        TimeDecay.applyToBm25Only(
+                                                                mergedItems,
+                                                                context,
+                                                                config.scoring());
+                                                mergedItems =
+                                                        mergedItems.stream()
+                                                                .sorted(
+                                                                        Comparator.comparingDouble(
+                                                                                        ScoredResult
+                                                                                                ::finalScore)
+                                                                                .reversed())
+                                                                .toList();
+
+                                                return applyMemoryThreadAssist(
+                                                                context,
+                                                                config,
+                                                                simpleConfig,
+                                                                mergedItems)
+                                                        .flatMap(
+                                                                candidatePool ->
+                                                                        applyGraphPhase(
+                                                                                        context,
+                                                                                        config,
+                                                                                        simpleConfig,
+                                                                                        candidatePool)
+                                                                                .map(
+                                                                                        items ->
+                                                                                                new PipelineInputs(
+                                                                                                        insightResult,
+                                                                                                        items)));
+                                            });
                         })
                 .map(inputs -> finalizeResult(context, config, inputs));
     }
@@ -332,21 +347,21 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
                             log.warn("Simple: Graph item channel failed", error);
                             return Mono.just(GraphExpansionResult.degraded(true, false));
                         })
-                .map(
+                .flatMap(
                         result ->
                                 mergeGraphChannelResults(
                                         candidatePool, result.graphItems(), config, simpleConfig));
     }
 
-    private List<ScoredResult> mergeGraphChannelResults(
+    private Mono<List<ScoredResult>> mergeGraphChannelResults(
             List<ScoredResult> directItems,
             List<ScoredResult> graphItems,
             RetrievalConfig config,
             SimpleStrategyConfig simpleConfig) {
         if (graphItems == null || graphItems.isEmpty()) {
-            return directItems;
+            return Mono.just(directItems);
         }
-        return ResultMerger.merge(
+        return resultMerger.merge(
                 config.scoring(),
                 List.of(directItems, graphItems),
                 1.0d,
@@ -473,7 +488,7 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
     private record PipelineInputs(TierResult insightResult, List<ScoredResult> items) {}
 
     /** Merge Item vector results with BM25 results */
-    private List<ScoredResult> mergeItemResults(
+    private Mono<List<ScoredResult>> mergeItemResults(
             List<ScoredResult> vectorResults,
             List<TextSearchResult> bm25Results,
             List<ScoredResult> temporalResults,
@@ -508,13 +523,13 @@ public class SimpleRetrievalStrategy implements RetrievalStrategy {
             weights.add(simpleConfig.temporalRetrieval().channelWeight());
         }
         if (rankedLists.isEmpty()) {
-            return List.of();
+            return Mono.just(List.of());
         }
         if (rankedLists.size() == 1) {
-            return rankedLists.getFirst();
+            return Mono.just(rankedLists.getFirst());
         }
 
-        return ResultMerger.merge(
+        return resultMerger.merge(
                 config.scoring(),
                 rankedLists,
                 weights.stream().mapToDouble(Double::doubleValue).toArray());

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/InsightTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/InsightTierRetriever.java
@@ -54,7 +54,7 @@ import reactor.core.publisher.Mono;
  * </ul>
  *
  */
-public class InsightTierRetriever {
+public class InsightTierRetriever implements InsightTierSearch {
 
     private static final Logger log = LoggerFactory.getLogger(InsightTierRetriever.class);
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/InsightTierSearch.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/InsightTierSearch.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.tier;
+
+import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import reactor.core.publisher.Mono;
+
+/** Strategy-facing insight tier retrieval contract. */
+public interface InsightTierSearch {
+
+    Mono<TierResult> retrieve(QueryContext context, RetrievalConfig config);
+
+    void invalidateCache(MemoryId memoryId);
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/ItemTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/ItemTierRetriever.java
@@ -47,7 +47,7 @@ import reactor.core.publisher.Mono;
  * <p>Vector search MemoryItem, output scopeHints = list of rawDataId matching items
  *
  */
-public class ItemTierRetriever implements TierSearchable {
+public class ItemTierRetriever implements ItemTierSearch {
 
     private static final Logger log = LoggerFactory.getLogger(ItemTierRetriever.class);
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/ItemTierSearch.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/tier/ItemTierSearch.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.tier;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
+import reactor.core.publisher.Mono;
+
+/** Strategy-facing item tier retrieval contract. */
+public interface ItemTierSearch extends TierSearchable {
+
+    Mono<TierResult> searchByVector(QueryContext context, RetrievalConfig config);
+
+    MemoryTextSearch textSearch();
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/MemoryAttributes.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/MemoryAttributes.java
@@ -177,6 +177,12 @@ public final class MemoryAttributes {
     public static final String RETRIEVAL_INTENT = "memind.retrieval.intent";
     public static final String RETRIEVAL_TIER = "memind.retrieval.sufficiency";
     public static final String RETRIEVAL_RESULT_COUNT = "memind.retrieval.result_count";
+    public static final String RETRIEVAL_CANDIDATE_COUNT = "memind.retrieval.candidate_count";
+    public static final String RETRIEVAL_SOURCE_LIST_COUNT = "memind.retrieval.source_list_count";
+    public static final String RETRIEVAL_DEDUPED_COUNT = "memind.retrieval.deduped_count";
+    public static final String RETRIEVAL_WEIGHT_COUNT = "memind.retrieval.weight_count";
+    public static final String RETRIEVAL_TIER_NAME = "memind.retrieval.tier";
+    public static final String RETRIEVAL_CHANNEL = "memind.retrieval.channel";
     public static final String RETRIEVAL_SUFFICIENT = "memind.retrieval.sufficient";
     public static final String RETRIEVAL_CACHE_HIT = "memind.retrieval.cache_hit";
     public static final String RETRIEVAL_TOP_K = "memind.retrieval.top_k";
@@ -212,4 +218,8 @@ public final class MemoryAttributes {
             "memind.retrieval.graph.skipped_overfanout_entity_count";
     public static final String RETRIEVAL_GRAPH_TIMEOUT = "memind.retrieval.graph.timeout";
     public static final String RETRIEVAL_GRAPH_DEGRADED = "memind.retrieval.graph.degraded";
+    public static final String RETRIEVAL_TEMPORAL_ENABLED = "memind.retrieval.temporal.enabled";
+    public static final String RETRIEVAL_TEMPORAL_CONSTRAINT_PRESENT =
+            "memind.retrieval.temporal.constraint_present";
+    public static final String RETRIEVAL_TEMPORAL_DEGRADED = "memind.retrieval.temporal.degraded";
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/MemorySpanNames.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/MemorySpanNames.java
@@ -54,16 +54,19 @@ public final class MemorySpanNames {
     public static final String RETRIEVAL_INTENT = "memind.retrieval.intent";
     public static final String RETRIEVAL_REWRITE = "memind.retrieval.rewrite";
     public static final String RETRIEVAL_STRATEGY = "memind.retrieval.strategy";
-    public static final String RETRIEVAL_TIER_INSIGHT = "memind.retrieval.sufficiency.insight";
-    public static final String RETRIEVAL_TIER_ITEM = "memind.retrieval.sufficiency.item";
-    public static final String RETRIEVAL_TIER_RAWDATA = "memind.retrieval.sufficiency.rawdata";
+    public static final String RETRIEVAL_TIER_INSIGHT = "memind.retrieval.tier.insight";
+    public static final String RETRIEVAL_TIER_ITEM = "memind.retrieval.tier.item";
+    public static final String RETRIEVAL_TIER_RAWDATA = "memind.retrieval.tier.rawdata";
     public static final String RETRIEVAL_SUFFICIENCY = "memind.retrieval.sufficiency";
     public static final String RETRIEVAL_VECTOR_SEARCH = "memind.retrieval.vector_search";
+    public static final String RETRIEVAL_RESULT_MERGE = "memind.retrieval.result_merge";
     public static final String RETRIEVAL_RERANK = "memind.retrieval.rerank";
     public static final String RETRIEVAL_KEYWORD_SEARCH = "memind.retrieval.keyword_search";
     public static final String RETRIEVAL_MEMORY_THREAD_ASSIST =
             "memind.retrieval.memory_thread.assist";
     public static final String RETRIEVAL_GRAPH_ASSIST = "memind.retrieval.graph.assist";
+    public static final String RETRIEVAL_GRAPH_CHANNEL = "memind.retrieval.channel.graph";
+    public static final String RETRIEVAL_TEMPORAL_CHANNEL = "memind.retrieval.channel.temporal";
     public static final String RETRIEVAL_INSIGHT_TYPE_ROUTING =
             "memind.retrieval.insight_type_routing";
     public static final String RETRIEVAL_MULTI_QUERY_EXPAND = "memind.retrieval.multi_query_expand";

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannel.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannel.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.graph.GraphExpansionResult;
+import com.openmemind.ai.memory.core.retrieval.graph.GraphItemChannel;
+import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphSettings;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
+import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import reactor.core.publisher.Mono;
+
+/** Tracing decorator for graph item channel retrieval. */
+public final class TracingGraphItemChannel extends TracingSupport implements GraphItemChannel {
+
+    private final GraphItemChannel delegate;
+
+    public TracingGraphItemChannel(GraphItemChannel delegate, MemoryObserver observer) {
+        super(Objects.requireNonNull(observer, "observer"));
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public Mono<GraphExpansionResult> retrieve(
+            QueryContext context,
+            RetrievalConfig config,
+            RetrievalGraphSettings settings,
+            List<ScoredResult> seeds) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_GRAPH_CHANNEL,
+                Map.of(
+                        MemoryAttributes.MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        MemoryAttributes.RETRIEVAL_CHANNEL,
+                        "graph",
+                        MemoryAttributes.RETRIEVAL_GRAPH_ENABLED,
+                        settings != null && settings.enabled(),
+                        MemoryAttributes.RETRIEVAL_GRAPH_SEED_COUNT,
+                        seeds == null ? 0 : seeds.size()),
+                result ->
+                        Map.of(
+                                MemoryAttributes.RETRIEVAL_RESULT_COUNT,
+                                result.graphItems().size(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_LINK_EXPANSION_COUNT,
+                                result.linkExpansionCount(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_ENTITY_EXPANSION_COUNT,
+                                result.entityExpansionCount(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_DEDUPED_CANDIDATE_COUNT,
+                                result.dedupedCandidateCount(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_OVERLAP_COUNT,
+                                result.overlapCount(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_SKIPPED_OVERFANOUT_ENTITY_COUNT,
+                                result.skippedOverFanoutEntityCount(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_TIMEOUT,
+                                result.timedOut(),
+                                MemoryAttributes.RETRIEVAL_GRAPH_DEGRADED,
+                                result.degraded()),
+                () -> delegate.retrieve(context, config, settings, seeds));
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetriever.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TIER_NAME;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
+
+import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
+import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
+import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/** Tracing decorator for insight tier retrieval. */
+public class TracingInsightTierRetriever extends TracingSupport implements InsightTierSearch {
+
+    private final InsightTierSearch delegate;
+
+    public TracingInsightTierRetriever(InsightTierSearch delegate, MemoryObserver observer) {
+        super(observer);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Mono<TierResult> retrieve(QueryContext context, RetrievalConfig config) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_TIER_INSIGHT,
+                Map.of(
+                        MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        RETRIEVAL_TIER_NAME,
+                        "insight",
+                        RETRIEVAL_TOP_K,
+                        config.tier1().topK()),
+                result -> Map.of(RETRIEVAL_RESULT_COUNT, result.results().size()),
+                () -> delegate.retrieve(context, config));
+    }
+
+    @Override
+    public void invalidateCache(MemoryId memoryId) {
+        delegate.invalidateCache(memoryId);
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetriever.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TIER_NAME;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
+import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
+import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
+import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
+import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/** Tracing decorator for item tier retrieval operations. */
+public class TracingItemTierRetriever extends TracingSupport implements ItemTierSearch {
+
+    private final ItemTierSearch delegate;
+
+    public TracingItemTierRetriever(ItemTierSearch delegate, MemoryObserver observer) {
+        super(observer);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Mono<TierResult> searchByVector(QueryContext context, RetrievalConfig config) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_VECTOR_SEARCH,
+                Map.of(
+                        MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        RETRIEVAL_TIER_NAME,
+                        "item",
+                        RETRIEVAL_TOP_K,
+                        config.tier2().topK()),
+                result -> Map.of(RETRIEVAL_RESULT_COUNT, result.results().size()),
+                () -> delegate.searchByVector(context, config));
+    }
+
+    @Override
+    public MemoryTextSearch textSearch() {
+        return delegate.textSearch();
+    }
+
+    @Override
+    public Mono<List<ScoredResult>> searchByVector(
+            QueryContext context, RetrievalConfig.TierConfig tier, ScoringConfig scoring) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_VECTOR_SEARCH,
+                Map.of(
+                        MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        RETRIEVAL_TIER_NAME,
+                        "item",
+                        RETRIEVAL_TOP_K,
+                        tier.topK()),
+                result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
+                () -> delegate.searchByVector(context, tier, scoring));
+    }
+
+    @Override
+    public Mono<List<ScoredResult>> searchByKeyword(
+            QueryContext context, RetrievalConfig.TierConfig tier, ScoringConfig scoring) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_KEYWORD_SEARCH,
+                Map.of(
+                        MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        RETRIEVAL_TIER_NAME,
+                        "item",
+                        RETRIEVAL_TOP_K,
+                        tier.topK()),
+                result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
+                () -> delegate.searchByKeyword(context, tier, scoring));
+    }
+
+    @Override
+    public Mono<List<ScoredResult>> searchHybrid(
+            QueryContext context, RetrievalConfig.TierConfig tier, ScoringConfig scoring) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_TIER_ITEM,
+                Map.of(
+                        MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        RETRIEVAL_TIER_NAME,
+                        "item",
+                        RETRIEVAL_TOP_K,
+                        tier.topK()),
+                result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
+                () -> delegate.searchHybrid(context, tier, scoring));
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMerger.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMerger.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
+import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
+import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import reactor.core.publisher.Mono;
+
+/** Tracing decorator for strategy-level retrieval result fusion. */
+public final class TracingRetrievalResultMerger extends TracingSupport
+        implements RetrievalResultMerger {
+
+    private final RetrievalResultMerger delegate;
+
+    public TracingRetrievalResultMerger(RetrievalResultMerger delegate, MemoryObserver observer) {
+        super(Objects.requireNonNull(observer, "observer"));
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public Mono<List<ScoredResult>> merge(
+            ScoringConfig scoring, List<List<ScoredResult>> rankedLists, double... weights) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_RESULT_MERGE,
+                requestAttributes(rankedLists, weights),
+                result -> resultAttributes(rankedLists, result),
+                () -> delegate.merge(scoring, rankedLists, weights));
+    }
+
+    private Map<String, Object> requestAttributes(
+            List<List<ScoredResult>> rankedLists, double[] weights) {
+        return Map.of(
+                MemoryAttributes.RETRIEVAL_SOURCE_LIST_COUNT,
+                rankedLists == null ? 0 : rankedLists.size(),
+                MemoryAttributes.RETRIEVAL_CANDIDATE_COUNT,
+                candidateCount(rankedLists),
+                MemoryAttributes.RETRIEVAL_DEDUPED_COUNT,
+                dedupedCount(rankedLists),
+                MemoryAttributes.RETRIEVAL_WEIGHT_COUNT,
+                weights == null ? 0 : weights.length);
+    }
+
+    private Map<String, Object> resultAttributes(
+            List<List<ScoredResult>> rankedLists, List<ScoredResult> result) {
+        int before = candidateCount(rankedLists);
+        int after = result == null ? 0 : result.size();
+        return Map.of(
+                MemoryAttributes.RETRIEVAL_RESULT_COUNT,
+                after,
+                MemoryAttributes.RETRIEVAL_DEDUPED_COUNT,
+                Math.max(0, before - after));
+    }
+
+    private int candidateCount(List<List<ScoredResult>> rankedLists) {
+        if (rankedLists == null) {
+            return 0;
+        }
+        return rankedLists.stream().filter(Objects::nonNull).mapToInt(List::size).sum();
+    }
+
+    private int dedupedCount(List<List<ScoredResult>> rankedLists) {
+        if (rankedLists == null) {
+            return 0;
+        }
+        return (int)
+                rankedLists.stream()
+                        .filter(Objects::nonNull)
+                        .flatMap(List::stream)
+                        .map(ScoredResult::dedupKey)
+                        .distinct()
+                        .count();
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannel.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannel.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalConstraint;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannel;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelResult;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelSettings;
+import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
+import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import reactor.core.publisher.Mono;
+
+/** Tracing decorator for temporal item channel retrieval. */
+public final class TracingTemporalItemChannel extends TracingSupport
+        implements TemporalItemChannel {
+
+    private final TemporalItemChannel delegate;
+
+    public TracingTemporalItemChannel(TemporalItemChannel delegate, MemoryObserver observer) {
+        super(Objects.requireNonNull(observer, "observer"));
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public Mono<TemporalItemChannelResult> retrieve(
+            QueryContext context,
+            RetrievalConfig config,
+            Optional<TemporalConstraint> temporalConstraint,
+            TemporalItemChannelSettings settings) {
+        return trace(
+                MemorySpanNames.RETRIEVAL_TEMPORAL_CHANNEL,
+                Map.of(
+                        MemoryAttributes.MEMORY_ID,
+                        context.memoryId().toIdentifier(),
+                        MemoryAttributes.RETRIEVAL_CHANNEL,
+                        "temporal",
+                        MemoryAttributes.RETRIEVAL_TEMPORAL_ENABLED,
+                        settings != null && settings.enabled(),
+                        MemoryAttributes.RETRIEVAL_TEMPORAL_CONSTRAINT_PRESENT,
+                        temporalConstraint != null && temporalConstraint.isPresent()),
+                result ->
+                        Map.of(
+                                MemoryAttributes.RETRIEVAL_RESULT_COUNT,
+                                result.items().size(),
+                                MemoryAttributes.RETRIEVAL_CANDIDATE_COUNT,
+                                result.candidateCount(),
+                                MemoryAttributes.RETRIEVAL_TEMPORAL_ENABLED,
+                                result.enabled(),
+                                MemoryAttributes.RETRIEVAL_TEMPORAL_CONSTRAINT_PRESENT,
+                                result.constraintPresent(),
+                                MemoryAttributes.RETRIEVAL_TEMPORAL_DEGRADED,
+                                result.degraded()),
+                () -> delegate.retrieve(context, config, temporalConstraint, settings));
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/internal/DefaultMemoryBuilderTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/builder/internal/DefaultMemoryBuilderTest.java
@@ -43,6 +43,7 @@ import com.openmemind.ai.memory.core.builder.SimpleRetrievalGraphOptions;
 import com.openmemind.ai.memory.core.builder.SimpleRetrievalOptions;
 import com.openmemind.ai.memory.core.builder.SufficiencyOptions;
 import com.openmemind.ai.memory.core.extraction.DefaultMemoryExtractor;
+import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.context.LlmContextCommitDetector;
 import com.openmemind.ai.memory.core.extraction.insight.InsightLayer;
 import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildScheduler;
@@ -65,6 +66,7 @@ import com.openmemind.ai.memory.core.prompt.PromptType;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
 import com.openmemind.ai.memory.core.resource.ResourceFetcher;
 import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
+import com.openmemind.ai.memory.core.retrieval.MemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.deep.LlmTypedQueryExpander;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphMode;
@@ -79,7 +81,11 @@ import com.openmemind.ai.memory.core.store.item.ItemOperations;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
 import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
+import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.core.tracing.NoopMemoryObserver;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingItemGraphMaterializer;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryRetriever;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
 import java.lang.reflect.Proxy;
 import java.util.Map;
@@ -220,6 +226,37 @@ class DefaultMemoryBuilderTest {
                                 .derivation()
                                 .enabled())
                 .isFalse();
+    }
+
+    @Test
+    void builderWrapsExtractorWithTracingDecoratorWhenObserverConfigured() {
+        var observer = new RecordingMemoryObserver();
+
+        var memory = buildMinimalMemory(observer);
+
+        var extractor = readField(memory, "extractor", MemoryExtractor.class);
+        assertThat(extractor).isInstanceOf(TracingMemoryExtractor.class);
+    }
+
+    @Test
+    void builderWrapsRetrieverWithTracingDecoratorWhenObserverConfigured() {
+        var observer = new RecordingMemoryObserver();
+
+        var memory = buildMinimalMemory(observer);
+
+        var retriever = readField(memory, "retriever", MemoryRetriever.class);
+        assertThat(retriever).isInstanceOf(TracingMemoryRetriever.class);
+    }
+
+    @Test
+    void builderKeepsTopLevelDelegatesUnwrappedForNoopObserver() {
+        var memory = buildMinimalMemory(new NoopMemoryObserver());
+
+        var extractor = readField(memory, "extractor", MemoryExtractor.class);
+        var retriever = readField(memory, "retriever", MemoryRetriever.class);
+
+        assertThat(extractor).isNotInstanceOf(TracingMemoryExtractor.class);
+        assertThat(retriever).isNotInstanceOf(TracingMemoryRetriever.class);
     }
 
     @Test
@@ -365,13 +402,13 @@ class DefaultMemoryBuilderTest {
                                 .vector(MEMORY_VECTOR)
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var memoryItemLayer = readField(extractor, "memoryItemStep", MemoryItemLayer.class);
         var itemExtractor =
                 readField(memoryItemLayer, "extractor", DefaultMemoryItemExtractor.class);
         var itemStrategy =
                 readField(itemExtractor, "defaultStrategy", LlmItemExtractionStrategy.class);
-        var retriever = readField(memory, "retriever", DefaultMemoryRetriever.class);
+        var retriever = underlyingRetriever(memory);
         @SuppressWarnings("unchecked")
         var strategies = readField(retriever, "strategies", Map.class);
         var deepStrategy =
@@ -405,7 +442,7 @@ class DefaultMemoryBuilderTest {
                                 .resourceFetcher(fetcher)
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
 
         assertThat(readField(extractor, "contentParserRegistry", ContentParserRegistry.class))
                 .isSameAs(registry);
@@ -427,7 +464,7 @@ class DefaultMemoryBuilderTest {
                                 .bubbleTrackerStore(customBubbleTracker)
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var insightLayer = readField(extractor, "insightStep", InsightLayer.class);
         var scheduler = readField(insightLayer, "scheduler", InsightBuildScheduler.class);
         var reorganizer = readField(scheduler, "treeReorganizer", InsightTreeReorganizer.class);
@@ -453,12 +490,12 @@ class DefaultMemoryBuilderTest {
                                 .promptRegistry(promptRegistry)
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var contextCommitDetector =
                 readField(extractor, "contextCommitDetector", LlmContextCommitDetector.class);
         var extractionPromptRegistry =
                 readField(contextCommitDetector, "promptRegistry", PromptRegistry.class);
-        var retriever = readField(memory, "retriever", DefaultMemoryRetriever.class);
+        var retriever = underlyingRetriever(memory);
         @SuppressWarnings("unchecked")
         var strategies = readField(retriever, "strategies", Map.class);
         var deepStrategy =
@@ -487,7 +524,7 @@ class DefaultMemoryBuilderTest {
                                 .options(graphEnabledBuildOptions())
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var itemLayer = readField(extractor, "memoryItemStep", MemoryItemLayer.class);
 
         assertThat(readField(itemLayer, "graphMaterializer", ItemGraphMaterializer.class))
@@ -506,7 +543,7 @@ class DefaultMemoryBuilderTest {
                                 .options(graphEnabledBuildOptions())
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var itemLayer = readField(extractor, "memoryItemStep", MemoryItemLayer.class);
         var tracing = readField(itemLayer, "graphMaterializer", TracingItemGraphMaterializer.class);
         var delegate = readField(tracing, "delegate", DefaultItemGraphMaterializer.class);
@@ -532,7 +569,7 @@ class DefaultMemoryBuilderTest {
                                 .options(MemoryBuildOptions.defaults())
                                 .build();
 
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var itemLayer = readField(extractor, "memoryItemStep", MemoryItemLayer.class);
 
         assertThat(readField(itemLayer, "graphMaterializer", ItemGraphMaterializer.class))
@@ -897,6 +934,33 @@ class DefaultMemoryBuilderTest {
                             }
                             return null;
                         });
+    }
+
+    private DefaultMemory buildMinimalMemory(MemoryObserver observer) {
+        return (DefaultMemory)
+                Memory.builder()
+                        .chatClient(CHAT_CLIENT)
+                        .store(new InMemoryMemoryStore())
+                        .buffer(MEMORY_BUFFER)
+                        .vector(MEMORY_VECTOR)
+                        .memoryObserver(observer)
+                        .build();
+    }
+
+    private static DefaultMemoryExtractor underlyingExtractor(DefaultMemory memory) {
+        MemoryExtractor extractor = readField(memory, "extractor", MemoryExtractor.class);
+        if (extractor instanceof TracingMemoryExtractor tracing) {
+            return readField(tracing, "delegate", DefaultMemoryExtractor.class);
+        }
+        return DefaultMemoryExtractor.class.cast(extractor);
+    }
+
+    private static DefaultMemoryRetriever underlyingRetriever(DefaultMemory memory) {
+        MemoryRetriever retriever = readField(memory, "retriever", MemoryRetriever.class);
+        if (retriever instanceof TracingMemoryRetriever tracing) {
+            return readField(tracing, "delegate", DefaultMemoryRetriever.class);
+        }
+        return DefaultMemoryRetriever.class.cast(retriever);
     }
 
     @SuppressWarnings("unchecked")

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannelTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannelTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_CHANNEL;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_GRAPH_DEGRADED;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_GRAPH_ENABLED;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_GRAPH_SEED_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_GRAPH_TIMEOUT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_GRAPH_CHANNEL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.graph.GraphExpansionResult;
+import com.openmemind.ai.memory.core.retrieval.graph.GraphItemChannel;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.strategy.SimpleStrategyConfig;
+import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.ObservationContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TracingGraphItemChannelTest {
+
+    @Test
+    void retrievePublishesGraphChannelSpanAndPropagatesResult() {
+        var observer = new RecordingMemoryObserver();
+        GraphItemChannel delegate = mock(GraphItemChannel.class);
+        var context = queryContext();
+        var config = RetrievalConfig.simple();
+        var settings = SimpleStrategyConfig.GraphAssistConfig.defaults();
+        var seed = scoredResult("seed-1");
+        var graphResult = scoredResult("graph-1");
+        var result =
+                new GraphExpansionResult(
+                        List.of(graphResult), true, false, false, 1, 2, 3, 4, 5, 6);
+        when(delegate.retrieve(context, config, settings, List.of(seed)))
+                .thenReturn(Mono.just(result));
+
+        var traced = new TracingGraphItemChannel(delegate, observer);
+
+        StepVerifier.create(traced.retrieve(context, config, settings, List.of(seed)))
+                .expectNext(result)
+                .verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        var observation = observer.monoContexts().getFirst();
+        assertThat(observation.spanName()).isEqualTo(RETRIEVAL_GRAPH_CHANNEL);
+        assertThat(observation.requestAttributes())
+                .containsEntry(MEMORY_ID, "memory")
+                .containsEntry(RETRIEVAL_CHANNEL, "graph")
+                .containsEntry(RETRIEVAL_GRAPH_ENABLED, true)
+                .containsEntry(RETRIEVAL_GRAPH_SEED_COUNT, 1);
+        assertThat(resultAttributes(observation, result))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1)
+                .containsEntry(RETRIEVAL_GRAPH_TIMEOUT, false)
+                .containsEntry(RETRIEVAL_GRAPH_DEGRADED, false);
+    }
+
+    private QueryContext queryContext() {
+        return new QueryContext(
+                DefaultMemoryId.of("memory", null), "query", null, List.of(), Map.of(), null, null);
+    }
+
+    private ScoredResult scoredResult(String id) {
+        return new ScoredResult(ScoredResult.SourceType.ITEM, id, "text", 0.9f, 0.8d);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resultAttributes(
+            ObservationContext<?> context, GraphExpansionResult result) {
+        return ((ObservationContext<GraphExpansionResult>) context)
+                .resultExtractor()
+                .extract(result);
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetrieverTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetrieverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TIER_NAME;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_TIER_INSIGHT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
+import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
+import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.ObservationContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TracingInsightTierRetrieverTest {
+
+    @Test
+    void retrievePublishesInsightTierSpanAndPropagatesResult() {
+        var observer = new RecordingMemoryObserver();
+        InsightTierSearch delegate = mock(InsightTierSearch.class);
+        var context = queryContext();
+        var config = RetrievalConfig.simple();
+        var result = new TierResult(List.of(scoredResult()), List.of());
+        when(delegate.retrieve(context, config)).thenReturn(Mono.just(result));
+
+        var traced = new TracingInsightTierRetriever(delegate, observer);
+
+        StepVerifier.create(traced.retrieve(context, config)).expectNext(result).verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        assertThat(observer.monoContexts().getFirst().spanName()).isEqualTo(RETRIEVAL_TIER_INSIGHT);
+        assertThat(observer.monoContexts().getFirst().requestAttributes())
+                .containsEntry(MEMORY_ID, "memory")
+                .containsEntry(RETRIEVAL_TIER_NAME, "insight")
+                .containsEntry(RETRIEVAL_TOP_K, config.tier1().topK());
+        assertThat(resultAttributes(observer.monoContexts().getFirst(), result))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1);
+    }
+
+    private QueryContext queryContext() {
+        return new QueryContext(
+                DefaultMemoryId.of("memory", null), "query", null, List.of(), Map.of(), null, null);
+    }
+
+    private ScoredResult scoredResult() {
+        return new ScoredResult(ScoredResult.SourceType.INSIGHT, "insight-1", "text", 0.9f, 0.8d);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resultAttributes(ObservationContext<?> context, TierResult result) {
+        return ((ObservationContext<TierResult>) context).resultExtractor().extract(result);
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetrieverTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetrieverTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TIER_NAME;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_KEYWORD_SEARCH;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_VECTOR_SEARCH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
+import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
+import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.ObservationContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TracingItemTierRetrieverTest {
+
+    @Test
+    void searchByVectorPublishesVectorSpanAndPropagatesResults() {
+        var observer = new RecordingMemoryObserver();
+        ItemTierSearch delegate = mock(ItemTierSearch.class);
+        var context = queryContext();
+        var tier = RetrievalConfig.TierConfig.enabled(5);
+        var scoring = ScoringConfig.defaults();
+        var result = scoredResult();
+        when(delegate.searchByVector(context, tier, scoring))
+                .thenReturn(Mono.just(List.of(result)));
+
+        var traced = new TracingItemTierRetriever(delegate, observer);
+
+        StepVerifier.create(traced.searchByVector(context, tier, scoring))
+                .expectNext(List.of(result))
+                .verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        assertThat(observer.monoContexts().getFirst().spanName())
+                .isEqualTo(RETRIEVAL_VECTOR_SEARCH);
+        assertThat(observer.monoContexts().getFirst().requestAttributes())
+                .containsEntry(MEMORY_ID, "memory")
+                .containsEntry(RETRIEVAL_TIER_NAME, "item")
+                .containsEntry(RETRIEVAL_TOP_K, 5);
+        assertThat(resultAttributes(observer.monoContexts().getFirst(), List.of(result)))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1);
+    }
+
+    @Test
+    void searchByKeywordPublishesKeywordSpanAndPropagatesResults() {
+        var observer = new RecordingMemoryObserver();
+        ItemTierSearch delegate = mock(ItemTierSearch.class);
+        var context = queryContext();
+        var tier = RetrievalConfig.TierConfig.enabled(3);
+        var scoring = ScoringConfig.defaults();
+        var result = scoredResult();
+        when(delegate.searchByKeyword(context, tier, scoring))
+                .thenReturn(Mono.just(List.of(result)));
+
+        var traced = new TracingItemTierRetriever(delegate, observer);
+
+        StepVerifier.create(traced.searchByKeyword(context, tier, scoring))
+                .expectNext(List.of(result))
+                .verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        assertThat(observer.monoContexts().getFirst().spanName())
+                .isEqualTo(RETRIEVAL_KEYWORD_SEARCH);
+        assertThat(resultAttributes(observer.monoContexts().getFirst(), List.of(result)))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1);
+    }
+
+    private QueryContext queryContext() {
+        return new QueryContext(
+                DefaultMemoryId.of("memory", null), "query", null, List.of(), Map.of(), null, null);
+    }
+
+    private ScoredResult scoredResult() {
+        return new ScoredResult(ScoredResult.SourceType.ITEM, "item-1", "text", 0.9f, 0.8d);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resultAttributes(
+            ObservationContext<?> context, List<ScoredResult> result) {
+        return ((ObservationContext<List<ScoredResult>>) context).resultExtractor().extract(result);
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMergerTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMergerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_CANDIDATE_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_DEDUPED_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_SOURCE_LIST_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_WEIGHT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_RESULT_MERGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
+import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.ObservationContext;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TracingRetrievalResultMergerTest {
+
+    @Test
+    void mergePublishesResultMergeSpanAndPropagatesResult() {
+        var observer = new RecordingMemoryObserver();
+        var merged = List.of(scoredResult("item-1"));
+        RetrievalResultMerger delegate = (scoring, rankedLists, weights) -> Mono.just(merged);
+        var rankedLists = List.of(List.of(scoredResult("item-1")), List.of(scoredResult("item-1")));
+
+        var traced = new TracingRetrievalResultMerger(delegate, observer);
+
+        StepVerifier.create(traced.merge(ScoringConfig.defaults(), rankedLists, 1.0d, 0.8d))
+                .expectNext(merged)
+                .verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        var observation = observer.monoContexts().getFirst();
+        assertThat(observation.spanName()).isEqualTo(RETRIEVAL_RESULT_MERGE);
+        assertThat(observation.requestAttributes())
+                .containsEntry(RETRIEVAL_SOURCE_LIST_COUNT, 2)
+                .containsEntry(RETRIEVAL_CANDIDATE_COUNT, 2)
+                .containsEntry(RETRIEVAL_DEDUPED_COUNT, 1)
+                .containsEntry(RETRIEVAL_WEIGHT_COUNT, 2);
+        assertThat(resultAttributes(observation, merged))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1)
+                .containsEntry(RETRIEVAL_DEDUPED_COUNT, 1);
+    }
+
+    private ScoredResult scoredResult(String id) {
+        return new ScoredResult(ScoredResult.SourceType.ITEM, id, "text", 0.9f, 0.8d);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resultAttributes(
+            ObservationContext<?> context, List<ScoredResult> result) {
+        return ((ObservationContext<List<ScoredResult>>) context).resultExtractor().extract(result);
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannelTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannelTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.tracing.decorator;
+
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_CANDIDATE_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_CHANNEL;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TEMPORAL_CONSTRAINT_PRESENT;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TEMPORAL_DEGRADED;
+import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TEMPORAL_ENABLED;
+import static com.openmemind.ai.memory.core.tracing.MemorySpanNames.RETRIEVAL_TEMPORAL_CHANNEL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalConstraint;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannel;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelResult;
+import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelSettings;
+import com.openmemind.ai.memory.core.support.RecordingMemoryObserver;
+import com.openmemind.ai.memory.core.tracing.ObservationContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TracingTemporalItemChannelTest {
+
+    @Test
+    void retrievePublishesTemporalChannelSpanAndPropagatesResult() {
+        var observer = new RecordingMemoryObserver();
+        TemporalItemChannel delegate = mock(TemporalItemChannel.class);
+        var context = queryContext();
+        var config = RetrievalConfig.simple();
+        Optional<TemporalConstraint> constraint = Optional.empty();
+        var settings = TemporalItemChannelSettings.defaults();
+        var item = scoredResult();
+        var result = new TemporalItemChannelResult(List.of(item), true, false, false, 7);
+        when(delegate.retrieve(context, config, constraint, settings))
+                .thenReturn(Mono.just(result));
+
+        var traced = new TracingTemporalItemChannel(delegate, observer);
+
+        StepVerifier.create(traced.retrieve(context, config, constraint, settings))
+                .expectNext(result)
+                .verifyComplete();
+
+        assertThat(observer.monoContexts()).hasSize(1);
+        var observation = observer.monoContexts().getFirst();
+        assertThat(observation.spanName()).isEqualTo(RETRIEVAL_TEMPORAL_CHANNEL);
+        assertThat(observation.requestAttributes())
+                .containsEntry(MEMORY_ID, "memory")
+                .containsEntry(RETRIEVAL_CHANNEL, "temporal")
+                .containsEntry(RETRIEVAL_TEMPORAL_ENABLED, true)
+                .containsEntry(RETRIEVAL_TEMPORAL_CONSTRAINT_PRESENT, false);
+        assertThat(resultAttributes(observation, result))
+                .containsEntry(RETRIEVAL_RESULT_COUNT, 1)
+                .containsEntry(RETRIEVAL_CANDIDATE_COUNT, 7)
+                .containsEntry(RETRIEVAL_TEMPORAL_DEGRADED, false);
+    }
+
+    private QueryContext queryContext() {
+        return new QueryContext(
+                DefaultMemoryId.of("memory", null), "query", null, List.of(), Map.of(), null, null);
+    }
+
+    private ScoredResult scoredResult() {
+        return new ScoredResult(ScoredResult.SourceType.ITEM, "item-1", "text", 0.9f, 0.8d);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> resultAttributes(
+            ObservationContext<?> context, TemporalItemChannelResult result) {
+        return ((ObservationContext<TemporalItemChannelResult>) context)
+                .resultExtractor()
+                .extract(result);
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessor.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessor.java
@@ -17,14 +17,17 @@ import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.insight.generator.InsightGenerator;
 import com.openmemind.ai.memory.core.extraction.insight.group.InsightGroupClassifier;
 import com.openmemind.ai.memory.core.extraction.item.dedup.MemoryItemDeduplicator;
+import com.openmemind.ai.memory.core.extraction.item.graph.ItemGraphMaterializer;
 import com.openmemind.ai.memory.core.extraction.step.InsightExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.MemoryItemExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.RawDataExtractStep;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.MemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.deep.TypedQueryExpander;
+import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategy;
 import com.openmemind.ai.memory.core.retrieval.sufficiency.SufficiencyGate;
+import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTypeRouter;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.NoopMemoryObserver;
@@ -32,12 +35,15 @@ import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightExtractStep
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightGenerator;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightGroupClassifier;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightTypeRouter;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingItemGraphMaterializer;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryItemDeduplicator;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryItemExtractStep;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryRetriever;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryThreadAssistant;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingRawDataExtractStep;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingReranker;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalStrategy;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingSufficiencyGate;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingTypedQueryExpander;
@@ -100,9 +106,21 @@ public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
                 && !(bean instanceof TracingMemoryItemDeduplicator)) {
             return new TracingMemoryItemDeduplicator(d, observer);
         }
+        if (bean instanceof ItemGraphMaterializer d
+                && !(bean instanceof TracingItemGraphMaterializer)) {
+            return new TracingItemGraphMaterializer(d, observer);
+        }
 
         if (bean instanceof MemoryRetriever d && !(bean instanceof TracingMemoryRetriever)) {
             return new TracingMemoryRetriever(d, observer);
+        }
+        if (bean instanceof RetrievalGraphAssistant d
+                && !(bean instanceof TracingRetrievalGraphAssistant)) {
+            return new TracingRetrievalGraphAssistant(d, observer);
+        }
+        if (bean instanceof MemoryThreadAssistant d
+                && !(bean instanceof TracingMemoryThreadAssistant)) {
+            return new TracingMemoryThreadAssistant(d, observer);
         }
         if (bean instanceof RetrievalStrategy d && !(bean instanceof TracingRetrievalStrategy)) {
             return new TracingRetrievalStrategy(d, observer);
@@ -131,7 +149,10 @@ public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
                 || bean instanceof InsightGenerator
                 || bean instanceof InsightGroupClassifier
                 || bean instanceof MemoryItemDeduplicator
+                || bean instanceof ItemGraphMaterializer
                 || bean instanceof MemoryRetriever
+                || bean instanceof RetrievalGraphAssistant
+                || bean instanceof MemoryThreadAssistant
                 || bean instanceof RetrievalStrategy
                 || bean instanceof Reranker
                 || bean instanceof InsightTypeRouter
@@ -147,7 +168,10 @@ public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
                 || bean instanceof TracingInsightGenerator
                 || bean instanceof TracingInsightGroupClassifier
                 || bean instanceof TracingMemoryItemDeduplicator
+                || bean instanceof TracingItemGraphMaterializer
                 || bean instanceof TracingMemoryRetriever
+                || bean instanceof TracingRetrievalGraphAssistant
+                || bean instanceof TracingMemoryThreadAssistant
                 || bean instanceof TracingRetrievalStrategy
                 || bean instanceof TracingReranker
                 || bean instanceof TracingInsightTypeRouter

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/test/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessorTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/test/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessorTest.java
@@ -19,14 +19,17 @@ import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.insight.generator.InsightGenerator;
 import com.openmemind.ai.memory.core.extraction.insight.group.InsightGroupClassifier;
 import com.openmemind.ai.memory.core.extraction.item.dedup.MemoryItemDeduplicator;
+import com.openmemind.ai.memory.core.extraction.item.graph.ItemGraphMaterializer;
 import com.openmemind.ai.memory.core.extraction.step.InsightExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.MemoryItemExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.RawDataExtractStep;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
 import com.openmemind.ai.memory.core.retrieval.MemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.deep.TypedQueryExpander;
+import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategy;
 import com.openmemind.ai.memory.core.retrieval.sufficiency.SufficiencyGate;
+import com.openmemind.ai.memory.core.retrieval.thread.MemoryThreadAssistant;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTypeRouter;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.NoopMemoryObserver;
@@ -34,12 +37,15 @@ import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightExtractStep
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightGenerator;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightGroupClassifier;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingInsightTypeRouter;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingItemGraphMaterializer;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryItemDeduplicator;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryItemExtractStep;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryRetriever;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryThreadAssistant;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingRawDataExtractStep;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingReranker;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalGraphAssistant;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingRetrievalStrategy;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingSufficiencyGate;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingTypedQueryExpander;
@@ -144,11 +150,35 @@ class TracingBeanPostProcessorTest {
         }
 
         @Test
+        @DisplayName("wraps ItemGraphMaterializer")
+        void wrapsItemGraphMaterializer() {
+            var bean = proxy(ItemGraphMaterializer.class);
+            var result = processor.postProcessAfterInitialization(bean, "test");
+            assertThat(result).isInstanceOf(TracingItemGraphMaterializer.class);
+        }
+
+        @Test
         @DisplayName("wraps MemoryRetriever")
         void wrapsMemoryRetriever() {
             var bean = proxy(MemoryRetriever.class);
             var result = processor.postProcessAfterInitialization(bean, "test");
             assertThat(result).isInstanceOf(TracingMemoryRetriever.class);
+        }
+
+        @Test
+        @DisplayName("wraps RetrievalGraphAssistant")
+        void wrapsRetrievalGraphAssistant() {
+            var bean = proxy(RetrievalGraphAssistant.class);
+            var result = processor.postProcessAfterInitialization(bean, "test");
+            assertThat(result).isInstanceOf(TracingRetrievalGraphAssistant.class);
+        }
+
+        @Test
+        @DisplayName("wraps MemoryThreadAssistant")
+        void wrapsMemoryThreadAssistant() {
+            var bean = proxy(MemoryThreadAssistant.class);
+            var result = processor.postProcessAfterInitialization(bean, "test");
+            assertThat(result).isInstanceOf(TracingMemoryThreadAssistant.class);
         }
 
         @Test

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
@@ -31,6 +31,7 @@ import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
 import com.openmemind.ai.memory.core.builder.PromptBudgetOptions;
 import com.openmemind.ai.memory.core.builder.RawDataExtractionOptions;
 import com.openmemind.ai.memory.core.extraction.DefaultMemoryExtractor;
+import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.insight.InsightLayer;
 import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildScheduler;
 import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
@@ -59,6 +60,7 @@ import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.ObservationContext;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingItemGraphMaterializer;
+import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
 import com.openmemind.ai.memory.plugin.rawdata.audio.content.AudioContent;
 import com.openmemind.ai.memory.plugin.rawdata.audio.parser.TranscriptionAudioContentParser;
@@ -107,8 +109,7 @@ class MemindServerRuntimeConfigurationTest {
                         emptyProvider(MemoryObserver.class));
 
         Memory memory = factory.create(MemoryBuildOptions.defaults()).memory();
-        var extractor =
-                readField((DefaultMemory) memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor((DefaultMemory) memory);
         var insightLayer = readField(extractor, "insightStep", InsightLayer.class);
         var scheduler = readField(insightLayer, "scheduler", InsightBuildScheduler.class);
         var reorganizer = readField(scheduler, "treeReorganizer", InsightTreeReorganizer.class);
@@ -137,7 +138,7 @@ class MemindServerRuntimeConfigurationTest {
                         provider(MemoryObserver.class, observer));
 
         var memory = (DefaultMemory) factory.create(graphEnabledBuildOptions()).memory();
-        var extractor = readField(memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor(memory);
         var itemLayer = readField(extractor, "memoryItemStep", MemoryItemLayer.class);
 
         assertThat(readField(itemLayer, "graphMaterializer", ItemGraphMaterializer.class))
@@ -260,8 +261,7 @@ class MemindServerRuntimeConfigurationTest {
                         emptyProvider(MemoryObserver.class));
 
         Memory memory = factory.create(MemoryBuildOptions.defaults()).memory();
-        var extractor =
-                readField((DefaultMemory) memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor((DefaultMemory) memory);
         ContentParserRegistry registry =
                 readField(extractor, "contentParserRegistry", ContentParserRegistry.class);
 
@@ -325,8 +325,7 @@ class MemindServerRuntimeConfigurationTest {
                         emptyProvider(MemoryObserver.class));
 
         Memory memory = factory.create(MemoryBuildOptions.defaults()).memory();
-        var extractor =
-                readField((DefaultMemory) memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor((DefaultMemory) memory);
 
         RawContentProcessorRegistry registry =
                 readField(
@@ -367,8 +366,7 @@ class MemindServerRuntimeConfigurationTest {
                         emptyProvider(MemoryObserver.class));
 
         Memory memory = factory.create(MemoryBuildOptions.defaults()).memory();
-        var extractor =
-                readField((DefaultMemory) memory, "extractor", DefaultMemoryExtractor.class);
+        var extractor = underlyingExtractor((DefaultMemory) memory);
         ContentParserRegistry registry =
                 readField(extractor, "contentParserRegistry", ContentParserRegistry.class);
 
@@ -648,5 +646,13 @@ class MemindServerRuntimeConfigurationTest {
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
+    }
+
+    private static DefaultMemoryExtractor underlyingExtractor(DefaultMemory memory) {
+        MemoryExtractor extractor = readField(memory, "extractor", MemoryExtractor.class);
+        if (extractor instanceof TracingMemoryExtractor tracing) {
+            return readField(tracing, "delegate", DefaultMemoryExtractor.class);
+        }
+        return DefaultMemoryExtractor.class.cast(extractor);
     }
 }


### PR DESCRIPTION
## Summary
- Add default top-level tracing wrappers for memory extraction and retrieval in the builder path.
- Add retrieval middle-layer tracing for tier retrievers, temporal/graph channels, and result merging.
- Align Spring tracing post-processing coverage and add observability documentation and tests.

## Test Plan
- [x] mvn test