### PR TITLE
feat: docker compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.idea
+.vscode
+**/target
+**/node_modules
+**/dist
+memind-ui
+**/.DS_Store
+**/.env
+**/.env.*
+docs/superpowers

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 services:
   memind-server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  memind-server:
+    build:
+      context: .
+      dockerfile: memind-server/Dockerfile
+    image: memind-server:local
+    container_name: memind-server
+    environment:
+      SERVER_PORT: 8366
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://openrouter.ai/api}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-123}
+      OPENAI_CHAT_MODEL: ${OPENAI_CHAT_MODEL:-openai/gpt-4o-mini}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-openai/text-embedding-3-small}
+      MEMIND_DATASOURCE_URL: jdbc:sqlite:/app/data/memind-server.db
+      MEMIND_VECTOR_STORE_PATH: /app/data/vector-store.json
+      MEMIND_RERANK_BASE_URL: ${MEMIND_RERANK_BASE_URL:-https://aihubmix.com}
+      MEMIND_RERANK_API_KEY: ${MEMIND_RERANK_API_KEY:-}
+      MEMIND_RERANK_MODEL: ${MEMIND_RERANK_MODEL:-jina-reranker-v3}
+    volumes:
+      - memind-data:/app/data
+    ports:
+      - "${MEMIND_SERVER_PORT:-8366}:8366"
+    restart: unless-stopped
+
+  memind-ui:
+    build:
+      context: memind-ui
+      dockerfile: Dockerfile
+    image: memind-ui:local
+    container_name: memind-ui
+    depends_on:
+      - memind-server
+    ports:
+      - "${MEMIND_UI_PORT:-8080}:80"
+    restart: unless-stopped
+
+volumes:
+  memind-data:

--- a/memind-server/Dockerfile
+++ b/memind-server/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3.9.11-eclipse-temurin-21 AS build
+WORKDIR /workspace
+
+COPY . .
+RUN mvn -pl memind-server -am -DskipTests -Dmaven.javadoc.skip=true \
+        -Dlicense.skip=true -Dcheckstyle.skip=true package \
+    && JAR="$(find memind-server/target -maxdepth 1 -type f -name 'memind-server-*.jar' \
+        ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*.original' | head -n 1)" \
+    && test -n "$JAR" \
+    && cp "$JAR" /workspace/memind-server.jar
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+RUN mkdir -p /app/data
+COPY --from=build /workspace/memind-server.jar /app/memind-server.jar
+
+EXPOSE 8366
+ENTRYPOINT ["java", "-jar", "/app/memind-server.jar"]

--- a/memind-server/Dockerfile
+++ b/memind-server/Dockerfile
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM maven:3.9.11-eclipse-temurin-21 AS build
 WORKDIR /workspace
 

--- a/memind-ui/.dockerignore
+++ b/memind-ui/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.DS_Store
+.env
+.env.*

--- a/memind-ui/Caddyfile
+++ b/memind-ui/Caddyfile
@@ -1,0 +1,17 @@
+:80 {
+	root * /srv
+	encode zstd gzip
+
+	handle /admin/* {
+		reverse_proxy memind-server:8366
+	}
+
+	handle /open/* {
+		reverse_proxy memind-server:8366
+	}
+
+	handle {
+		try_files {path} /index.html
+		file_server
+	}
+}

--- a/memind-ui/Dockerfile
+++ b/memind-ui/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM caddy:2-alpine
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /srv
+
+EXPOSE 80

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,7 @@
                         <exclude>data/**</exclude>
                         <exclude>etc/**</exclude>
                         <exclude>eval-data/**</exclude>
+                        <exclude>memind-integrations/claude-code/**</exclude>
                         <exclude>memind-integrations/codex/**</exclude>
                         <exclude>memind-ui/**</exclude>
                         <exclude>memind-evaluation/data/**</exclude>


### PR DESCRIPTION
## Summary

  - Add Docker Compose setup for running `memind-server` and `memind-ui` together.
  - Add a production-style `memind-server` Dockerfile that builds the Spring Boot jar in a Maven stage and runs it on
  JRE 21.
  - Add a `memind-ui` Dockerfile using Caddy to serve the built Vite app.
  - Add `memind-ui/Caddyfile` to serve SPA routes and reverse proxy `/admin/*` and `/open/*` to `memind-server:8366`.
  - Add Docker ignore files to keep build contexts small.

  ## How to Run

  ```bash
  OPENAI_API_KEY=your-key docker compose up --build

  Then open:

  http://localhost:8080

  The server is also exposed on:

  http://localhost:8366

  ## Verification

  - docker compose config --quiet
  - docker compose build --check
  - caddy validate --config /etc/caddy/Caddyfile
  - docker compose up --build -d

  ## Notes

  memind-server requires OPENAI_API_KEY at startup because Spring AI creates the embedding model during application
  initialization. Without the key, the server container restarts with OpenAI API key must be set.