### PR TITLE
feat: add Maven Central release workflow

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -1,0 +1,80 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Maven Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Maven release version, for example 0.2.0
+        required: true
+        type: string
+      auto_publish:
+        description: Publish automatically after Central Portal validation
+        required: true
+        default: false
+        type: boolean
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            version="${{ inputs.version }}"
+            auto_publish="${{ inputs.auto_publish }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+            auto_publish="false"
+          fi
+
+          if [[ -z "${version}" || "${version}" == *"-SNAPSHOT" ]]; then
+            echo "Release version must be non-empty and must not end with -SNAPSHOT." >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "auto_publish=${auto_publish}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Build and deploy to Central Portal
+        run: mvn -B -Prelease -Drevision=${{ steps.version.outputs.version }} -Dcentral.autoPublish=${{ steps.version.outputs.auto_publish }} clean deploy
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/memind-dependencies/pom.xml
+++ b/memind-dependencies/pom.xml
@@ -1,13 +1,59 @@
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.openmemind.ai</groupId>
     <artifactId>memind-dependencies</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>Memind - Dependencies Bom</name>
+    <description>Dependency management BOM for Memind modules.</description>
+    <url>https://github.com/openmemind/memind</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>openmemind</id>
+            <name>OpenMemind Contributors</name>
+            <organization>OpenMemind</organization>
+            <organizationUrl>https://github.com/openmemind</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/openmemind/memind.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/openmemind/memind.git</developerConnection>
+        <url>https://github.com/openmemind/memind</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/openmemind/memind/issues</url>
+    </issueManagement>
 
     <properties>
         <revision>0.2.0-SNAPSHOT</revision>
@@ -48,7 +94,6 @@
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <google-java-format.version>1.28.0</google-java-format.version>
         <maven.deploy.skip>false</maven.deploy.skip>
-        <central.publishing.maven.version>0.10.0</central.publishing.maven.version>
     </properties>
 
     <dependencyManagement>
@@ -361,4 +406,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <configuration>
+                            <bestPractices>true</bestPractices>
+                            <passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/memind-evaluation/pom.xml
+++ b/memind-evaluation/pom.xml
@@ -29,6 +29,10 @@
     <name>Memind - Evaluation</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.openmemind.ai</groupId>

--- a/memind-server/pom.xml
+++ b/memind-server/pom.xml
@@ -30,6 +30,10 @@
     <name>Memind - Server</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.openmemind.ai</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,39 @@
     <packaging>pom</packaging>
     <version>${revision}</version>
     <name>Memind - Parent</name>
+    <description>Open-source memory infrastructure for AI applications.</description>
+    <url>https://github.com/openmemind/memind</url>
 
     <inceptionYear>2026</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>openmemind</id>
+            <name>OpenMemind Contributors</name>
+            <organization>OpenMemind</organization>
+            <organizationUrl>https://github.com/openmemind</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/openmemind/memind.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/openmemind/memind.git</developerConnection>
+        <url>https://github.com/openmemind/memind</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/openmemind/memind/issues</url>
+    </issueManagement>
 
     <modules>
         <module>memind-dependencies</module>
@@ -51,9 +82,13 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <google-java-format.version>1.28.0</google-java-format.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <central.autoPublish>false</central.autoPublish>
+        <central.skipPublishing>false</central.skipPublishing>
+        <central.waitUntil>validated</central.waitUntil>
 
         <license.plugin.version>4.1</license.plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -344,4 +379,51 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <configuration>
+                            <bestPractices>true</bestPractices>
+                            <passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <deploymentName>Memind ${revision}</deploymentName>
+                            <autoPublish>${central.autoPublish}</autoPublish>
+                            <skipPublishing>${central.skipPublishing}</skipPublishing>
+                            <waitUntil>${central.waitUntil}</waitUntil>
+                            <excludeArtifacts>
+                                <excludeArtifact>memind-server</excludeArtifact>
+                                <excludeArtifact>memind-evaluation</excludeArtifact>
+                                <excludeArtifact>memind-examples</excludeArtifact>
+                                <excludeArtifact>memind-example-java</excludeArtifact>
+                            </excludeArtifacts>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Summary
- Add Maven Central release metadata to the parent POM and standalone BOM.
- Add a release profile with GPG signing and Sonatype Central Portal publishing.
- Exclude runnable apps, evaluation tooling, and examples from Maven deployment.
- Add a GitHub Actions workflow for manual and tag-driven Maven releases.

## Test Plan
- git diff --check
- mvn com.mycila:license-maven-plugin:4.1:check
- mvn -Prelease -Drevision=0.2.0 -Dcentral.skipPublishing=true validate
