### PR TITLE
Add memory observability metrics and retrieval traces

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/DefaultMemoryBuilder.java
@@ -23,6 +23,8 @@ import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.NoopReranker;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.plugin.RawDataPlugin;
 import com.openmemind.ai.memory.core.prompt.PromptRegistry;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
@@ -63,6 +65,7 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
     private final List<RawDataPlugin> rawDataPlugins = new ArrayList<>();
     private MemoryBuildOptions options = MemoryBuildOptions.defaults();
     private MemoryObserver memoryObserver = new NoopMemoryObserver();
+    private MemoryMetricsRecorder memoryMetricsRecorder = NoopMemoryMetricsRecorder.INSTANCE;
     private boolean externallyManaged;
 
     @Override
@@ -158,6 +161,12 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
     }
 
     @Override
+    public MemoryBuilder memoryMetricsRecorder(MemoryMetricsRecorder recorder) {
+        this.memoryMetricsRecorder = Objects.requireNonNull(recorder, "recorder");
+        return this;
+    }
+
+    @Override
     public MemoryBuilder externallyManaged(boolean externallyManaged) {
         this.externallyManaged = externallyManaged;
         return this;
@@ -186,14 +195,20 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                         List.copyOf(rawDataPlugins),
                         bubbleTrackerStore,
                         memoryObserver,
+                        memoryMetricsRecorder,
                         sanitization.memoryThreadForcedDisableReason());
         MemoryExtractionAssembly extractionAssembly =
                 new MemoryExtractionAssembler().assemble(context);
         MemoryExtractor pipeline =
-                tracingExtractor(extractionAssembly.pipeline(), context.memoryObserver());
+                tracingExtractor(
+                        extractionAssembly.pipeline(),
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         MemoryRetriever memoryRetriever =
                 tracingRetriever(
-                        new MemoryRetrievalAssembler().assemble(context), context.memoryObserver());
+                        new MemoryRetrievalAssembler().assemble(context),
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         AutoCloseable lifecycle =
                 externallyManaged
                         ? lifecycle(extractionAssembly.lifecycle())
@@ -216,18 +231,25 @@ public final class DefaultMemoryBuilder implements MemoryBuilder {
                 extractionAssembly.memoryThreadLayer());
     }
 
-    private MemoryExtractor tracingExtractor(MemoryExtractor extractor, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver || extractor instanceof TracingMemoryExtractor) {
+    private MemoryExtractor tracingExtractor(
+            MemoryExtractor extractor, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder) || extractor instanceof TracingMemoryExtractor) {
             return extractor;
         }
-        return new TracingMemoryExtractor(extractor, observer);
+        return new TracingMemoryExtractor(extractor, observer, recorder);
     }
 
-    private MemoryRetriever tracingRetriever(MemoryRetriever retriever, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver || retriever instanceof TracingMemoryRetriever) {
+    private MemoryRetriever tracingRetriever(
+            MemoryRetriever retriever, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder) || retriever instanceof TracingMemoryRetriever) {
             return retriever;
         }
         return new TracingMemoryRetriever(retriever, observer);
+    }
+
+    private boolean hasObservability(MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        return !(observer instanceof NoopMemoryObserver)
+                || !(recorder instanceof NoopMemoryMetricsRecorder);
     }
 
     MemoryBuildOptions buildOptions() {

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryAssemblyContext.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryAssemblyContext.java
@@ -20,6 +20,8 @@ import com.openmemind.ai.memory.core.buffer.RecentConversationBuffer;
 import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
 import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.plugin.RawDataPlugin;
 import com.openmemind.ai.memory.core.prompt.PromptRegistry;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
@@ -47,6 +49,7 @@ record MemoryAssemblyContext(
         List<RawDataPlugin> rawDataPlugins,
         BubbleTrackerStore bubbleTrackerStore,
         MemoryObserver memoryObserver,
+        MemoryMetricsRecorder memoryMetricsRecorder,
         Optional<String> memoryThreadForcedDisableReason) {
 
     MemoryAssemblyContext {
@@ -68,10 +71,47 @@ record MemoryAssemblyContext(
         Objects.requireNonNull(options, "options");
         rawDataPlugins = List.copyOf(Objects.requireNonNull(rawDataPlugins, "rawDataPlugins"));
         memoryObserver = memoryObserver != null ? memoryObserver : new NoopMemoryObserver();
+        memoryMetricsRecorder =
+                memoryMetricsRecorder != null
+                        ? memoryMetricsRecorder
+                        : NoopMemoryMetricsRecorder.INSTANCE;
         memoryThreadForcedDisableReason =
                 memoryThreadForcedDisableReason != null
                         ? memoryThreadForcedDisableReason
                         : Optional.empty();
+    }
+
+    MemoryAssemblyContext(
+            ChatClientRegistry chatClientRegistry,
+            MemoryStore memoryStore,
+            MemoryBuffer memoryBuffer,
+            MemoryTextSearch textSearch,
+            MemoryVector memoryVector,
+            Reranker reranker,
+            PromptRegistry promptRegistry,
+            MemoryBuildOptions options,
+            ContentParserRegistry contentParserRegistry,
+            ResourceFetcher resourceFetcher,
+            List<RawDataPlugin> rawDataPlugins,
+            BubbleTrackerStore bubbleTrackerStore,
+            MemoryObserver memoryObserver,
+            Optional<String> memoryThreadForcedDisableReason) {
+        this(
+                chatClientRegistry,
+                memoryStore,
+                memoryBuffer,
+                textSearch,
+                memoryVector,
+                reranker,
+                promptRegistry,
+                options,
+                contentParserRegistry,
+                resourceFetcher,
+                rawDataPlugins,
+                bubbleTrackerStore,
+                memoryObserver,
+                NoopMemoryMetricsRecorder.INSTANCE,
+                memoryThreadForcedDisableReason);
     }
 
     InsightBuffer insightBuffer() {

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryBuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryBuilder.java
@@ -19,6 +19,7 @@ import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.plugin.RawDataPlugin;
 import com.openmemind.ai.memory.core.prompt.PromptRegistry;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
@@ -60,6 +61,10 @@ public interface MemoryBuilder {
     MemoryBuilder options(MemoryBuildOptions options);
 
     default MemoryBuilder memoryObserver(MemoryObserver observer) {
+        return this;
+    }
+
+    default MemoryBuilder memoryMetricsRecorder(MemoryMetricsRecorder recorder) {
         return this;
     }
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/builder/MemoryRetrievalAssembler.java
@@ -15,6 +15,8 @@ package com.openmemind.ai.memory.core.builder;
 
 import com.openmemind.ai.memory.core.llm.ChatClientRegistry;
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.retrieval.DefaultMemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.admission.DefaultRetrievalAdmissionPolicy;
 import com.openmemind.ai.memory.core.retrieval.cache.CaffeineRetrievalCache;
@@ -71,14 +73,16 @@ final class MemoryRetrievalAssembler {
                 tracingInsightTierRetriever(
                         new InsightTierRetriever(
                                 context.memoryStore(), context.memoryVector(), insightTypeRouter),
-                        context.memoryObserver());
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         ItemTierSearch itemTierRetriever =
                 tracingItemTierRetriever(
                         new ItemTierRetriever(
                                 context.memoryStore(),
                                 context.memoryVector(),
                                 context.textSearch()),
-                        context.memoryObserver());
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         SufficiencyGate sufficiencyGate =
                 new LlmSufficiencyGate(
                         registry.resolve(ChatClientSlot.SUFFICIENCY_GATE),
@@ -91,11 +95,14 @@ final class MemoryRetrievalAssembler {
         GraphItemChannel graphItemChannel =
                 tracingGraphItemChannel(
                         new DefaultGraphItemChannel(graphExpansionEngine),
-                        context.memoryObserver());
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         MemoryThreadAssistant memoryThreadAssistant = buildMemoryThreadAssistant(context);
         RetrievalResultMerger resultMerger =
                 tracingRetrievalResultMerger(
-                        DefaultRetrievalResultMerger.INSTANCE, context.memoryObserver());
+                        DefaultRetrievalResultMerger.INSTANCE,
+                        context.memoryObserver(),
+                        context.memoryMetricsRecorder());
         SimpleStrategyConfig simpleStrategyConfig = simpleStrategyConfig(context.options());
         DeepStrategyConfig deepStrategyConfig = deepStrategyConfig(context.options());
         DeepRetrievalStrategy deepRetrievalStrategy =
@@ -122,7 +129,8 @@ final class MemoryRetrievalAssembler {
                         new DefaultTemporalConstraintExtractor(),
                         tracingTemporalItemChannel(
                                 new DefaultTemporalItemChannel(context.memoryStore()),
-                                context.memoryObserver()),
+                                context.memoryObserver(),
+                                context.memoryMetricsRecorder()),
                         graphItemChannel,
                         resultMerger,
                         java.time.Clock.systemDefaultZone());
@@ -155,47 +163,52 @@ final class MemoryRetrievalAssembler {
     }
 
     private InsightTierSearch tracingInsightTierRetriever(
-            InsightTierSearch retriever, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver
+            InsightTierSearch retriever, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder)
                 || retriever instanceof TracingInsightTierRetriever) {
             return retriever;
         }
-        return new TracingInsightTierRetriever(retriever, observer);
+        return new TracingInsightTierRetriever(retriever, observer, recorder);
     }
 
     private ItemTierSearch tracingItemTierRetriever(
-            ItemTierSearch retriever, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver
+            ItemTierSearch retriever, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder)
                 || retriever instanceof TracingItemTierRetriever) {
             return retriever;
         }
-        return new TracingItemTierRetriever(retriever, observer);
+        return new TracingItemTierRetriever(retriever, observer, recorder);
     }
 
     private GraphItemChannel tracingGraphItemChannel(
-            GraphItemChannel channel, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver || channel instanceof TracingGraphItemChannel) {
+            GraphItemChannel channel, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder) || channel instanceof TracingGraphItemChannel) {
             return channel;
         }
-        return new TracingGraphItemChannel(channel, observer);
+        return new TracingGraphItemChannel(channel, observer, recorder);
     }
 
     private TemporalItemChannel tracingTemporalItemChannel(
-            TemporalItemChannel channel, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver
+            TemporalItemChannel channel, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder)
                 || channel instanceof TracingTemporalItemChannel) {
             return channel;
         }
