### PR TITLE
Improve memory item extraction prompt

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/prompt/extraction/item/MemoryItemUnifiedPrompts.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/prompt/extraction/item/MemoryItemUnifiedPrompts.java
@@ -82,12 +82,18 @@ public final class MemoryItemUnifiedPrompts {
             """
             # Extraction Scope & What NOT to Extract
             - Extract from BOTH user AND assistant messages.
+            - Extract only information that is likely to remain useful beyond the current \
+            turn or immediate coordination context, such as over future days, weeks, or months.
+            - Do not create a memory item just because a sentence is factual. Create a memory \
+            only when it has durable retrieval value.
             - User messages mainly reveal profile, behavior, and event memories.
             - Keep assistant content ONLY when it contains durable agent instructions, \
             reusable task workflows, resolved problem knowledge, or concrete tool guidance \
             with future reuse value.
-            - Do NOT extract: greetings, small talk, praise toward the assistant, or vague \
-            platitudes without user-specific context.
+            - Do NOT extract: generic greetings, pure acknowledgements, filler and small talk, \
+            process chatter, repeated facts in the same source text, temporary status updates \
+            useful only inside the current session, one-off control messages, or vague \
+            summaries without actionable or retrievable detail.
             - Do NOT extract assistant emotional support, encouragement, validation, reflective \
             coaching questions, or therapeutic phrasing unless the user explicitly adopts them \
             as a lasting routine, preference, or instruction.
@@ -97,16 +103,34 @@ public final class MemoryItemUnifiedPrompts {
             user to", or "At 2026-03-27 the assistant said...".
             - One-off control messages, transient execution commands, and session-management \
             turns are not durable agent memory.
+            - A one-off command can still be extracted if it reveals a durable directive, \
+            reusable playbook, project context, or resolution.
+            - Temporary project status can still be extracted as event when it is important \
+            context likely to matter later.
             """;
 
     private static final String EXTRACTION_BIAS =
             """
             # Extraction Bias
-            - For profile, behavior, and event, extract clearly stated facts even if they \
-            seem minor.
-            - For directive, playbook, and resolution, use strict precision.
+            - For USER-scope categories (`profile`, `behavior`, `event`), extract clearly \
+            stated facts even if they seem minor, as long as they have future retrieval value.
+            - For AGENT-scope categories (`tool`, `directive`, `playbook`, `resolution`), \
+            use strict precision. If the item is merely a one-off command, loose suggestion, \
+            unresolved discussion, or temporary execution status, do not extract it.
             - If there is no clear evidence, do not extract.
-            - if uncertain between agent memory and nothing, prefer nothing
+            - If uncertain between AGENT memory and nothing, prefer nothing.
+            """;
+
+    private static final String CONTENT_PRESERVATION =
+            """
+            # Content Preservation
+            Preserve who, what, when, where, and why when those details affect future retrieval \
+            or interpretation.
+            Preserve important relationships, locations, causes, motivations, comparisons, \
+            capabilities, attitudes, constraints, and user intent.
+            Do not compress away the detail that makes the memory useful.
+            Do not turn a specific memory into a vague summary.
+            Prefer one complete, self-contained sentence over fragments.
             """;
 
     private static final String CATEGORY_CONTEXT_SECTION = "{{CATEGORY_CONTEXT}}";
@@ -347,6 +371,34 @@ public final class MemoryItemUnifiedPrompts {
             -> Wrong: this is profile. Stable professional identity, not a time-bound situation.
 
 
+            ## tool
+
+            Good:
+            {
+              "items": [
+                {
+                  "content": "For the code search tool, use ripgrep with file globs to narrow large repository searches",
+                  "confidence": 0.95,
+                  "time": null,
+                  "insightTypes": ["tool_usage"],
+                  "category_reason": "Specific reusable tool usage guidance with future reuse value.",
+                  "category": "tool"
+                }
+              ]
+            }
+
+            Bad:
+            {
+              "items": [
+                {
+                  "content": "User asked the agent to run a search once",
+                  "category": "tool"
+                }
+              ]
+            }
+            -> Wrong: a one-off tool command is not durable tool usage knowledge.
+
+
             ## directive
 
             Good:
@@ -486,6 +538,7 @@ public final class MemoryItemUnifiedPrompts {
     public static PromptTemplate buildPreview() {
         return defaultBuilder()
                 .variable("CATEGORY_CONTEXT", buildCategoryContext(null, DefaultInsightTypes.all()))
+                .variable("CATEGORY_EXAMPLES", buildCategoryExamples(null))
                 .variable("IDENTITY_CONTEXT", buildIdentityContext("Ada"))
                 .variable("SUBJECT_CONTEXT", buildSubjectClarityContext("Ada"))
                 .variable(
@@ -530,6 +583,7 @@ public final class MemoryItemUnifiedPrompts {
 
         return builder.userPrompt(USER_PROMPT_TEMPLATE)
                 .variable("CATEGORY_CONTEXT", buildCategoryContext(categories, insightTypes))
+                .variable("CATEGORY_EXAMPLES", buildCategoryExamples(categories))
                 .variable("IDENTITY_CONTEXT", buildIdentityContext(userName))
                 .variable("SUBJECT_CONTEXT", buildSubjectClarityContext(userName))
                 .variable("TEMPORAL_CONTEXT", buildTimeContext(segmentText, referenceTime))
@@ -566,6 +620,12 @@ public final class MemoryItemUnifiedPrompts {
         - Use "special" only for conversational role anchors such as self, user, or assistant; do not label arbitrary nouns as special.
         - Good entities: named people, organizations, places, durable objects, and durable concepts central to the item.
         - Bad entities: pronouns, generic nouns, dates, categories, vague topics, or entities not grounded in the source.
+        - Extract entities only when they help link related memories. Prefer concrete named entities and specific durable domain concepts over generic nouns.
+        - Resolve role-only mentions to named entities when the source provides a name.
+        - If "my roommate" and "Emily" refer to the same person, use entity name "Emily" and preserve "user's roommate" in content or alias evidence.
+        - If "the PM" and "Sarah" refer to the same person, use entity name "Sarah" and preserve "PM" as role evidence.
+        - Do not create separate entities for generic role mentions when a named entity is available.
+        - Do not extract generic nouns such as "project", "team", "system", "issue", or "problem" unless grounded as a specific named or durable domain concept.
         - Include `"causalRelations"` only for strong explicit cause/effect links inside this response; keep at most %d per item.
         - Good causal relation: one item states a cause, trigger, enabler, or motivation for another item.
         - Bad causal relation: not for topical similarity, not for ownership or dependency, and not for simple co-occurrence.
@@ -644,25 +704,59 @@ public final class MemoryItemUnifiedPrompts {
                 .section("principles", PRINCIPLES)
                 .section("extractionScope", EXTRACTION_SCOPE)
                 .section("extractionBias", EXTRACTION_BIAS)
+                .section("contentPreservation", CONTENT_PRESERVATION)
                 .section("categoryContext", CATEGORY_CONTEXT_SECTION)
                 .section("identityContext", IDENTITY_CONTEXT_SECTION)
                 .section("subjectContext", SUBJECT_CONTEXT_SECTION)
                 .section("temporalContext", TEMPORAL_CONTEXT_SECTION)
                 .section("scoring", SCORING)
                 .section("output", OUTPUT)
-                .section("examples", CATEGORY_EXAMPLES);
+                .section("examples", "{{CATEGORY_EXAMPLES}}");
     }
 
     // ── Category Context ─────────────────────────────────────────────────────
 
+    static String buildCategoryExamples(Set<MemoryCategory> categories) {
+        Set<MemoryCategory> effectiveCategories = effectiveCategories(categories);
+        if (effectiveCategories.isEmpty()) {
+            return "";
+        }
+        String examples = renderExamplesFor(effectiveCategories);
+        return examples.isBlank() ? "" : "\n\n# Examples by Category\n" + examples;
+    }
+
+    private static Set<MemoryCategory> effectiveCategories(Set<MemoryCategory> categories) {
+        if (categories == null) {
+            return EnumSet.allOf(MemoryCategory.class);
+        }
+        if (categories.isEmpty()) {
+            return EnumSet.noneOf(MemoryCategory.class);
+        }
+        return EnumSet.copyOf(categories);
+    }
+
+    private static String renderExamplesFor(Set<MemoryCategory> categories) {
+        return categories.stream()
+                .map(MemoryCategory::categoryName)
+                .map(MemoryItemUnifiedPrompts::renderExampleFor)
+                .filter(example -> !example.isBlank())
+                .collect(Collectors.joining());
+    }
+
+    private static String renderExampleFor(String categoryName) {
+        String heading = "\n## " + categoryName + "\n";
+        int start = CATEGORY_EXAMPLES.indexOf(heading);
+        if (start < 0) {
+            return "";
+        }
+        int next = CATEGORY_EXAMPLES.indexOf("\n## ", start + heading.length());
+        int end = next < 0 ? CATEGORY_EXAMPLES.length() : next;
+        return CATEGORY_EXAMPLES.substring(start, end);
+    }
+
     static String buildCategoryContext(
             Set<MemoryCategory> categories, List<MemoryInsightType> insightTypes) {
-        Set<MemoryCategory> effectiveCategories =
-                categories == null
-                        ? EnumSet.allOf(MemoryCategory.class)
-                        : categories.isEmpty()
-                                ? EnumSet.noneOf(MemoryCategory.class)
-                                : EnumSet.copyOf(categories);
+        Set<MemoryCategory> effectiveCategories = effectiveCategories(categories);
 
         String userDefs =
                 renderCategoryDefinitions(effectiveCategories, MemoryScope.USER, insightTypes);

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/prompt/extraction/item/MemoryItemUnifiedPromptsTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/prompt/extraction/item/MemoryItemUnifiedPromptsTest.java
@@ -32,6 +32,212 @@ import org.junit.jupiter.api.parallel.Resources;
 class MemoryItemUnifiedPromptsTest {
 
     @Test
+    @DisplayName("Rendered prompt should preserve user-scope category grouping")
+    void shouldPreserveUserScopeCategoryGrouping() {
+        var categoryDefinitions =
+                categoryDefinitionsSection(renderSystemPrompt(MemoryCategory.userCategories()));
+
+        assertThat(categoryDefinitions)
+                .contains("### [USER Scope]")
+                .contains("**profile**")
+                .contains("**behavior**")
+                .contains("**event**")
+                .doesNotContain("### [AGENT Scope]")
+                .doesNotContain("**tool**")
+                .doesNotContain("**directive**")
+                .doesNotContain("**playbook**")
+                .doesNotContain("**resolution**");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should preserve agent-scope categories including tool")
+    void shouldPreserveAgentScopeCategoriesIncludingTool() {
+        var categoryDefinitions =
+                categoryDefinitionsSection(renderSystemPrompt(MemoryCategory.agentCategories()));
+
+        assertThat(categoryDefinitions)
+                .contains("### [AGENT Scope]")
+                .contains("**tool**")
+                .contains("**directive**")
+                .contains("**playbook**")
+                .contains("**resolution**")
+                .doesNotContain("### [USER Scope]")
+                .doesNotContain("**profile**")
+                .doesNotContain("**behavior**")
+                .doesNotContain("**event**");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should preserve all categories and scope grouping")
+    void shouldPreserveAllCategoriesAndScopeGrouping() {
+        var categoryDefinitions =
+                categoryDefinitionsSection(renderSystemPrompt(Set.of(MemoryCategory.values())));
+
+        assertThat(categoryDefinitions)
+                .contains("### [USER Scope]")
+                .contains("### [AGENT Scope]")
+                .contains("**profile**")
+                .contains("**behavior**")
+                .contains("**event**")
+                .contains("**tool**")
+                .contains("**directive**")
+                .contains("**playbook**")
+                .contains("**resolution**");
+    }
+
+    @Test
+    @DisplayName("Rendered examples should not recommend disallowed categories")
+    void shouldRenderExamplesOnlyForAllowedCategories() {
+        var userOnlyExamples = examplesSection(renderSystemPrompt(MemoryCategory.userCategories()));
+        var agentOnlyExamples =
+                examplesSection(renderSystemPrompt(MemoryCategory.agentCategories()));
+        var allExamples = examplesSection(renderSystemPrompt(Set.of(MemoryCategory.values())));
+
+        assertThat(userOnlyExamples)
+                .contains("## profile")
+                .contains("## behavior")
+                .contains("## event")
+                .doesNotContain("## tool")
+                .doesNotContain("## directive")
+                .doesNotContain("## playbook")
+                .doesNotContain("## resolution");
+        assertThat(agentOnlyExamples)
+                .contains("## tool")
+                .doesNotContain("## profile")
+                .doesNotContain("## behavior")
+                .doesNotContain("## event");
+        assertThat(allExamples)
+                .contains("## profile")
+                .contains("## behavior")
+                .contains("## event")
+                .contains("## tool")
+                .contains("## directive")
+                .contains("## playbook")
+                .contains("## resolution");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should require durable value and filter low-value chatter")
+    void shouldRequireDurableValueAndFilterLowValueChatter() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.values()));
+
+        assertThat(systemPrompt)
+                .contains("likely to remain useful beyond the current turn")
+                .contains("future days, weeks, or months")
+                .contains("Do not create a memory item just because a sentence is factual")
+                .contains("generic greetings")
+                .contains("pure acknowledgements")
+                .contains("process chatter")
+                .contains("temporary status updates")
+                .contains("one-off control messages")
+                .contains("vague summaries without actionable or retrievable detail");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should preserve user permissive and agent strict extraction bias")
+    void shouldPreserveExtractionBiasGradient() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.values()));
+
+        assertThat(systemPrompt)
+                .contains("For USER-scope categories")
+                .contains("profile")
+                .contains("behavior")
+                .contains("event")
+                .contains("extract clearly stated facts even if they seem minor")
+                .contains("For AGENT-scope categories")
+                .contains("tool")
+                .contains("directive")
+                .contains("playbook")
+                .contains("resolution")
+                .contains("use strict precision")
+                .contains("If uncertain between AGENT memory and nothing, prefer nothing");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should preserve important semantic dimensions")
+    void shouldRenderContentPreservationChecklist() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.values()));
+
+        assertThat(systemPrompt)
+                .contains("Preserve who")
+                .contains("what")
+                .contains("when")
+                .contains("where")
+                .contains("why")
+                .contains("important relationships")
+                .contains("comparisons")
+                .contains("capabilities")
+                .contains("attitudes")
+                .contains("intent")
+                .contains("Do not compress away the detail that makes the memory useful");
+    }
+
+    @Test
+    @DisplayName("Rendered prompt should keep key common confusion examples")
+    void shouldKeepKeyCommonConfusionExamples() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.values()));
+
+        assertThat(systemPrompt)
+                .contains("We use Redis/Kafka/X for purpose Y")
+                .contains("Currently learning/reading/migrating X")
+                .contains("Teammate Zhang is responsible for backend services")
+                .contains("Assistant says 'be gentle with yourself'")
+                .contains("Do NOT extract unless the user later adopts it")
+                .contains("User follows a fixed process or SOP for X");
+    }
+
+    @Test
+    @DisplayName("Graph-enabled prompt should include entity and coreference quality rules")
+    void graphEnabledPromptShouldIncludeEntityCoreferenceQualityRules() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.EVENT), true);
+
+        assertThat(systemPrompt)
+                .contains("Extract entities only when they help link related memories")
+                .contains("Prefer concrete named entities")
+                .contains("specific durable domain concepts")
+                .contains("Resolve role-only mentions to named entities")
+                .contains("my roommate")
+                .contains("Emily")
+                .contains("Do not create separate entities for generic role mentions")
+                .contains("Do not extract generic nouns such as")
+                .contains("project")
+                .contains("team")
+                .contains("system")
+                .doesNotContain("aliasClass: role")
+                .doesNotContain("role_alias");
+    }
+
+    @Test
+    @DisplayName("Graph-disabled prompt should omit graph rules but keep subject clarity")
+    void graphDisabledPromptShouldOmitGraphRulesButKeepSubjectClarity() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.EVENT), false);
+
+        assertThat(systemPrompt)
+                .doesNotContain("Extract entities only when they help link related memories")
+                .doesNotContain("Resolve role-only mentions to named entities")
+                .doesNotContain("Do not extract generic nouns such as")
+                .doesNotContain("\"entities\"")
+                .doesNotContain("\"causalRelations\"")
+                .contains("# Subject Clarity")
+                .contains("Do NOT use bare pronouns like \"他\", \"她\", \"他们\", or \"自己\"")
+                .contains("If the subject cannot be made explicit from the source text");
+    }
+
+    @Test
+    @DisplayName("Directive example should not duplicate category_reason")
+    void directiveExampleShouldNotDuplicateCategoryReason() {
+        var systemPrompt = renderSystemPrompt(Set.of(MemoryCategory.values()));
+        var directiveStart = systemPrompt.indexOf("## directive");
+        var playbookStart = systemPrompt.indexOf("## playbook");
+
+        assertThat(directiveStart).isGreaterThanOrEqualTo(0);
+        assertThat(playbookStart).isGreaterThan(directiveStart);
+
+        var directiveExample = systemPrompt.substring(directiveStart, playbookStart);
+        assertThat(countOccurrences(directiveExample, "\"category_reason\"")).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("Rendered prompt should include graph schema only when graph is enabled")
     void shouldIncludeGraphSchemaOnlyWhenGraphIsEnabled() {
         var enabled =
@@ -185,8 +391,8 @@ class MemoryItemUnifiedPromptsTest {
         assertThat(template.describeStructure())
                 .contains(
                         "Sections: objective, principles, extractionScope, extractionBias,"
-                                + " categoryContext, identityContext, subjectContext,"
-                                + " temporalContext, scoring, output, examples");
+                                + " contentPreservation, categoryContext, identityContext,"
+                                + " subjectContext, temporalContext, scoring, output, examples");
         assertThat(result.systemPrompt()).contains("## Decision Logic");
         assertThat(result.systemPrompt()).contains("## Category Definitions");
         assertThat(result.systemPrompt()).contains("**profile**");
@@ -220,7 +426,7 @@ class MemoryItemUnifiedPromptsTest {
                 .contains("directive")
                 .contains("playbook")
                 .contains("resolution")
-                .contains("if uncertain between agent memory and nothing, prefer nothing")
+                .contains("If uncertain between AGENT memory and nothing, prefer nothing")
                 .contains("one-off control messages");
     }
 
@@ -399,6 +605,53 @@ class MemoryItemUnifiedPromptsTest {
 
         assertThat(result.systemPrompt()).contains("Custom unified extraction instruction");
         assertThat(result.systemPrompt()).doesNotContain("# Core Principles");
+    }
+
+    private static String renderSystemPrompt(Set<MemoryCategory> categories) {
+        return MemoryItemUnifiedPrompts.build(
+                        List.of(),
+                        "user: Please remember the durable project preference",
+                        Instant.parse("2026-04-16T00:00:00Z"),
+                        "Ada",
+                        categories,
+                        ItemGraphOptions.defaults().withEnabled(true))
+                .render("English")
+                .systemPrompt();
+    }
+
+    private static String renderSystemPrompt(Set<MemoryCategory> categories, boolean graphEnabled) {
+        return MemoryItemUnifiedPrompts.build(
+                        List.of(),
+                        "user: Please remember the durable project preference",
+                        Instant.parse("2026-04-16T00:00:00Z"),
+                        "Ada",
+                        categories,
+                        ItemGraphOptions.defaults().withEnabled(graphEnabled))
+                .render("English")
+                .systemPrompt();
+    }
+
+    private static String categoryDefinitionsSection(String systemPrompt) {
+        var start = systemPrompt.indexOf("## Category Definitions");
+        var end = systemPrompt.indexOf("# Identity", start);
+        assertThat(start).isGreaterThanOrEqualTo(0);
+        assertThat(end).isGreaterThan(start);
+        return systemPrompt.substring(start, end);
+    }
+
+    private static String examplesSection(String systemPrompt) {
+        var start = systemPrompt.indexOf("# Examples by Category");
+        return start < 0 ? "" : systemPrompt.substring(start);
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        var count = 0;
+        var index = 0;
+        while ((index = text.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
     }
 
     private static MemoryInsightType createInsightType(String name, List<String> categories) {


### PR DESCRIPTION
## Summary
- strengthen durable-value and low-value filtering guidance in the unified memory item extraction prompt
- preserve USER/AGENT category semantics while rendering category examples only for allowed categories
- add graph entity/coreference guidance and regression tests for prompt rendering contracts

## Validation
- mvn -pl memind-core -Dtest=MemoryItemUnifiedPromptsTest test
- mvn -pl memind-core test
- mvn -pl memind-core spotless:check
- mvn clean install