-        return new TracingTemporalItemChannel(channel, observer);
+        return new TracingTemporalItemChannel(channel, observer, recorder);
     }
 
     private RetrievalResultMerger tracingRetrievalResultMerger(
-            RetrievalResultMerger merger, MemoryObserver observer) {
-        if (observer instanceof NoopMemoryObserver
+            RetrievalResultMerger merger, MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        if (!hasObservability(observer, recorder)
                 || merger instanceof TracingRetrievalResultMerger) {
             return merger;
         }
-        return new TracingRetrievalResultMerger(merger, observer);
+        return new TracingRetrievalResultMerger(merger, observer, recorder);
+    }
+
+    private boolean hasObservability(MemoryObserver observer, MemoryMetricsRecorder recorder) {
+        return !(observer instanceof NoopMemoryObserver)
+                || !(recorder instanceof NoopMemoryMetricsRecorder);
     }
 
     private MemoryThreadAssistant buildMemoryThreadAssistant(MemoryAssemblyContext context) {

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/ExtractionMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/ExtractionMetrics.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public record ExtractionMetrics(
+        String status,
+        int rawDataCount,
+        Integer segmentCount,
+        int newItemCount,
+        Integer reinforcedItemCount,
+        int insightCount,
+        Integer graphEntityCount,
+        Integer graphMentionCount,
+        Integer graphRelationCount,
+        String source) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/ExtractionMetricsExtractor.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/ExtractionMetricsExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+import com.openmemind.ai.memory.core.extraction.ExtractionResult;
+import com.openmemind.ai.memory.core.extraction.ExtractionStatus;
+import com.openmemind.ai.memory.core.extraction.item.graph.ItemGraphMaterializationResult;
+import com.openmemind.ai.memory.core.extraction.result.MemoryItemResult;
+
+public final class ExtractionMetricsExtractor {
+
+    private ExtractionMetricsExtractor() {}
+
+    public static ExtractionMetrics extract(ExtractionResult result, String source) {
+        if (result == null) {
+            return new ExtractionMetrics(
+                    "unknown", 0, null, 0, null, 0, null, null, null, sourceOrCore(source));
+        }
+        MemoryItemResult itemResult = result.memoryItemResult();
+        ItemGraphMaterializationResult graph =
+                itemResult == null ? null : itemResult.graphMaterializationResult();
+        ItemGraphMaterializationResult.Stats stats = graph == null ? null : graph.stats();
+        return new ExtractionMetrics(
+                status(result.status()),
+                result.rawDataResult() == null ? 0 : result.rawDataResult().rawDataList().size(),
+                result.rawDataResult() == null ? null : result.rawDataResult().segments().size(),
+                itemResult == null ? 0 : itemResult.newCount(),
+                null,
+                result.totalInsights(),
+                stats == null ? null : stats.entityCount(),
+                stats == null ? null : stats.mentionCount(),
+                finalRelationCount(stats),
+                sourceOrCore(source));
+    }
+
+    private static Integer finalRelationCount(ItemGraphMaterializationResult.Stats stats) {
+        if (stats == null || stats.finalRelationStats() == null) {
+            return null;
+        }
+        var finalStats = stats.finalRelationStats();
+        return finalStats.semanticRelationCount()
+                + finalStats.temporalRelationCount()
+                + finalStats.causalRelationCount()
+                + finalStats.itemLinkCount();
+    }
+
+    private static String status(ExtractionStatus status) {
+        return status == null ? "unknown" : status.name().toLowerCase();
+    }
+
+    private static String sourceOrCore(String source) {
+        return source == null || source.isBlank() ? "core" : source;
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/MemoryMetricsRecorder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/MemoryMetricsRecorder.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public interface MemoryMetricsRecorder {
+
+    void recordExtractionSummary(ExtractionMetrics metrics);
+
+    void recordRetrievalStage(RetrievalStageMetrics metrics);
+
+    void recordRetrievalMerge(RetrievalMergeMetrics metrics);
+
+    void recordRetrievalSummary(RetrievalSummaryMetrics metrics);
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/NoopMemoryMetricsRecorder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/NoopMemoryMetricsRecorder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public enum NoopMemoryMetricsRecorder implements MemoryMetricsRecorder {
+    INSTANCE;
+
+    @Override
+    public void recordExtractionSummary(ExtractionMetrics metrics) {}
+
+    @Override
+    public void recordRetrievalStage(RetrievalStageMetrics metrics) {}
+
+    @Override
+    public void recordRetrievalMerge(RetrievalMergeMetrics metrics) {}
+
+    @Override
+    public void recordRetrievalSummary(RetrievalSummaryMetrics metrics) {}
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalMergeMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalMergeMetrics.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public record RetrievalMergeMetrics(
+        String strategy,
+        int inputCount,
+        int outputCount,
+        int deduplicatedCount,
+        int sourceCount,
+        String status,
+        String source) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalMetricsSupport.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalMetricsSupport.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalResult;
+
+public final class RetrievalMetricsSupport {
+
+    private RetrievalMetricsSupport() {}
+
+    public static RetrievalSummaryMetrics summary(
+            String strategy, RetrievalResult result, String source) {
+        String status = result == null || result.isEmpty() ? "empty" : "success";
+        return new RetrievalSummaryMetrics(
+                strategyOrUnknown(strategy),
+                status,
+                result == null || result.items() == null ? 0 : result.items().size(),
+                result == null || result.insights() == null ? 0 : result.insights().size(),
+                result == null || result.rawData() == null ? 0 : result.rawData().size(),
+                result == null || result.evidences() == null ? 0 : result.evidences().size(),
+                sourceOrCore(source));
+    }
+
+    public static int deduplicatedCount(int inputCount, int outputCount) {
+        return Math.max(0, inputCount - outputCount);
+    }
+
+    public static void safeRecord(Runnable recorder) {
+        try {
+            recorder.run();
+        } catch (RuntimeException ignored) {
+            // Metrics collection must never affect memory operations.
+        }
+    }
+
+    public static String strategyOrUnknown(String strategy) {
+        return strategy == null || strategy.isBlank() ? "unknown" : strategy;
+    }
+
+    public static String sourceOrCore(String source) {
+        return source == null || source.isBlank() ? "core" : source;
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalResultType.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalResultType.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public enum RetrievalResultType {
+    ITEM,
+    INSIGHT,
+    RAW_DATA,
+    EVIDENCE
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalStageMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalStageMetrics.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public record RetrievalStageMetrics(
+        String strategy,
+        String stage,
+        String tier,
+        String method,
+        String status,
+        Integer inputCount,
+        Integer candidateCount,
+        Integer resultCount,
+        boolean degraded,
+        boolean skipped,
+        String source) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalSummaryMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/metrics/RetrievalSummaryMetrics.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+public record RetrievalSummaryMetrics(
+        String strategy,
+        String status,
+        int itemCount,
+        int insightCount,
+        int rawDataCount,
+        int evidenceCount,
+        String source) {
+
+    public int countFor(RetrievalResultType type) {
+        return switch (type) {
+            case ITEM -> itemCount;
+            case INSIGHT -> insightCount;
+            case RAW_DATA -> rawDataCount;
+            case EVIDENCE -> evidenceCount;
+        };
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/BoundedRetrievalTraceCollector.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/BoundedRetrievalTraceCollector.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class BoundedRetrievalTraceCollector implements RetrievalTraceCollector {
+
+    private final String traceId;
+    private final Instant startedAt;
+    private final RetrievalTraceOptions options;
+    private final Queue<RetrievalStageTrace> stages = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean truncated = new AtomicBoolean();
+    private final AtomicReference<RetrievalMergeTrace> merge = new AtomicReference<>();
+    private final AtomicReference<RetrievalFinalTrace> finalResults = new AtomicReference<>();
+
+    public BoundedRetrievalTraceCollector(RetrievalTraceOptions options) {
+        this(UUID.randomUUID().toString(), Instant.now(), options);
+    }
+
+    public BoundedRetrievalTraceCollector(
+            String traceId, Instant startedAt, RetrievalTraceOptions options) {
+        this.traceId = Objects.requireNonNull(traceId, "traceId");
+        this.startedAt = Objects.requireNonNull(startedAt, "startedAt");
+        this.options = options == null ? RetrievalTraceOptions.defaults() : options;
+    }
+
+    @Override
+    public void stageCompleted(RetrievalStageTrace event) {
+        if (event == null) {
+            return;
+        }
+        if (stages.size() >= options.maxStages()) {
+            truncated.set(true);
+            return;
+        }
+        stages.add(event);
+    }
+
+    @Override
+    public void mergeCompleted(RetrievalMergeTrace event) {
+        if (event != null) {
+            merge.set(event);
+        }
+    }
+
+    @Override
+    public void finalResults(RetrievalFinalTrace event) {
+        if (event != null) {
+            finalResults.set(event);
+        }
+    }
+
+    @Override
+    public Optional<RetrievalDebugTrace> snapshot() {
+        List<RetrievalStageTrace> orderedStages =
+                stages.stream()
+                        .sorted(Comparator.comparing(RetrievalStageTrace::startedAt))
+                        .toList();
+        return Optional.of(
+                new RetrievalDebugTrace(
+                        traceId,
+                        startedAt,
+                        Instant.now(),
+                        truncated.get(),
+                        orderedStages,
+                        merge.get(),
+                        finalResults.get()));
+    }
+
+    public RetrievalTraceOptions options() {
+        return options;
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/NoopRetrievalTraceCollector.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/NoopRetrievalTraceCollector.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import java.util.Optional;
+
+public enum NoopRetrievalTraceCollector implements RetrievalTraceCollector {
+    INSTANCE;
+
+    @Override
+    public void stageCompleted(RetrievalStageTrace event) {}
+
+    @Override
+    public void mergeCompleted(RetrievalMergeTrace event) {}
+
+    @Override
+    public void finalResults(RetrievalFinalTrace event) {}
+
+    @Override
+    public Optional<RetrievalDebugTrace> snapshot() {
+        return Optional.empty();
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalCandidateTrace.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalCandidateTrace.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+public record RetrievalCandidateTrace(
+        String sourceType, int rank, Double finalScore, Float vectorScore, String textPreview) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalDebugTrace.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalDebugTrace.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RetrievalDebugTrace(
+        String traceId,
+        Instant startedAt,
+        Instant completedAt,
+        boolean truncated,
+        List<RetrievalStageTrace> stages,
+        RetrievalMergeTrace merge,
+        RetrievalFinalTrace finalResults) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalFinalTrace.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalFinalTrace.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+public record RetrievalFinalTrace(
+        String strategy,
+        String status,
+        int itemCount,
+        int insightCount,
+        int rawDataCount,
+        int evidenceCount) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalMergeTrace.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalMergeTrace.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+public record RetrievalMergeTrace(
+        int inputCount, int outputCount, int deduplicatedCount, int sourceCount, String status) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalStageTrace.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalStageTrace.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record RetrievalStageTrace(
+        String stage,
+        String tier,
+        String method,
+        String status,
+        Integer inputCount,
+        Integer candidateCount,
+        Integer resultCount,
+        boolean degraded,
+        boolean skipped,
+        Instant startedAt,
+        Long durationMillis,
+        Map<String, Object> attributes,
+        List<RetrievalCandidateTrace> candidates) {}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceCollector.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceCollector.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import java.util.Optional;
+
+public interface RetrievalTraceCollector {
+
+    void stageCompleted(RetrievalStageTrace event);
+
+    void mergeCompleted(RetrievalMergeTrace event);
+
+    void finalResults(RetrievalFinalTrace event);
+
+    Optional<RetrievalDebugTrace> snapshot();
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceContext.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceContext.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+public final class RetrievalTraceContext {
+
+    private static final Class<RetrievalTraceCollector> KEY = RetrievalTraceCollector.class;
+
+    private RetrievalTraceContext() {}
+
+    public static Context withCollector(Context context, RetrievalTraceCollector collector) {
+        if (collector == null || collector instanceof NoopRetrievalTraceCollector) {
+            return context;
+        }
+        return context.put(KEY, collector);
+    }
+
+    public static RetrievalTraceCollector collector(ContextView context) {
+        if (context == null || !context.hasKey(KEY)) {
+            return NoopRetrievalTraceCollector.INSTANCE;
+        }
+        return context.get(KEY);
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceOptions.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceOptions.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+public record RetrievalTraceOptions(int maxStages, int maxCandidatesPerStage, int maxTextLength) {
+
+    public static RetrievalTraceOptions defaults() {
+        return new RetrievalTraceOptions(32, 8, 160);
+    }
+
+    public RetrievalTraceOptions {
+        maxStages = Math.max(1, maxStages);
+        maxCandidatesPerStage = Math.max(0, maxCandidatesPerStage);
+        maxTextLength = Math.max(0, maxTextLength);
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceSupport.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/retrieval/trace/RetrievalTraceSupport.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.retrieval.trace;
+
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+public final class RetrievalTraceSupport {
+
+    private RetrievalTraceSupport() {}
+
+    public static <T> Mono<T> traceStage(
+            Mono<T> operation,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            StageResultMapper<T> mapper) {
+        return Mono.deferContextual(
+                context -> {
+                    RetrievalTraceCollector collector = RetrievalTraceContext.collector(context);
+                    if (collector instanceof NoopRetrievalTraceCollector) {
+                        return operation;
+                    }
+                    RetrievalTraceOptions options =
+                            collector instanceof BoundedRetrievalTraceCollector bounded
+                                    ? bounded.options()
+                                    : RetrievalTraceOptions.defaults();
+                    Instant startedAt = Instant.now();
+                    return operation
+                            .doOnNext(
+                                    result ->
+                                            collector.stageCompleted(
+                                                    mapper.toStageTrace(
+                                                            result,
+                                                            stage,
+                                                            tier,
+                                                            method,
+                                                            inputCount,
+                                                            startedAt,
+                                                            elapsedMillis(startedAt),
+                                                            options)))
+                            .doOnError(
+                                    ignored ->
+                                            collector.stageCompleted(
+                                                    new RetrievalStageTrace(
+                                                            stage,
+                                                            tier,
+                                                            method,
+                                                            "error",
+                                                            inputCount,
+                                                            null,
+                                                            0,
+                                                            false,
+                                                            false,
+                                                            startedAt,
+                                                            elapsedMillis(startedAt),
+                                                            Map.of(),
+                                                            List.of())));
+                });
+    }
+
+    public static List<RetrievalCandidateTrace> candidates(
+            List<ScoredResult> results, int maxCandidates, int maxTextLength) {
+        if (results == null || maxCandidates <= 0) {
+            return List.of();
+        }
+        return java.util.stream.IntStream.range(0, Math.min(maxCandidates, results.size()))
+                .mapToObj(index -> candidate(results.get(index), index + 1, maxTextLength))
+                .toList();
+    }
+
+    private static RetrievalCandidateTrace candidate(
+            ScoredResult result, int rank, int maxTextLength) {
+        return new RetrievalCandidateTrace(
+                result.sourceType() == null ? "unknown" : result.sourceType().name().toLowerCase(),
+                rank,
+                result.finalScore(),
+                result.vectorScore(),
+                preview(result.text(), maxTextLength));
+    }
+
+    public static long elapsedMillis(Instant startedAt) {
+        return Duration.between(startedAt, Instant.now()).toMillis();
+    }
+
+    public static String preview(String text, int maxTextLength) {
+        if (text == null || maxTextLength <= 0) {
+            return null;
+        }
+        String compact = text.replaceAll("\\s+", " ").trim();
+        if (compact.length() <= maxTextLength) {
+            return compact;
+        }
+        return compact.substring(0, maxTextLength);
+    }
+
+    @FunctionalInterface
+    public interface StageResultMapper<T> {
+        RetrievalStageTrace toStageTrace(
+                T result,
+                String stage,
+                String tier,
+                String method,
+                Integer inputCount,
+                Instant startedAt,
+                long durationMillis,
+                RetrievalTraceOptions options);
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannel.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingGraphItemChannel.java
@@ -13,12 +13,19 @@
  */
 package com.openmemind.ai.memory.core.tracing.decorator;
 
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.graph.GraphExpansionResult;
 import com.openmemind.ai.memory.core.retrieval.graph.GraphItemChannel;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphSettings;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalStageTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceOptions;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceSupport;
 import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
@@ -32,10 +39,20 @@ import reactor.core.publisher.Mono;
 public final class TracingGraphItemChannel extends TracingSupport implements GraphItemChannel {
 
     private final GraphItemChannel delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingGraphItemChannel(GraphItemChannel delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingGraphItemChannel(
+            GraphItemChannel delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(Objects.requireNonNull(observer, "observer"));
         this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -73,6 +90,94 @@ public final class TracingGraphItemChannel extends TracingSupport implements Gra
                                 result.timedOut(),
                                 MemoryAttributes.RETRIEVAL_GRAPH_DEGRADED,
                                 result.degraded()),
-                () -> delegate.retrieve(context, config, settings, seeds));
+                () ->
+                        RetrievalTraceSupport.traceStage(
+                                        delegate.retrieve(context, config, settings, seeds),
+                                        "channel",
+                                        "item",
+                                        "graph",
+                                        seeds == null ? 0 : seeds.size(),
+                                        this::graphStageTrace)
+                                .doOnNext(
+                                        result ->
+                                                recordStage(
+                                                        seeds,
+                                                        result == null
+                                                                ? 0
+                                                                : result.dedupedCandidateCount(),
+                                                        result == null
+                                                                        || result.graphItems()
+                                                                                == null
+                                                                ? 0
+                                                                : result.graphItems().size(),
+                                                        result != null && result.degraded(),
+                                                        result == null || !result.enabled(),
+                                                        result != null && result.degraded()
+                                                                ? "degraded"
+                                                                : "success"))
+                                .doOnError(
+                                        ignored ->
+                                                recordStage(seeds, 0, 0, false, false, "error")));
+    }
+
+    private void recordStage(
+            List<ScoredResult> seeds,
+            int candidateCount,
+            int resultCount,
+            boolean degraded,
+            boolean skipped,
+            String status) {
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        metricsRecorder.recordRetrievalStage(
+                                new RetrievalStageMetrics(
+                                        null,
+                                        "channel",
+                                        "item",
+                                        "graph",
+                                        status,
+                                        seeds == null ? 0 : seeds.size(),
+                                        candidateCount,
+                                        resultCount,
+                                        degraded,
+                                        skipped,
+                                        "core")));
+    }
+
+    private RetrievalStageTrace graphStageTrace(
+            GraphExpansionResult result,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            java.time.Instant startedAt,
+            long durationMillis,
+            RetrievalTraceOptions options) {
+        List<ScoredResult> results = result == null ? List.of() : result.graphItems();
+        return new RetrievalStageTrace(
+                stage,
+                tier,
+                method,
+                result != null && result.degraded() ? "degraded" : "success",
+                inputCount,
+                result == null ? 0 : result.dedupedCandidateCount(),
+                results == null ? 0 : results.size(),
+                result != null && result.degraded(),
+                result == null || !result.enabled(),
+                startedAt,
+                durationMillis,
+                result == null
+                        ? Map.of()
+                        : Map.of(
+                                "linkExpansionCount",
+                                result.linkExpansionCount(),
+                                "entityExpansionCount",
+                                result.entityExpansionCount(),
+                                "overlapCount",
+                                result.overlapCount(),
+                                "timedOut",
+                                result.timedOut()),
+                RetrievalTraceSupport.candidates(
+                        results, options.maxCandidatesPerStage(), options.maxTextLength()));
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingInsightTierRetriever.java
@@ -19,13 +19,22 @@ import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_T
 import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
 
 import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.tier.InsightTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalStageTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceOptions;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceSupport;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
 import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
 
@@ -33,10 +42,20 @@ import reactor.core.publisher.Mono;
 public class TracingInsightTierRetriever extends TracingSupport implements InsightTierSearch {
 
     private final InsightTierSearch delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingInsightTierRetriever(InsightTierSearch delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingInsightTierRetriever(
+            InsightTierSearch delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(observer);
         this.delegate = delegate;
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -51,11 +70,71 @@ public class TracingInsightTierRetriever extends TracingSupport implements Insig
                         RETRIEVAL_TOP_K,
                         config.tier1().topK()),
                 result -> Map.of(RETRIEVAL_RESULT_COUNT, result.results().size()),
-                () -> delegate.retrieve(context, config));
+                () ->
+                        RetrievalTraceSupport.traceStage(
+                                        delegate.retrieve(context, config),
+                                        "tier",
+                                        "insight",
+                                        "vector",
+                                        null,
+                                        this::tierStageTrace)
+                                .doOnNext(
+                                        result ->
+                                                recordStage(
+                                                        result == null || result.results() == null
+                                                                ? 0
+                                                                : result.results().size(),
+                                                        "success"))
+                                .doOnError(ignored -> recordStage(0, "error")));
     }
 
     @Override
     public void invalidateCache(MemoryId memoryId) {
         delegate.invalidateCache(memoryId);
+    }
+
+    private void recordStage(int resultCount, String status) {
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        metricsRecorder.recordRetrievalStage(
+                                new RetrievalStageMetrics(
+                                        null,
+                                        "tier",
+                                        "insight",
+                                        "vector",
+                                        status,
+                                        null,
+                                        null,
+                                        resultCount,
+                                        false,
+                                        false,
+                                        "core")));
+    }
+
+    private RetrievalStageTrace tierStageTrace(
+            TierResult result,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            java.time.Instant startedAt,
+            long durationMillis,
+            RetrievalTraceOptions options) {
+        List<ScoredResult> results = result == null ? List.of() : result.results();
+        return new RetrievalStageTrace(
+                stage,
+                tier,
+                method,
+                "success",
+                inputCount,
+                null,
+                results == null ? 0 : results.size(),
+                false,
+                false,
+                startedAt,
+                durationMillis,
+                Map.of(),
+                RetrievalTraceSupport.candidates(
+                        results, options.maxCandidatesPerStage(), options.maxTextLength()));
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetriever.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingItemTierRetriever.java
@@ -18,12 +18,19 @@ import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_R
 import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TIER_NAME;
 import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_TOP_K;
 
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
 import com.openmemind.ai.memory.core.retrieval.tier.ItemTierSearch;
 import com.openmemind.ai.memory.core.retrieval.tier.TierResult;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalStageTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceOptions;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceSupport;
 import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
@@ -36,10 +43,20 @@ import reactor.core.publisher.Mono;
 public class TracingItemTierRetriever extends TracingSupport implements ItemTierSearch {
 
     private final ItemTierSearch delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingItemTierRetriever(ItemTierSearch delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingItemTierRetriever(
+            ItemTierSearch delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(observer);
         this.delegate = delegate;
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -54,7 +71,29 @@ public class TracingItemTierRetriever extends TracingSupport implements ItemTier
                         RETRIEVAL_TOP_K,
                         config.tier2().topK()),
                 result -> Map.of(RETRIEVAL_RESULT_COUNT, result.results().size()),
-                () -> delegate.searchByVector(context, config));
+                () ->
+                        RetrievalTraceSupport.traceStage(
+                                        delegate.searchByVector(context, config),
+                                        "tier",
+                                        "item",
+                                        "vector",
+                                        null,
+                                        this::tierStageTrace)
+                                .doOnNext(
+                                        result ->
+                                                recordStage(
+                                                        "tier",
+                                                        "vector",
+                                                        null,
+                                                        result.results().size(),
+                                                        false,
+                                                        false,
+                                                        "success"))
+                                .doOnError(
+                                        ignored ->
+                                                recordStage(
+                                                        "tier", "vector", null, 0, false, false,
+                                                        "error")));
     }
 
     @Override
@@ -75,7 +114,11 @@ public class TracingItemTierRetriever extends TracingSupport implements ItemTier
                         RETRIEVAL_TOP_K,
                         tier.topK()),
                 result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
-                () -> delegate.searchByVector(context, tier, scoring));
+                () ->
+                        recordListStage(
+                                delegate.searchByVector(context, tier, scoring),
+                                context,
+                                "vector"));
     }
 
     @Override
@@ -91,7 +134,11 @@ public class TracingItemTierRetriever extends TracingSupport implements ItemTier
                         RETRIEVAL_TOP_K,
                         tier.topK()),
                 result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
-                () -> delegate.searchByKeyword(context, tier, scoring));
+                () ->
+                        recordListStage(
+                                delegate.searchByKeyword(context, tier, scoring),
+                                context,
+                                "keyword"));
     }
 
     @Override
@@ -107,6 +154,103 @@ public class TracingItemTierRetriever extends TracingSupport implements ItemTier
                         RETRIEVAL_TOP_K,
                         tier.topK()),
                 result -> Map.of(RETRIEVAL_RESULT_COUNT, result.size()),
-                () -> delegate.searchHybrid(context, tier, scoring));
+                () ->
+                        recordListStage(
+                                delegate.searchHybrid(context, tier, scoring), context, "hybrid"));
+    }
+
+    private Mono<List<ScoredResult>> recordListStage(
+            Mono<List<ScoredResult>> operation, QueryContext context, String method) {
+        return RetrievalTraceSupport.traceStage(
+                        operation, "tier", "item", method, null, this::listStageTrace)
+                .doOnNext(
+                        result ->
+                                recordStage(
+                                        "tier",
+                                        method,
+                                        null,
+                                        result == null ? 0 : result.size(),
+                                        false,
+                                        false,
+                                        "success"))
+                .doOnError(ignored -> recordStage("tier", method, null, 0, false, false, "error"));
+    }
+
+    private void recordStage(
+            String stage,
+            String method,
+            Integer candidateCount,
+            Integer resultCount,
+            boolean degraded,
+            boolean skipped,
+            String status) {
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        metricsRecorder.recordRetrievalStage(
+                                new RetrievalStageMetrics(
+                                        null,
+                                        stage,
+                                        "item",
+                                        method,
+                                        status,
+                                        null,
+                                        candidateCount,
+                                        resultCount,
+                                        degraded,
+                                        skipped,
+                                        "core")));
+    }
+
+    private RetrievalStageTrace tierStageTrace(
+            TierResult result,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            java.time.Instant startedAt,
+            long durationMillis,
+            RetrievalTraceOptions options) {
+        List<ScoredResult> results = result == null ? List.of() : result.results();
+        return new RetrievalStageTrace(
+                stage,
+                tier,
+                method,
+                "success",
+                inputCount,
+                null,
+                results == null ? 0 : results.size(),
+                false,
+                false,
+                startedAt,
+                durationMillis,
+                Map.of(),
+                RetrievalTraceSupport.candidates(
+                        results, options.maxCandidatesPerStage(), options.maxTextLength()));
+    }
+
+    private RetrievalStageTrace listStageTrace(
+            List<ScoredResult> result,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            java.time.Instant startedAt,
+            long durationMillis,
+            RetrievalTraceOptions options) {
+        return new RetrievalStageTrace(
+                stage,
+                tier,
+                method,
+                "success",
+                inputCount,
+                null,
+                result == null ? 0 : result.size(),
+                false,
+                false,
+                startedAt,
+                durationMillis,
+                Map.of(),
+                RetrievalTraceSupport.candidates(
+                        result, options.maxCandidatesPerStage(), options.maxTextLength()));
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingMemoryExtractor.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingMemoryExtractor.java
@@ -19,6 +19,11 @@ import com.openmemind.ai.memory.core.extraction.ExtractionRequest;
 import com.openmemind.ai.memory.core.extraction.ExtractionResult;
 import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
+import com.openmemind.ai.memory.core.metrics.ExtractionMetrics;
+import com.openmemind.ai.memory.core.metrics.ExtractionMetricsExtractor;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
 import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
@@ -34,10 +39,20 @@ import reactor.core.publisher.Mono;
 public class TracingMemoryExtractor extends TracingSupport implements MemoryExtractor {
 
     private final MemoryExtractor delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingMemoryExtractor(MemoryExtractor delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingMemoryExtractor(
+            MemoryExtractor delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(observer);
         this.delegate = delegate;
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -45,7 +60,7 @@ public class TracingMemoryExtractor extends TracingSupport implements MemoryExtr
         return trace(
                 MemorySpanNames.EXTRACTION,
                 Map.of(MemoryAttributes.MEMORY_ID, request.memoryId().toIdentifier()),
-                () -> delegate.extract(request));
+                () -> recordExtraction(delegate.extract(request)));
     }
 
     @Override
@@ -54,6 +69,25 @@ public class TracingMemoryExtractor extends TracingSupport implements MemoryExtr
         return trace(
                 MemorySpanNames.EXTRACTION,
                 Map.of(MemoryAttributes.MEMORY_ID, memoryId.toIdentifier()),
-                () -> delegate.addMessage(memoryId, message, config));
+                () -> recordExtraction(delegate.addMessage(memoryId, message, config)));
+    }
+
+    private Mono<ExtractionResult> recordExtraction(Mono<ExtractionResult> operation) {
+        return operation
+                .doOnNext(
+                        result ->
+                                RetrievalMetricsSupport.safeRecord(
+                                        () ->
+                                                metricsRecorder.recordExtractionSummary(
+                                                        ExtractionMetricsExtractor.extract(
+                                                                result, "core"))))
+                .doOnError(
+                        ignored ->
+                                RetrievalMetricsSupport.safeRecord(
+                                        () ->
+                                                metricsRecorder.recordExtractionSummary(
+                                                        new ExtractionMetrics(
+                                                                "error", 0, null, 0, null, 0, null,
+                                                                null, null, "core"))));
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMerger.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalResultMerger.java
@@ -13,9 +13,16 @@
  */
 package com.openmemind.ai.memory.core.tracing.decorator;
 
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMergeMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
 import com.openmemind.ai.memory.core.retrieval.scoring.RetrievalResultMerger;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoringConfig;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalMergeTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceCollector;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceContext;
 import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
@@ -30,10 +37,20 @@ public final class TracingRetrievalResultMerger extends TracingSupport
         implements RetrievalResultMerger {
 
     private final RetrievalResultMerger delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingRetrievalResultMerger(RetrievalResultMerger delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingRetrievalResultMerger(
+            RetrievalResultMerger delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(Objects.requireNonNull(observer, "observer"));
         this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -43,7 +60,58 @@ public final class TracingRetrievalResultMerger extends TracingSupport
                 MemorySpanNames.RETRIEVAL_RESULT_MERGE,
                 requestAttributes(rankedLists, weights),
                 result -> resultAttributes(rankedLists, result),
-                () -> delegate.merge(scoring, rankedLists, weights));
+                () ->
+                        Mono.deferContextual(
+                                context -> {
+                                    RetrievalTraceCollector collector =
+                                            RetrievalTraceContext.collector(context);
+                                    return delegate.merge(scoring, rankedLists, weights)
+                                            .doOnNext(
+                                                    result ->
+                                                            recordMerge(
+                                                                    collector,
+                                                                    rankedLists,
+                                                                    result,
+                                                                    "success"))
+                                            .doOnError(
+                                                    ignored ->
+                                                            recordMerge(
+                                                                    collector,
+                                                                    rankedLists,
+                                                                    null,
+                                                                    "error"));
+                                }));
+    }
+
+    private void recordMerge(
+            RetrievalTraceCollector collector,
+            List<List<ScoredResult>> rankedLists,
+            List<ScoredResult> result,
+            String status) {
+        int inputCount = candidateCount(rankedLists);
+        int outputCount = result == null ? 0 : result.size();
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        metricsRecorder.recordRetrievalMerge(
+                                new RetrievalMergeMetrics(
+                                        null,
+                                        inputCount,
+                                        outputCount,
+                                        RetrievalMetricsSupport.deduplicatedCount(
+                                                inputCount, outputCount),
+                                        rankedLists == null ? 0 : rankedLists.size(),
+                                        status,
+                                        "core")));
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        collector.mergeCompleted(
+                                new RetrievalMergeTrace(
+                                        inputCount,
+                                        outputCount,
+                                        RetrievalMetricsSupport.deduplicatedCount(
+                                                inputCount, outputCount),
+                                        rankedLists == null ? 0 : rankedLists.size(),
+                                        status)));
     }
 
     private Map<String, Object> requestAttributes(

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalStrategy.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingRetrievalStrategy.java
@@ -17,10 +17,17 @@ import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.MEMORY_ID;
 import static com.openmemind.ai.memory.core.tracing.MemoryAttributes.RETRIEVAL_RESULT_COUNT;
 
 import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
+import com.openmemind.ai.memory.core.metrics.RetrievalSummaryMetrics;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.RetrievalResult;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
 import com.openmemind.ai.memory.core.retrieval.strategy.RetrievalStrategy;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalFinalTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceCollector;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceContext;
 import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
@@ -37,10 +44,20 @@ import reactor.core.publisher.Mono;
 public class TracingRetrievalStrategy extends TracingSupport implements RetrievalStrategy {
 
     private final RetrievalStrategy delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingRetrievalStrategy(RetrievalStrategy delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingRetrievalStrategy(
+            RetrievalStrategy delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(observer);
         this.delegate = delegate;
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -58,11 +75,45 @@ public class TracingRetrievalStrategy extends TracingSupport implements Retrieva
                         MemoryAttributes.RETRIEVAL_STRATEGY,
                         delegate.name()),
                 r -> Map.of(RETRIEVAL_RESULT_COUNT, r.items().size()),
-                () -> delegate.retrieve(context, config));
+                () ->
+                        Mono.deferContextual(
+                                reactorContext -> {
+                                    RetrievalTraceCollector collector =
+                                            RetrievalTraceContext.collector(reactorContext);
+                                    return delegate.retrieve(context, config)
+                                            .doOnNext(result -> recordSummary(collector, result))
+                                            .doOnError(ignored -> recordSummaryError(collector));
+                                }));
     }
 
     @Override
     public void onDataChanged(MemoryId memoryId) {
         delegate.onDataChanged(memoryId);
+    }
+
+    private void recordSummary(RetrievalTraceCollector collector, RetrievalResult result) {
+        RetrievalSummaryMetrics metrics =
+                RetrievalMetricsSupport.summary(delegate.name(), result, "core");
+        RetrievalMetricsSupport.safeRecord(() -> metricsRecorder.recordRetrievalSummary(metrics));
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        collector.finalResults(
+                                new RetrievalFinalTrace(
+                                        metrics.strategy(),
+                                        metrics.status(),
+                                        metrics.itemCount(),
+                                        metrics.insightCount(),
+                                        metrics.rawDataCount(),
+                                        metrics.evidenceCount())));
+    }
+
+    private void recordSummaryError(RetrievalTraceCollector collector) {
+        RetrievalSummaryMetrics metrics =
+                new RetrievalSummaryMetrics(delegate.name(), "error", 0, 0, 0, 0, "core");
+        RetrievalMetricsSupport.safeRecord(() -> metricsRecorder.recordRetrievalSummary(metrics));
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        collector.finalResults(
+                                new RetrievalFinalTrace(metrics.strategy(), "error", 0, 0, 0, 0)));
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannel.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/tracing/decorator/TracingTemporalItemChannel.java
@@ -13,16 +13,25 @@
  */
 package com.openmemind.ai.memory.core.tracing.decorator;
 
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMetricsSupport;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.query.QueryContext;
+import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
 import com.openmemind.ai.memory.core.retrieval.temporal.TemporalConstraint;
 import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannel;
 import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelResult;
 import com.openmemind.ai.memory.core.retrieval.temporal.TemporalItemChannelSettings;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalStageTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceOptions;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceSupport;
 import com.openmemind.ai.memory.core.tracing.MemoryAttributes;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.tracing.MemorySpanNames;
 import com.openmemind.ai.memory.core.tracing.TracingSupport;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,10 +42,20 @@ public final class TracingTemporalItemChannel extends TracingSupport
         implements TemporalItemChannel {
 
     private final TemporalItemChannel delegate;
+    private final MemoryMetricsRecorder metricsRecorder;
 
     public TracingTemporalItemChannel(TemporalItemChannel delegate, MemoryObserver observer) {
+        this(delegate, observer, NoopMemoryMetricsRecorder.INSTANCE);
+    }
+
+    public TracingTemporalItemChannel(
+            TemporalItemChannel delegate,
+            MemoryObserver observer,
+            MemoryMetricsRecorder metricsRecorder) {
         super(Objects.requireNonNull(observer, "observer"));
         this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.metricsRecorder =
+                metricsRecorder == null ? NoopMemoryMetricsRecorder.INSTANCE : metricsRecorder;
     }
 
     @Override
@@ -68,6 +87,75 @@ public final class TracingTemporalItemChannel extends TracingSupport
                                 result.constraintPresent(),
                                 MemoryAttributes.RETRIEVAL_TEMPORAL_DEGRADED,
                                 result.degraded()),
-                () -> delegate.retrieve(context, config, temporalConstraint, settings));
+                () ->
+                        RetrievalTraceSupport.traceStage(
+                                        delegate.retrieve(
+                                                context, config, temporalConstraint, settings),
+                                        "channel",
+                                        "item",
+                                        "temporal",
+                                        null,
+                                        this::temporalStageTrace)
+                                .doOnNext(
+                                        result ->
+                                                recordStage(
+                                                        result == null
+                                                                ? 0
+                                                                : result.candidateCount(),
+                                                        result == null || result.items() == null
+                                                                ? 0
+                                                                : result.items().size(),
+                                                        result != null && result.degraded(),
+                                                        result == null || !result.enabled(),
+                                                        result != null && result.degraded()
+                                                                ? "degraded"
+                                                                : "success"))
+                                .doOnError(ignored -> recordStage(0, 0, false, false, "error")));
+    }
+
+    private void recordStage(
+            int candidateCount, int resultCount, boolean degraded, boolean skipped, String status) {
+        RetrievalMetricsSupport.safeRecord(
+                () ->
+                        metricsRecorder.recordRetrievalStage(
+                                new RetrievalStageMetrics(
+                                        null,
+                                        "channel",
+                                        "item",
+                                        "temporal",
+                                        status,
+                                        null,
+                                        candidateCount,
+                                        resultCount,
+                                        degraded,
+                                        skipped,
+                                        "core")));
+    }
+
+    private RetrievalStageTrace temporalStageTrace(
+            TemporalItemChannelResult result,
+            String stage,
+            String tier,
+            String method,
+            Integer inputCount,
+            java.time.Instant startedAt,
+            long durationMillis,
+            RetrievalTraceOptions options) {
+        List<ScoredResult> results = result == null ? List.of() : result.items();
+        return new RetrievalStageTrace(
+                stage,
+                tier,
+                method,
+                result != null && result.degraded() ? "degraded" : "success",
+                inputCount,
+                result == null ? 0 : result.candidateCount(),
+                results == null ? 0 : results.size(),
+                result != null && result.degraded(),
+                result == null || !result.enabled(),
+                startedAt,
+                durationMillis,
+                result == null ? Map.of() : Map.of("constraintPresent", result.constraintPresent()),
+                RetrievalTraceSupport.candidates(
+                        results, options.maxCandidatesPerStage(), options.maxTextLength()));
     }
 }

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/metrics/ExtractionMetricsExtractorTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/metrics/ExtractionMetricsExtractorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.extraction.ExtractionResult;
+import com.openmemind.ai.memory.core.extraction.item.graph.ItemGraphMaterializationResult;
+import com.openmemind.ai.memory.core.extraction.rawdata.ParsedSegment;
+import com.openmemind.ai.memory.core.extraction.result.InsightResult;
+import com.openmemind.ai.memory.core.extraction.result.MemoryItemResult;
+import com.openmemind.ai.memory.core.extraction.result.RawDataResult;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ExtractionMetricsExtractorTest {
+
+    @Test
+    void extractsRawDataSegmentItemAndInsightCounts() {
+        var result =
+                ExtractionResult.success(
+                        DefaultMemoryId.of("user", "agent"),
+                        new RawDataResult(
+                                List.of(), List.of(parsedSegment(), parsedSegment()), false),
+                        MemoryItemResult.empty(),
+                        InsightResult.empty(),
+                        Duration.ofMillis(10));
+
+        ExtractionMetrics metrics = ExtractionMetricsExtractor.extract(result, "core");
+
+        assertThat(metrics.status()).isEqualTo("success");
+        assertThat(metrics.rawDataCount()).isZero();
+        assertThat(metrics.segmentCount()).isEqualTo(2);
+        assertThat(metrics.newItemCount()).isZero();
+        assertThat(metrics.reinforcedItemCount()).isNull();
+        assertThat(metrics.insightCount()).isZero();
+        assertThat(metrics.graphRelationCount()).isZero();
+        assertThat(metrics.source()).isEqualTo("core");
+    }
+
+    @Test
+    void sumsFinalRelationStatsWithoutMixingLowerLevelCreatedLinkCounters() {
+        var stats =
+                ItemGraphMaterializationResult.Stats.empty()
+                        .withFinalRelationStats(
+                                new ItemGraphMaterializationResult.Stats.FinalRelationStats(
+                                        1, 2, 3, 4));
+        var graphResult = new ItemGraphMaterializationResult(stats);
+        var result =
+                ExtractionResult.success(
+                        DefaultMemoryId.of("user", "agent"),
+                        RawDataResult.empty(),
+                        new MemoryItemResult(List.of(), List.of(), graphResult),
+                        InsightResult.empty(),
+                        Duration.ofMillis(10));
+
+        ExtractionMetrics metrics = ExtractionMetricsExtractor.extract(result, "core");
+
+        assertThat(metrics.graphEntityCount()).isEqualTo(0);
+        assertThat(metrics.graphMentionCount()).isEqualTo(0);
+        assertThat(metrics.graphRelationCount()).isEqualTo(10);
+    }
+
+    @Test
+    void handlesFailedExtractionWithoutGraphOrItemResults() {
+        var result =
+                ExtractionResult.failed(DefaultMemoryId.of("user", "agent"), Duration.ZERO, "boom");
+
+        ExtractionMetrics metrics = ExtractionMetricsExtractor.extract(result, "api");
+
+        assertThat(metrics.status()).isEqualTo("failed");
+        assertThat(metrics.rawDataCount()).isZero();
+        assertThat(metrics.segmentCount()).isNull();
+        assertThat(metrics.newItemCount()).isZero();
+        assertThat(metrics.reinforcedItemCount()).isNull();
+        assertThat(metrics.graphRelationCount()).isNull();
+        assertThat(metrics.source()).isEqualTo("api");
+    }
+
+    private static ParsedSegment parsedSegment() {
+        return new ParsedSegment("segment", null, 0, 7, null, Map.of());
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/metrics/NoopMemoryMetricsRecorderTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/metrics/NoopMemoryMetricsRecorderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class NoopMemoryMetricsRecorderTest {
+
+    @Test
+    void acceptsAllMetricPayloadsWithoutSideEffects() {
+        MemoryMetricsRecorder recorder = NoopMemoryMetricsRecorder.INSTANCE;
+
+        assertThatCode(
+                        () -> {
+                            recorder.recordExtractionSummary(
+                                    new ExtractionMetrics(
+                                            "success", 1, null, 2, null, 3, 4, 5, 6, "core"));
+                            recorder.recordRetrievalStage(
+                                    new RetrievalStageMetrics(
+                                            "simple", "tier", "item", "vector", "success", null, 10,
+                                            5, false, false, "core"));
+                            recorder.recordRetrievalMerge(
+                                    new RetrievalMergeMetrics(
+                                            "simple", 20, 12, 8, 3, "success", "core"));
+                            recorder.recordRetrievalSummary(
+                                    new RetrievalSummaryMetrics(
+                                            "simple", "success", 5, 1, 0, 0, "core"));
+                        })
+                .doesNotThrowAnyException();
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/MemoryObserverAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/MemoryObserverAutoConfiguration.java
@@ -13,7 +13,9 @@
  */
 package com.openmemind.ai.memory.plugin.tracing.otel.autoconfigure;
 
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
+import com.openmemind.ai.memory.plugin.tracing.otel.OpenTelemetryMemoryMetricsRecorder;
 import com.openmemind.ai.memory.plugin.tracing.otel.OpenTelemetryMemoryObserver;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -40,8 +42,15 @@ public class MemoryObserverAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(MemoryMetricsRecorder.class)
+    public MemoryMetricsRecorder openTelemetryMemoryMetricsRecorder(Meter meter) {
+        return new OpenTelemetryMemoryMetricsRecorder(meter);
+    }
+
+    @Bean
     public static TracingBeanPostProcessor tracingBeanPostProcessor(
-            ObjectProvider<MemoryObserver> observerProvider) {
-        return new TracingBeanPostProcessor(observerProvider);
+            ObjectProvider<MemoryObserver> observerProvider,
+            ObjectProvider<MemoryMetricsRecorder> metricsRecorderProvider) {
+        return new TracingBeanPostProcessor(observerProvider, metricsRecorderProvider);
     }
 }

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessor.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-tracing-opentelemetry-starter/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/autoconfigure/TracingBeanPostProcessor.java
@@ -22,6 +22,8 @@ import com.openmemind.ai.memory.core.extraction.step.InsightExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.MemoryItemExtractStep;
 import com.openmemind.ai.memory.core.extraction.step.RawDataExtractStep;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.NoopMemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.retrieval.MemoryRetriever;
 import com.openmemind.ai.memory.core.retrieval.deep.TypedQueryExpander;
 import com.openmemind.ai.memory.core.retrieval.graph.RetrievalGraphAssistant;
@@ -61,9 +63,17 @@ import org.springframework.core.Ordered;
 public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
 
     private final ObjectProvider<MemoryObserver> observerProvider;
+    private final ObjectProvider<MemoryMetricsRecorder> metricsRecorderProvider;
 
     public TracingBeanPostProcessor(ObjectProvider<MemoryObserver> observerProvider) {
+        this(observerProvider, null);
+    }
+
+    public TracingBeanPostProcessor(
+            ObjectProvider<MemoryObserver> observerProvider,
+            ObjectProvider<MemoryMetricsRecorder> metricsRecorderProvider) {
         this.observerProvider = observerProvider;
+        this.metricsRecorderProvider = metricsRecorderProvider;
     }
 
     @Override
@@ -78,12 +88,21 @@ public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
         }
 
         MemoryObserver observer = observerProvider.getIfAvailable();
-        if (observer == null || observer instanceof NoopMemoryObserver) {
+        if (observer == null) {
+            observer = new NoopMemoryObserver();
+        }
+        MemoryMetricsRecorder metricsRecorder =
+                metricsRecorderProvider == null
+                        ? NoopMemoryMetricsRecorder.INSTANCE
+                        : metricsRecorderProvider.getIfAvailable(
+                                () -> NoopMemoryMetricsRecorder.INSTANCE);
+        if ((observer == null || observer instanceof NoopMemoryObserver)
+                && metricsRecorder instanceof NoopMemoryMetricsRecorder) {
             return bean;
         }
 
         if (bean instanceof MemoryExtractor d && !(bean instanceof TracingMemoryExtractor)) {
-            return new TracingMemoryExtractor(d, observer);
+            return new TracingMemoryExtractor(d, observer, metricsRecorder);
         }
         if (bean instanceof RawDataExtractStep d && !(bean instanceof TracingRawDataExtractStep)) {
             return new TracingRawDataExtractStep(d, observer);
@@ -123,7 +142,7 @@ public class TracingBeanPostProcessor implements BeanPostProcessor, Ordered {
             return new TracingMemoryThreadAssistant(d, observer);
         }
         if (bean instanceof RetrievalStrategy d && !(bean instanceof TracingRetrievalStrategy)) {
-            return new TracingRetrievalStrategy(d, observer);
+            return new TracingRetrievalStrategy(d, observer, metricsRecorder);
         }
         if (bean instanceof Reranker d && !(bean instanceof TracingReranker)) {
             return new TracingReranker(d, observer);

--- a/memind-plugins/memind-plugin-tracing-opentelemetry/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/OpenTelemetryMemoryMetricsRecorder.java
+++ b/memind-plugins/memind-plugin-tracing-opentelemetry/src/main/java/com/openmemind/ai/memory/plugin/tracing/otel/OpenTelemetryMemoryMetricsRecorder.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.tracing.otel;
+
+import com.openmemind.ai.memory.core.metrics.ExtractionMetrics;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
+import com.openmemind.ai.memory.core.metrics.RetrievalMergeMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalResultType;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalSummaryMetrics;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import java.util.Set;
+
+public final class OpenTelemetryMemoryMetricsRecorder implements MemoryMetricsRecorder {
+
+    private static final Set<String> STRATEGIES = Set.of("simple", "deep", "unknown");
+    private static final Set<String> STAGES = Set.of("tier", "channel", "merge", "rerank", "final");
+    private static final Set<String> TIERS = Set.of("item", "insight", "raw_data", "none");
+    private static final Set<String> METHODS =
+            Set.of(
+                    "vector",
+                    "keyword",
+                    "hybrid",
+                    "graph",
+                    "temporal",
+                    "rrf",
+                    "rerank",
+                    "final",
+                    "none");
+    private static final Set<String> STATUSES =
+            Set.of(
+                    "success",
+                    "error",
+                    "degraded",
+                    "skipped",
+                    "empty",
+                    "failed",
+                    "partial_success",
+                    "unknown");
+    private static final Set<String> SOURCES = Set.of("api", "core", "internal");
+
+    private final DoubleHistogram extractionRawData;
+    private final DoubleHistogram extractionSegments;
+    private final DoubleHistogram extractionItems;
+    private final DoubleHistogram extractionItemsNew;
+    private final DoubleHistogram extractionItemsReinforced;
+    private final DoubleHistogram extractionInsights;
+    private final DoubleHistogram extractionGraphEntities;
+    private final DoubleHistogram extractionGraphMentions;
+    private final DoubleHistogram extractionGraphRelations;
+    private final DoubleHistogram retrievalCandidates;
+    private final DoubleHistogram retrievalResults;
+    private final DoubleHistogram retrievalMergeInputs;
+    private final DoubleHistogram retrievalMergeOutputs;
+    private final DoubleHistogram retrievalMergeDeduplicated;
+    private final LongCounter retrievalStageDegraded;
+    private final LongCounter retrievalStageSkipped;
+    private final LongCounter retrievalEmptyResults;
+
+    public OpenTelemetryMemoryMetricsRecorder(Meter meter) {
+        this.extractionRawData = histogram(meter, "memind.extraction.raw_data", "{raw_data}");
+        this.extractionSegments = histogram(meter, "memind.extraction.segments", "{segment}");
+        this.extractionItems = histogram(meter, "memind.extraction.items", "{item}");
+        this.extractionItemsNew = histogram(meter, "memind.extraction.items.new", "{item}");
+        this.extractionItemsReinforced =
+                histogram(meter, "memind.extraction.items.reinforced", "{item}");
+        this.extractionInsights = histogram(meter, "memind.extraction.insights", "{insight}");
+        this.extractionGraphEntities =
+                histogram(meter, "memind.extraction.graph.entities", "{entity}");
+        this.extractionGraphMentions =
+                histogram(meter, "memind.extraction.graph.mentions", "{mention}");
+        this.extractionGraphRelations =
+                histogram(meter, "memind.extraction.graph.relations", "{relation}");
+        this.retrievalCandidates = histogram(meter, "memind.retrieval.candidates", "{candidate}");
+        this.retrievalResults = histogram(meter, "memind.retrieval.results", "{result}");
+        this.retrievalMergeInputs =
+                histogram(meter, "memind.retrieval.merge.inputs", "{candidate}");
+        this.retrievalMergeOutputs =
+                histogram(meter, "memind.retrieval.merge.outputs", "{candidate}");
+        this.retrievalMergeDeduplicated =
+                histogram(meter, "memind.retrieval.merge.deduplicated", "{candidate}");
+        this.retrievalStageDegraded = counter(meter, "memind.retrieval.stage.degraded");
+        this.retrievalStageSkipped = counter(meter, "memind.retrieval.stage.skipped");
+        this.retrievalEmptyResults = counter(meter, "memind.retrieval.empty_results");
+    }
+
+    @Override
+    public void recordExtractionSummary(ExtractionMetrics metrics) {
+        if (metrics == null) {
+            return;
+        }
+        Attributes attrs = extractionAttrs(metrics.status(), metrics.source());
+        extractionRawData.record(metrics.rawDataCount(), attrs);
+        recordNullable(extractionSegments, metrics.segmentCount(), attrs);
+        extractionItems.record(metrics.newItemCount(), attrs);
+        extractionItemsNew.record(metrics.newItemCount(), attrs);
+        recordNullable(extractionItemsReinforced, metrics.reinforcedItemCount(), attrs);
+        extractionInsights.record(metrics.insightCount(), attrs);
+        recordNullable(extractionGraphEntities, metrics.graphEntityCount(), attrs);
+        recordNullable(extractionGraphMentions, metrics.graphMentionCount(), attrs);
+        recordNullable(extractionGraphRelations, metrics.graphRelationCount(), attrs);
+    }
+
+    @Override
+    public void recordRetrievalStage(RetrievalStageMetrics metrics) {
+        if (metrics == null) {
+            return;
+        }
+        Attributes attrs =
+                retrievalAttrs(
+                        metrics.strategy(),
+                        metrics.stage(),
+                        metrics.tier(),
+                        metrics.method(),
+                        metrics.status(),
+                        metrics.source());
+        recordNullable(retrievalCandidates, metrics.candidateCount(), attrs);
+        recordNullable(retrievalResults, metrics.resultCount(), attrs);
+        if (metrics.degraded()) {
+            retrievalStageDegraded.add(1, attrs);
+        }
+        if (metrics.skipped()) {
+            retrievalStageSkipped.add(1, attrs);
+        }
+    }
+
+    @Override
+    public void recordRetrievalMerge(RetrievalMergeMetrics metrics) {
+        if (metrics == null) {
+            return;
+        }
+        Attributes attrs =
+                retrievalAttrs(
+                        metrics.strategy(),
+                        "merge",
+                        "none",
+                        "rrf",
+                        metrics.status(),
+                        metrics.source());
+        retrievalMergeInputs.record(metrics.inputCount(), attrs);
+        retrievalMergeOutputs.record(metrics.outputCount(), attrs);
+        retrievalMergeDeduplicated.record(metrics.deduplicatedCount(), attrs);
+    }
+
+    @Override
+    public void recordRetrievalSummary(RetrievalSummaryMetrics metrics) {
+        if (metrics == null) {
+            return;
+        }
+        Attributes attrs =
+                retrievalAttrs(
+                        metrics.strategy(),
+                        "final",
+                        "none",
+                        "final",
+                        metrics.status(),
+                        metrics.source());
+        recordFinalResult(metrics, RetrievalResultType.ITEM, attrs);
+        recordFinalResult(metrics, RetrievalResultType.INSIGHT, attrs);
+        recordFinalResult(metrics, RetrievalResultType.RAW_DATA, attrs);
+        recordFinalResult(metrics, RetrievalResultType.EVIDENCE, attrs);
+        if (metrics.itemCount() == 0
+                && metrics.insightCount() == 0
+                && metrics.rawDataCount() == 0) {
+            retrievalEmptyResults.add(1, attrs);
+        }
+    }
+
+    private void recordFinalResult(
+            RetrievalSummaryMetrics metrics, RetrievalResultType type, Attributes baseAttrs) {
+        retrievalResults.record(
+                metrics.countFor(type),
+                baseAttrs.toBuilder()
+                        .put(AttributeKey.stringKey("result_type"), resultType(type))
+                        .build());
+    }
+
+    private static DoubleHistogram histogram(Meter meter, String name, String unit) {
+        return meter.histogramBuilder(name).setUnit(unit).build();
+    }
+
+    private static LongCounter counter(Meter meter, String name) {
+        return meter.counterBuilder(name).setUnit("{event}").build();
+    }
+
+    private static void recordNullable(DoubleHistogram histogram, Integer value, Attributes attrs) {
+        if (value != null) {
+            histogram.record(value, attrs);
+        }
+    }
+
+    private static Attributes extractionAttrs(String status, String source) {
+        return Attributes.of(
+                AttributeKey.stringKey("operation"),
+                "extraction",
+                AttributeKey.stringKey("status"),
+                normalize(status, STATUSES, "unknown"),
+                AttributeKey.stringKey("source"),
+                normalize(source, SOURCES, "core"));
+    }
+
+    private static Attributes retrievalAttrs(
+            String strategy,
+            String stage,
+            String tier,
+            String method,
+            String status,
+            String source) {
+        return Attributes.builder()
+                .put(AttributeKey.stringKey("operation"), "retrieval")
+                .put(AttributeKey.stringKey("strategy"), normalize(strategy, STRATEGIES, "unknown"))
+                .put(AttributeKey.stringKey("stage"), normalize(stage, STAGES, "final"))
+                .put(AttributeKey.stringKey("tier"), normalize(tier, TIERS, "none"))
+                .put(AttributeKey.stringKey("method"), normalize(method, METHODS, "none"))
+                .put(AttributeKey.stringKey("status"), normalize(status, STATUSES, "unknown"))
+                .put(AttributeKey.stringKey("source"), normalize(source, SOURCES, "core"))
+                .build();
+    }
+
+    private static String resultType(RetrievalResultType type) {
+        return switch (type) {
+            case ITEM -> "item";
+            case INSIGHT -> "insight";
+            case RAW_DATA -> "raw_data";
+            case EVIDENCE -> "evidence";
+        };
+    }
+
+    private static String normalize(String value, Set<String> allowed, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        String normalized = value.toLowerCase();
+        return allowed.contains(normalized) ? normalized : fallback;
+    }
+}

--- a/memind-plugins/memind-plugin-tracing-opentelemetry/src/test/java/com/openmemind/ai/memory/plugin/tracing/otel/OpenTelemetryMemoryMetricsRecorderTest.java
+++ b/memind-plugins/memind-plugin-tracing-opentelemetry/src/test/java/com/openmemind/ai/memory/plugin/tracing/otel/OpenTelemetryMemoryMetricsRecorderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.tracing.otel;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.openmemind.ai.memory.core.metrics.ExtractionMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalMergeMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalStageMetrics;
+import com.openmemind.ai.memory.core.metrics.RetrievalSummaryMetrics;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import org.junit.jupiter.api.Test;
+
+class OpenTelemetryMemoryMetricsRecorderTest {
+
+    @Test
+    void recordsAllBusinessMetricPayloads() {
+        try (SdkMeterProvider provider = SdkMeterProvider.builder().build()) {
+            Meter meter = provider.get("memind-test");
+            var recorder = new OpenTelemetryMemoryMetricsRecorder(meter);
+
+            assertThatCode(
+                            () -> {
+                                recorder.recordExtractionSummary(
+                                        new ExtractionMetrics(
+                                                "success", 1, null, 2, null, 3, 4, 5, 6, "core"));
+                                recorder.recordRetrievalStage(
+                                        new RetrievalStageMetrics(
+                                                "simple", "tier", "item", "vector", "success", null,
+                                                10, 5, false, false, "core"));
+                                recorder.recordRetrievalStage(
+                                        new RetrievalStageMetrics(
+                                                "simple",
+                                                "channel",
+                                                "item",
+                                                "temporal",
+                                                "degraded",
+                                                10,
+                                                3,
+                                                2,
+                                                true,
+                                                false,
+                                                "core"));
+                                recorder.recordRetrievalMerge(
+                                        new RetrievalMergeMetrics(
+                                                "simple", 20, 12, 8, 3, "success", "core"));
+                                recorder.recordRetrievalSummary(
+                                        new RetrievalSummaryMetrics(
+                                                "simple", "empty", 0, 0, 0, 0, "core"));
+                            })
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerObservabilityProperties.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerObservabilityProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "memind.observability")
+public class MemindServerObservabilityProperties {
+
+    private final RetrievalTrace retrievalTrace = new RetrievalTrace();
+
+    public RetrievalTrace getRetrievalTrace() {
+        return retrievalTrace;
+    }
+
+    public static class RetrievalTrace {
+
+        private boolean enabled;
+        private int maxStages = 32;
+        private int maxCandidatesPerStage = 8;
+        private int maxTextLength = 160;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxStages() {
+            return maxStages;
+        }
+
+        public void setMaxStages(int maxStages) {
+            this.maxStages = maxStages;
+        }
+
+        public int getMaxCandidatesPerStage() {
+            return maxCandidatesPerStage;
+        }
+
+        public void setMaxCandidatesPerStage(int maxCandidatesPerStage) {
+            this.maxCandidatesPerStage = maxCandidatesPerStage;
+        }
+
+        public int getMaxTextLength() {
+            return maxTextLength;
+        }
+
+        public void setMaxTextLength(int maxTextLength) {
+            this.maxTextLength = maxTextLength;
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
@@ -20,6 +20,7 @@ import com.openmemind.ai.memory.core.builder.MemoryBuildOptionsSanitizer;
 import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
+import com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder;
 import com.openmemind.ai.memory.core.plugin.RawDataPlugin;
 import com.openmemind.ai.memory.core.resource.ContentParser;
 import com.openmemind.ai.memory.core.resource.ContentParserRegistry;
@@ -42,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -49,6 +51,7 @@ import org.springframework.core.annotation.Order;
 import tools.jackson.databind.ObjectMapper;
 
 @Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(MemindServerObservabilityProperties.class)
 public class MemindServerRuntimeConfiguration {
 
     private static final Logger log =
@@ -76,7 +79,8 @@ public class MemindServerRuntimeConfiguration {
             ObjectProvider<RawDataPlugin> rawDataPluginProvider,
             ObjectProvider<ResourceFetcher> resourceFetcherProvider,
             ObjectProvider<BubbleTrackerStore> bubbleTrackerStoreProvider,
-            ObjectProvider<MemoryObserver> memoryObserverProvider) {
+            ObjectProvider<MemoryObserver> memoryObserverProvider,
+            ObjectProvider<MemoryMetricsRecorder> memoryMetricsRecorderProvider) {
         return options -> {
             StructuredChatClient structuredChatClient =
                     requireRuntimeDependency(structuredChatClientProvider);
@@ -91,6 +95,10 @@ public class MemindServerRuntimeConfiguration {
             ResourceFetcher resourceFetcher = resourceFetcherProvider.getIfAvailable();
             BubbleTrackerStore bubbleTrackerStore = bubbleTrackerStoreProvider.getIfAvailable();
             MemoryObserver memoryObserver = memoryObserverProvider.getIfAvailable();
+            MemoryMetricsRecorder memoryMetricsRecorder =
+                    memoryMetricsRecorderProvider == null
+                            ? null
+                            : memoryMetricsRecorderProvider.getIfAvailable();
             var builder =
                     Memory.builder()
                             .chatClient(structuredChatClient)
@@ -104,6 +112,9 @@ public class MemindServerRuntimeConfiguration {
             }
             if (memoryObserver != null) {
                 builder.memoryObserver(memoryObserver);
+            }
+            if (memoryMetricsRecorder != null) {
+                builder.memoryMetricsRecorder(memoryMetricsRecorder);
             }
             if (contentParserRegistry != null) {
                 builder.contentParserRegistry(contentParserRegistry);
@@ -122,6 +133,33 @@ public class MemindServerRuntimeConfiguration {
             }
             return new MemoryRuntimeFactory.CreationResult(builder.build(), effectiveOptions);
         };
+    }
+
+    MemoryRuntimeFactory memoryRuntimeFactory(
+            ObjectProvider<StructuredChatClient> structuredChatClientProvider,
+            ObjectProvider<MemoryStore> memoryStoreProvider,
+            ObjectProvider<MemoryBuffer> memoryBufferProvider,
+            ObjectProvider<MemoryVector> memoryVectorProvider,
+            ObjectProvider<MemoryTextSearch> memoryTextSearch,
+            ObjectProvider<Reranker> reranker,
+            ObjectProvider<ContentParser> contentParserProvider,
+            ObjectProvider<RawDataPlugin> rawDataPluginProvider,
+            ObjectProvider<ResourceFetcher> resourceFetcherProvider,
+            ObjectProvider<BubbleTrackerStore> bubbleTrackerStoreProvider,
+            ObjectProvider<MemoryObserver> memoryObserverProvider) {
+        return memoryRuntimeFactory(
+                structuredChatClientProvider,
+                memoryStoreProvider,
+                memoryBufferProvider,
+                memoryVectorProvider,
+                memoryTextSearch,
+                reranker,
+                contentParserProvider,
+                rawDataPluginProvider,
+                resourceFetcherProvider,
+                bubbleTrackerStoreProvider,
+                memoryObserverProvider,
+                null);
     }
 
     private static List<ContentParser> resolveContentParsers(

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/request/RetrieveMemoryRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/request/RetrieveMemoryRequest.java
@@ -21,4 +21,11 @@ public record RetrieveMemoryRequest(
         @NotBlank String userId,
         @NotBlank String agentId,
         @NotBlank String query,
-        @NotNull RetrievalConfig.Strategy strategy) {}
+        @NotNull RetrievalConfig.Strategy strategy,
+        Boolean trace) {
+
+    public RetrieveMemoryRequest(
+            String userId, String agentId, String query, RetrievalConfig.Strategy strategy) {
+        this(userId, agentId, query, strategy, null);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/response/RetrievalTraceView.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/response/RetrievalTraceView.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.domain.memory.response;
+
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalCandidateTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalFinalTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalMergeTrace;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record RetrievalTraceView(
+        String traceId,
+        Instant startedAt,
+        Instant completedAt,
+        boolean truncated,
+        List<StageView> stages,
+        MergeView merge,
+        FinalView finalResults) {
+
+    public record StageView(
+            String stage,
+            String tier,
+            String method,
+            String status,
+            Integer inputCount,
+            Integer candidateCount,
+            Integer resultCount,
+            boolean degraded,
+            boolean skipped,
+            Instant startedAt,
+            Long durationMillis,
+            Map<String, Object> attributes,
+            List<RetrievalCandidateTrace> candidates) {}
+
+    public record MergeView(
+            int inputCount,
+            int outputCount,
+            int deduplicatedCount,
+            int sourceCount,
+            String status) {
+        public static MergeView from(RetrievalMergeTrace trace) {
+            return trace == null
+                    ? null
+                    : new MergeView(
+                            trace.inputCount(),
+                            trace.outputCount(),
+                            trace.deduplicatedCount(),
+                            trace.sourceCount(),
+                            trace.status());
+        }
+    }
+
+    public record FinalView(
+            String strategy,
+            String status,
+            int itemCount,
+            int insightCount,
+            int rawDataCount,
+            int evidenceCount) {
+        public static FinalView from(RetrievalFinalTrace trace) {
+            return trace == null
+                    ? null
+                    : new FinalView(
+                            trace.strategy(),
+                            trace.status(),
+                            trace.itemCount(),
+                            trace.insightCount(),
+                            trace.rawDataCount(),
+                            trace.evidenceCount());
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/response/RetrieveMemoryResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/memory/response/RetrieveMemoryResponse.java
@@ -22,7 +22,18 @@ public record RetrieveMemoryResponse(
         List<RetrievedRawDataView> rawData,
         List<String> evidences,
         String strategy,
-        String query) {
+        String query,
+        RetrievalTraceView trace) {
+
+    public RetrieveMemoryResponse(
+            List<RetrievedItemView> items,
+            List<RetrievedInsightView> insights,
+            List<RetrievedRawDataView> rawData,
+            List<String> evidences,
+            String strategy,
+            String query) {
+        this(items, insights, rawData, evidences, strategy, query, null);
+    }
 
     public record RetrievedItemView(
             String id, String text, float vectorScore, double finalScore, Instant occurredAt) {}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryApplicationService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryApplicationService.java
@@ -13,6 +13,7 @@
  */
 package com.openmemind.ai.memory.server.service.memory;
 
+import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.data.DefaultMemoryId;
 import com.openmemind.ai.memory.core.data.MemoryId;
 import com.openmemind.ai.memory.core.data.MemoryInsight;
@@ -21,12 +22,18 @@ import com.openmemind.ai.memory.core.data.MemoryRawData;
 import com.openmemind.ai.memory.core.extraction.ExtractionResult;
 import com.openmemind.ai.memory.core.retrieval.RetrievalResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.trace.BoundedRetrievalTraceCollector;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalDebugTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceContext;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceOptions;
+import com.openmemind.ai.memory.server.configuration.MemindServerObservabilityProperties;
 import com.openmemind.ai.memory.server.domain.memory.request.AddMessageRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.CommitMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.RetrieveMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.response.AddMessageResponse;
 import com.openmemind.ai.memory.server.domain.memory.response.ExtractMemoryResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.RetrievalTraceView;
 import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeManager;
 import java.time.Duration;
@@ -35,6 +42,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -46,9 +54,18 @@ public class OpenMemoryApplicationService {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     private final MemoryRuntimeManager runtimeManager;
+    private final MemindServerObservabilityProperties observabilityProperties;
 
     public OpenMemoryApplicationService(MemoryRuntimeManager runtimeManager) {
+        this(runtimeManager, new MemindServerObservabilityProperties());
+    }
+
+    @Autowired
+    public OpenMemoryApplicationService(
+            MemoryRuntimeManager runtimeManager,
+            MemindServerObservabilityProperties observabilityProperties) {
         this.runtimeManager = runtimeManager;
+        this.observabilityProperties = observabilityProperties;
     }
 
     public void extractAsync(ExtractMemoryRequest request) {
@@ -116,18 +133,43 @@ public class OpenMemoryApplicationService {
 
     public RetrieveMemoryResponse retrieve(RetrieveMemoryRequest request) {
         try (var lease = runtimeManager.acquire()) {
+            BoundedRetrievalTraceCollector traceCollector = traceCollector(request);
             RetrievalResult result =
                     Objects.requireNonNull(
-                            lease.handle()
-                                    .memory()
-                                    .retrieve(
-                                            DefaultMemoryId.of(request.userId(), request.agentId()),
-                                            request.query(),
-                                            request.strategy())
+                            retrievalMono(lease.handle().memory(), request, traceCollector)
                                     .block(REQUEST_TIMEOUT),
                             "Memory retrieve returned no result");
-            return toRetrieveResponse(result);
+            return toRetrieveResponse(result, traceCollector);
         }
+    }
+
+    private Mono<RetrievalResult> retrievalMono(
+            Memory memory,
+            RetrieveMemoryRequest request,
+            BoundedRetrievalTraceCollector traceCollector) {
+        Mono<RetrievalResult> operation =
+                memory.retrieve(
+                        DefaultMemoryId.of(request.userId(), request.agentId()),
+                        request.query(),
+                        request.strategy());
+        if (traceCollector == null) {
+            return operation;
+        }
+        return operation.contextWrite(
+                context -> RetrievalTraceContext.withCollector(context, traceCollector));
+    }
+
+    private BoundedRetrievalTraceCollector traceCollector(RetrieveMemoryRequest request) {
+        if (!Boolean.TRUE.equals(request.trace())
+                || !observabilityProperties.getRetrievalTrace().isEnabled()) {
+            return null;
+        }
+        var properties = observabilityProperties.getRetrievalTrace();
+        return new BoundedRetrievalTraceCollector(
+                new RetrievalTraceOptions(
+                        properties.getMaxStages(),
+                        properties.getMaxCandidatesPerStage(),
+                        properties.getMaxTextLength()));
     }
 
     private void dispatchAsync(
@@ -182,7 +224,8 @@ public class OpenMemoryApplicationService {
         return result.insightResult().insights().stream().map(MemoryInsight::id).toList();
     }
 
-    private static RetrieveMemoryResponse toRetrieveResponse(RetrievalResult result) {
+    private static RetrieveMemoryResponse toRetrieveResponse(
+            RetrievalResult result, BoundedRetrievalTraceCollector traceCollector) {
         return new RetrieveMemoryResponse(
                 result.items() == null
                         ? List.of()
@@ -214,7 +257,41 @@ public class OpenMemoryApplicationService {
                                 .toList(),
                 result.evidences() == null ? List.of() : result.evidences(),
                 result.strategy(),
-                result.query());
+                result.query(),
+                traceCollector == null
+                        ? null
+                        : traceCollector
+                                .snapshot()
+                                .map(OpenMemoryApplicationService::toTraceView)
+                                .orElse(null));
+    }
+
+    private static RetrievalTraceView toTraceView(RetrievalDebugTrace trace) {
+        return new RetrievalTraceView(
+                trace.traceId(),
+                trace.startedAt(),
+                trace.completedAt(),
+                trace.truncated(),
+                trace.stages().stream()
+                        .map(
+                                stage ->
+                                        new RetrievalTraceView.StageView(
+                                                stage.stage(),
+                                                stage.tier(),
+                                                stage.method(),
+                                                stage.status(),
+                                                stage.inputCount(),
+                                                stage.candidateCount(),
+                                                stage.resultCount(),
+                                                stage.degraded(),
+                                                stage.skipped(),
+                                                stage.startedAt(),
+                                                stage.durationMillis(),
+                                                stage.attributes(),
+                                                stage.candidates()))
+                        .toList(),
+                RetrievalTraceView.MergeView.from(trace.merge()),
+                RetrievalTraceView.FinalView.from(trace.finalResults()));
     }
 
     private static RetrieveMemoryResponse.RetrievedItemView toRetrievedItemView(ScoredResult item) {

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryApplicationServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryApplicationServiceTest.java
@@ -41,6 +41,9 @@ import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
 import com.openmemind.ai.memory.core.retrieval.RetrievalRequest;
 import com.openmemind.ai.memory.core.retrieval.RetrievalResult;
 import com.openmemind.ai.memory.core.retrieval.scoring.ScoredResult;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalFinalTrace;
+import com.openmemind.ai.memory.core.retrieval.trace.RetrievalTraceContext;
+import com.openmemind.ai.memory.server.configuration.MemindServerObservabilityProperties;
 import com.openmemind.ai.memory.server.domain.memory.request.AddMessageRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.CommitMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
@@ -181,6 +184,29 @@ class OpenMemoryApplicationServiceTest {
         assertThat(runtimeManager.currentHandle().inFlightRequests()).hasValue(0);
     }
 
+    @Test
+    void retrieveIncludesDebugTraceWhenEnabledAndRequested() {
+        RecordingMemory memory = new RecordingMemory();
+        memory.retrieveResult = RetrievalResult.empty("SIMPLE", "coffee");
+        memory.recordTrace = true;
+        MemoryRuntimeManager runtimeManager =
+                new MemoryRuntimeManager(
+                        new RuntimeHandle(memory, MemoryBuildOptions.defaults(), 1));
+        MemindServerObservabilityProperties properties = new MemindServerObservabilityProperties();
+        properties.getRetrievalTrace().setEnabled(true);
+        OpenMemoryApplicationService service =
+                new OpenMemoryApplicationService(runtimeManager, properties);
+
+        var response =
+                service.retrieve(
+                        new RetrieveMemoryRequest(
+                                "u1", "a1", "coffee", RetrievalConfig.Strategy.SIMPLE, true));
+
+        assertThat(response.trace()).isNotNull();
+        assertThat(response.trace().finalResults().strategy()).isEqualTo("SIMPLE");
+        assertThat(response.trace().traceId()).isNotBlank();
+    }
+
     private static ExtractionResult extractionResult() {
         MemoryId memoryId = DefaultMemoryId.of("u1", "a1");
         return new ExtractionResult(
@@ -268,6 +294,7 @@ class OpenMemoryApplicationServiceTest {
         private final CountDownLatch addMessageInvoked = new CountDownLatch(1);
         private final CountDownLatch commitInvoked = new CountDownLatch(1);
         private RetrievalResult retrieveResult;
+        private boolean recordTrace;
 
         @Override
         public Mono<ExtractionResult> extract(MemoryId memoryId, RawContent content) {
@@ -327,7 +354,15 @@ class OpenMemoryApplicationServiceTest {
         public Mono<RetrievalResult> retrieve(
                 MemoryId memoryId, String query, RetrievalConfig.Strategy strategy) {
             this.lastMemoryId = memoryId;
-            return Mono.just(retrieveResult);
+            return Mono.deferContextual(
+                    context -> {
+                        if (recordTrace) {
+                            RetrievalTraceContext.collector(context)
+                                    .finalResults(
+                                            new RetrievalFinalTrace("SIMPLE", "empty", 0, 0, 0, 0));
+                        }
+                        return Mono.just(retrieveResult);
+                    });
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Add provider-neutral memory metrics for extraction, retrieval stages, merge, and retrieval summaries.
- Add bounded retrieval debug traces with Reactor Context propagation and sanitized candidate/stage details.
- Wire OpenTelemetry metrics recording, Spring auto-configuration, builder/assembler injection, and server trace response support.

## Validation
- mvn test