### PR TITLE
Optimize memory thread replay reads

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/NoOpThreadDerivationMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/NoOpThreadDerivationMetrics.java
@@ -38,6 +38,9 @@ public final class NoOpThreadDerivationMetrics implements ThreadDerivationMetric
     public void onReplayPublished(ThreadReplayOrigin origin) {}
 
     @Override
+    public void onReplayStats(ThreadReplayStats stats) {}
+
+    @Override
     public void onProviderHit(String providerName) {}
 
     @Override

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadDerivationMetrics.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadDerivationMetrics.java
@@ -18,7 +18,36 @@ package com.openmemind.ai.memory.core.extraction.thread;
  */
 public interface ThreadDerivationMetrics {
 
-    ThreadDerivationMetrics NOOP = NoOpThreadDerivationMetrics.INSTANCE;
+    ThreadDerivationMetrics NOOP =
+            new ThreadDerivationMetrics() {
+                @Override
+                public void onWakeScheduled() {}
+
+                @Override
+                public void onWakeSubmissionFailed() {}
+
+                @Override
+                public void onClaimedBatch(int batchSize) {}
+
+                @Override
+                public void onCoalescedReplayCutoffs(int coveredCutoffCount) {}
+
+                @Override
+                public void onReplayPublished(ThreadReplayOrigin origin) {}
+
+                @Override
+                public void onReplayStats(ThreadReplayStats stats) {}
+
+                @Override
+                public void onProviderHit(String providerName) {}
+
+                @Override
+                public void onGroupRelationshipPublished() {}
+
+                @Override
+                public void onNonAdmission(
+                        ThreadNonAdmissionDisposition disposition, String reason) {}
+            };
 
     void onWakeScheduled();
 
@@ -29,6 +58,8 @@ public interface ThreadDerivationMetrics {
     void onCoalescedReplayCutoffs(int coveredCutoffCount);
 
     void onReplayPublished(ThreadReplayOrigin origin);
+
+    default void onReplayStats(ThreadReplayStats stats) {}
 
     void onProviderHit(String providerName);
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadIntakeWorker.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadIntakeWorker.java
@@ -154,6 +154,7 @@ public class ThreadIntakeWorker {
                         .mapToLong(MemoryThreadIntakeClaim::triggerItemId)
                         .max()
                         .orElseThrow();
+        long replayStartedNanos = System.nanoTime();
         try {
             ThreadProjectionMaterializer.MaterializedProjection projection =
                     materializer.materializeUpTo(memoryId, replayCutoffItemId);
@@ -180,7 +181,15 @@ public class ThreadIntakeWorker {
                 store.releaseClaims(memoryId, claimed);
                 return false;
             }
-            notifyReplaySuccess(memoryId, claimed, projection, replayCutoffItemId, finalizedAt);
+            ThreadReplayStats stats =
+                    ThreadReplayStats.from(
+                            ThreadReplayOrigin.INTAKE_BATCH,
+                            replayStartedNanos,
+                            replayCutoffItemId,
+                            claimed.size(),
+                            projection);
+            notifyReplaySuccess(
+                    memoryId, claimed, projection, replayCutoffItemId, finalizedAt, stats);
             return true;
         } catch (RuntimeException e) {
             Instant failedAt = Instant.now();
@@ -230,9 +239,11 @@ public class ThreadIntakeWorker {
             List<MemoryThreadIntakeClaim> claimed,
             ThreadProjectionMaterializer.MaterializedProjection projection,
             long cutoffItemId,
-            Instant finalizedAt) {
+            Instant finalizedAt,
+            ThreadReplayStats stats) {
         metrics.onCoalescedReplayCutoffs(claimed.size());
         metrics.onReplayPublished(ThreadReplayOrigin.INTAKE_BATCH);
+        metrics.onReplayStats(stats);
         if (containsGroupRelationshipThread(projection.threads())) {
             metrics.onGroupRelationshipPublished();
         }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionMaterializer.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionMaterializer.java
@@ -113,18 +113,14 @@ class ThreadProjectionMaterializer {
         List<MemoryThreadEnrichmentInput> enrichmentInputs =
                 enrichmentInputStore.listReplayable(memoryId, cutoffItemId, policy.version());
 
-        List<MemoryItem> items =
-                itemOperations.listItems(memoryId).stream()
-                        .filter(item -> item.id() != null && item.id() <= cutoffItemId)
-                        .sorted(Comparator.comparing(MemoryItem::id))
-                        .toList();
+        List<MemoryItem> items = itemOperations.listItemsUpTo(memoryId, cutoffItemId);
         if (items.isEmpty()) {
             return MaterializedProjection.empty();
         }
 
         Set<Long> itemIds = items.stream().map(MemoryItem::id).collect(Collectors.toSet());
         Map<Long, List<ItemEntityMention>> mentionsByItemId =
-                graphOperations.listItemEntityMentions(memoryId).stream()
+                graphOperations.listItemEntityMentions(memoryId, itemIds).stream()
                         .filter(mention -> itemIds.contains(mention.itemId()))
                         .collect(
                                 Collectors.groupingBy(
@@ -272,7 +268,22 @@ class ThreadProjectionMaterializer {
                                         .thenComparing(MemoryThreadMembership::role))
                         .toList();
 
-        return new MaterializedProjection(threads, events, memberships, items.getLast().id());
+        int loadedMentionCount = mentionsByItemId.values().stream().mapToInt(List::size).sum();
+        int loadedAdjacentLinkCount =
+                adjacentLinksByItemId.values().stream()
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toSet())
+                        .size();
+
+        return new MaterializedProjection(
+                threads,
+                events,
+                memberships,
+                items.getLast().id(),
+                items.size(),
+                loadedMentionCount,
+                loadedAdjacentLinkCount,
+                cooccurrences.size());
     }
 
     private void applyEnrichmentInput(
@@ -445,7 +456,7 @@ class ThreadProjectionMaterializer {
 
     private Map<Long, List<ItemLink>> adjacentLinksByItemId(MemoryId memoryId, Set<Long> itemIds) {
         Map<Long, List<ItemLink>> linksByItemId = new LinkedHashMap<>();
-        for (ItemLink link : graphOperations.listItemLinks(memoryId)) {
+        for (ItemLink link : graphOperations.listAdjacentItemLinks(memoryId, itemIds, List.of())) {
             if (itemIds.contains(link.sourceItemId())) {
                 linksByItemId
                         .computeIfAbsent(link.sourceItemId(), ignored -> new ArrayList<>())
@@ -615,10 +626,22 @@ class ThreadProjectionMaterializer {
             List<MemoryThreadProjection> threads,
             List<MemoryThreadEvent> events,
             List<MemoryThreadMembership> memberships,
-            Long lastProcessedItemId) {
+            Long lastProcessedItemId,
+            int loadedItemCount,
+            int loadedMentionCount,
+            int loadedAdjacentLinkCount,
+            int loadedCooccurrenceCount) {
+
+        public MaterializedProjection(
+                List<MemoryThreadProjection> threads,
+                List<MemoryThreadEvent> events,
+                List<MemoryThreadMembership> memberships,
+                Long lastProcessedItemId) {
+            this(threads, events, memberships, lastProcessedItemId, 0, 0, 0, 0);
+        }
 
         static MaterializedProjection empty() {
-            return new MaterializedProjection(List.of(), List.of(), List.of(), null);
+            return new MaterializedProjection(List.of(), List.of(), List.of(), null, 0, 0, 0, 0);
         }
     }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionRebuilder.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionRebuilder.java
@@ -99,13 +99,7 @@ public class ThreadProjectionRebuilder {
 
     public void rebuild(MemoryId memoryId) {
         Objects.requireNonNull(memoryId, "memoryId");
-        long cutoff =
-                itemOperations.listItems(memoryId).stream()
-                        .map(item -> item.id())
-                        .filter(Objects::nonNull)
-                        .mapToLong(Long::longValue)
-                        .max()
-                        .orElse(0L);
+        long cutoff = itemOperations.maxItemId(memoryId).orElse(0L);
         rebuild(memoryId, cutoff);
     }
 
@@ -122,6 +116,7 @@ public class ThreadProjectionRebuilder {
                         .sorted()
                         .toList();
 
+        long replayStartedNanos = System.nanoTime();
         try {
             ThreadProjectionMaterializer.MaterializedProjection projection =
                     materializer.materializeUpTo(memoryId, rebuildCutoffItemId);
@@ -140,6 +135,13 @@ public class ThreadProjectionRebuilder {
                     availableRuntime(memoryId, current, lastProcessedItemId, finalizedAt),
                     finalizedAt);
             metrics.onReplayPublished(ThreadReplayOrigin.REBUILD);
+            metrics.onReplayStats(
+                    ThreadReplayStats.from(
+                            ThreadReplayOrigin.REBUILD,
+                            replayStartedNanos,
+                            rebuildCutoffItemId,
+                            coveredTriggerItemIds.size(),
+                            projection));
             if (containsGroupRelationshipThread(projection.threads())) {
                 metrics.onGroupRelationshipPublished();
             }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadReplayStats.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/thread/ThreadReplayStats.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.extraction.thread;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Replay publication statistics emitted after a successful atomic replay commit.
+ *
+ * <p>{@code triggerItemCount} is the number of outbox trigger items covered by the replay. For an
+ * intake replay this is the claimed batch size; for a rebuild this is the number of pending outbox
+ * triggers at or below the rebuild cutoff.
+ *
+ * <p>Loaded counts describe source rows read by the materializer. {@code loadedAdjacentLinkCount}
+ * counts unique item-link rows after per-item adjacency grouping has been de-duplicated. Replaced
+ * counts describe projection rows written by the successful commit.
+ *
+ * <p>{@code durationMillis} is measured from immediately before materialization starts until after
+ * the successful projection commit returns and before replay success listeners run. It therefore
+ * includes materialization and projection-store commit latency.
+ */
+public record ThreadReplayStats(
+        ThreadReplayOrigin origin,
+        long durationMillis,
+        long cutoffItemId,
+        int triggerItemCount,
+        int loadedItemCount,
+        int loadedMentionCount,
+        int loadedAdjacentLinkCount,
+        int loadedCooccurrenceCount,
+        int replacedThreadCount,
+        int replacedEventCount,
+        int replacedMembershipCount) {
+
+    static ThreadReplayStats from(
+            ThreadReplayOrigin origin,
+            long replayStartedNanos,
+            long replayCutoffItemId,
+            int triggerItemCount,
+            ThreadProjectionMaterializer.MaterializedProjection projection) {
+        return new ThreadReplayStats(
+                origin,
+                TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - replayStartedNanos),
+                replayCutoffItemId,
+                triggerItemCount,
+                projection.loadedItemCount(),
+                projection.loadedMentionCount(),
+                projection.loadedAdjacentLinkCount(),
+                projection.loadedCooccurrenceCount(),
+                projection.threads().size(),
+                projection.events().size(),
+                projection.memberships().size());
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/InMemoryMemoryStore.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/InMemoryMemoryStore.java
@@ -23,6 +23,7 @@ import com.openmemind.ai.memory.core.store.insight.InMemoryInsightOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.InMemoryItemOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.rawdata.InMemoryRawDataOperations;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
 import com.openmemind.ai.memory.core.store.resource.InMemoryResourceOperations;
@@ -38,6 +39,9 @@ import com.openmemind.ai.memory.core.store.thread.ThreadProjectionStore;
 public class InMemoryMemoryStore implements MemoryStore {
 
     private final RawDataOperations rawDataOperations = new InMemoryRawDataOperations();
+    static final ItemOperationsCapabilities ITEM_OPERATIONS_CAPABILITIES =
+            new ItemOperationsCapabilities(true, true, true);
+
     private final InMemoryItemOperations itemOperations = new InMemoryItemOperations();
     private final InsightOperations insightOperations = new InMemoryInsightOperations();
     private final InMemoryGraphOperations graphOperations = new InMemoryGraphOperations();
@@ -63,6 +67,11 @@ public class InMemoryMemoryStore implements MemoryStore {
     @Override
     public ItemOperations itemOperations() {
         return itemOperations;
+    }
+
+    @Override
+    public ItemOperationsCapabilities itemOperationsCapabilities() {
+        return ITEM_OPERATIONS_CAPABILITIES;
     }
 
     @Override

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/MemoryStore.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/MemoryStore.java
@@ -24,6 +24,7 @@ import com.openmemind.ai.memory.core.store.graph.NoOpGraphOperations;
 import com.openmemind.ai.memory.core.store.graph.NoOpItemGraphCommitOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
 import com.openmemind.ai.memory.core.store.resource.ResourceOperations;
 import com.openmemind.ai.memory.core.store.thread.NoOpThreadEnrichmentInputStore;
@@ -43,6 +44,10 @@ public interface MemoryStore extends AutoCloseable {
     RawDataOperations rawDataOperations();
 
     ItemOperations itemOperations();
+
+    default ItemOperationsCapabilities itemOperationsCapabilities() {
+        return ItemOperationsCapabilities.defaults();
+    }
 
     InsightOperations insightOperations();
 

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/InMemoryItemOperations.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/InMemoryItemOperations.java
@@ -17,10 +17,13 @@ import com.openmemind.ai.memory.core.data.MemoryId;
 import com.openmemind.ai.memory.core.data.MemoryItem;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -98,6 +101,38 @@ public class InMemoryItemOperations implements ItemOperations {
     @Override
     public List<MemoryItem> listItems(MemoryId id) {
         return new ArrayList<>(itemStore.getOrDefault(key(id), Map.of()).values());
+    }
+
+    @Override
+    public List<MemoryItem> listItemsUpTo(MemoryId id, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        return itemStore.getOrDefault(key(id), Map.of()).values().stream()
+                .filter(item -> item.id() != null && item.id() <= cutoffItemId)
+                .sorted(Comparator.comparing(MemoryItem::id))
+                .toList();
+    }
+
+    @Override
+    public List<MemoryItem> listItemsAfter(MemoryId id, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        return itemStore.getOrDefault(key(id), Map.of()).values().stream()
+                .filter(item -> item.id() != null && item.id() > afterItemId)
+                .sorted(Comparator.comparing(MemoryItem::id))
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public OptionalLong maxItemId(MemoryId id) {
+        return itemStore.getOrDefault(key(id), Map.of()).values().stream()
+                .map(MemoryItem::id)
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .max();
     }
 
     @Override

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/ItemOperations.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/ItemOperations.java
@@ -16,7 +16,10 @@ package com.openmemind.ai.memory.core.store.item;
 import com.openmemind.ai.memory.core.data.MemoryId;
 import com.openmemind.ai.memory.core.data.MemoryItem;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.OptionalLong;
 
 /**
  * Operations for memory item persistence.
@@ -32,6 +35,47 @@ public interface ItemOperations {
     List<MemoryItem> getItemsByContentHashes(MemoryId id, Collection<String> contentHashes);
 
     List<MemoryItem> listItems(MemoryId id);
+
+    /**
+     * Returns existing domain items with non-null ids less than or equal to {@code cutoffItemId},
+     * ordered by {@link MemoryItem#id()} ascending.
+     */
+    default List<MemoryItem> listItemsUpTo(MemoryId id, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        return listItems(id).stream()
+                .filter(item -> item.id() != null && item.id() <= cutoffItemId)
+                .sorted(Comparator.comparing(MemoryItem::id))
+                .toList();
+    }
+
+    /**
+     * Returns existing domain items with non-null ids greater than {@code afterItemId}, ordered by
+     * {@link MemoryItem#id()} ascending and capped to {@code limit}.
+     *
+     * <p>Phase 1 full replay does not call this method. It is added with the same range-read
+     * capability surface so persistent stores can expose a complete low-cost incremental read API
+     * for later intake and replay paths without another source-compatible interface expansion.
+     */
+    default List<MemoryItem> listItemsAfter(MemoryId id, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        return listItems(id).stream()
+                .filter(item -> item.id() != null && item.id() > afterItemId)
+                .sorted(Comparator.comparing(MemoryItem::id))
+                .limit(limit)
+                .toList();
+    }
+
+    default OptionalLong maxItemId(MemoryId id) {
+        return listItems(id).stream()
+                .map(MemoryItem::id)
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .max();
+    }
 
     default List<TemporalCandidateMatch> listTemporalCandidateMatches(
             MemoryId memoryId,

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/ItemOperationsCapabilities.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/ItemOperationsCapabilities.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.store.item;
+
+/**
+ * Capability metadata for item-store read paths used by replay and rebuild code.
+ *
+ * <p>These flags describe store-side pushdown, not merely API availability. Implementations that
+ * inherit correctness-first default methods backed by {@link ItemOperations#listItems(MemoryId)}
+ * should keep the default disabled capabilities.
+ */
+public record ItemOperationsCapabilities(
+        boolean boundedIdLookup, boolean boundedRangeReads, boolean maxItemIdLookup) {
+
+    public static ItemOperationsCapabilities defaults() {
+        return new ItemOperationsCapabilities(false, false, false);
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/RecordingThreadDerivationMetrics.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/RecordingThreadDerivationMetrics.java
@@ -21,6 +21,8 @@ final class RecordingThreadDerivationMetrics implements ThreadDerivationMetrics 
     private final List<Integer> claimedBatchSizes = new ArrayList<>();
     private final List<Integer> coalescedReplayCutoffCounts = new ArrayList<>();
     private final List<ThreadReplayOrigin> replayOrigins = new ArrayList<>();
+    private final List<ThreadReplayStats> replayStats = new ArrayList<>();
+    private final List<String> replayMetricEvents = new ArrayList<>();
     private final List<String> providerHits = new ArrayList<>();
     private final List<String> nonAdmissions = new ArrayList<>();
     private int wakeScheduledCount;
@@ -50,6 +52,13 @@ final class RecordingThreadDerivationMetrics implements ThreadDerivationMetrics 
     @Override
     public void onReplayPublished(ThreadReplayOrigin origin) {
         replayOrigins.add(origin);
+        replayMetricEvents.add("published:" + origin);
+    }
+
+    @Override
+    public void onReplayStats(ThreadReplayStats stats) {
+        replayStats.add(stats);
+        replayMetricEvents.add("stats:" + stats.origin());
     }
 
     @Override
@@ -77,6 +86,14 @@ final class RecordingThreadDerivationMetrics implements ThreadDerivationMetrics 
 
     List<ThreadReplayOrigin> replayOrigins() {
         return List.copyOf(replayOrigins);
+    }
+
+    List<ThreadReplayStats> replayStats() {
+        return List.copyOf(replayStats);
+    }
+
+    List<String> replayMetricEvents() {
+        return List.copyOf(replayMetricEvents);
     }
 
     List<String> providerHits() {

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadIntakeWorkerTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadIntakeWorkerTest.java
@@ -129,7 +129,7 @@ class ThreadIntakeWorkerTest {
         when(materializer.materializeUpTo(memoryId, 402L))
                 .thenReturn(
                         new ThreadProjectionMaterializer.MaterializedProjection(
-                                List.of(), List.of(), List.of(), 402L));
+                                List.of(), List.of(), List.of(), 402L, 2, 3, 1, 0));
         RecordingThreadDerivationMetrics metrics = new RecordingThreadDerivationMetrics();
         ThreadIntakeWorker worker =
                 new ThreadIntakeWorker(
@@ -140,6 +140,26 @@ class ThreadIntakeWorkerTest {
         assertThat(metrics.claimedBatchSizes()).containsExactly(2);
         assertThat(metrics.coalescedReplayCutoffCounts()).containsExactly(2);
         assertThat(metrics.replayOrigins()).containsExactly(ThreadReplayOrigin.INTAKE_BATCH);
+        assertThat(metrics.replayMetricEvents())
+                .containsExactly(
+                        "published:" + ThreadReplayOrigin.INTAKE_BATCH,
+                        "stats:" + ThreadReplayOrigin.INTAKE_BATCH);
+        assertThat(metrics.replayStats())
+                .singleElement()
+                .satisfies(
+                        stats -> {
+                            assertThat(stats.origin()).isEqualTo(ThreadReplayOrigin.INTAKE_BATCH);
+                            assertThat(stats.triggerItemCount()).isEqualTo(2);
+                            assertThat(stats.cutoffItemId()).isEqualTo(402L);
+                            assertThat(stats.loadedItemCount()).isEqualTo(2);
+                            assertThat(stats.loadedMentionCount()).isEqualTo(3);
+                            assertThat(stats.loadedAdjacentLinkCount()).isEqualTo(1);
+                            assertThat(stats.loadedCooccurrenceCount()).isEqualTo(0);
+                            assertThat(stats.replacedThreadCount()).isEqualTo(0);
+                            assertThat(stats.replacedEventCount()).isEqualTo(0);
+                            assertThat(stats.replacedMembershipCount()).isEqualTo(0);
+                            assertThat(stats.durationMillis()).isGreaterThanOrEqualTo(0L);
+                        });
     }
 
     @Test

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionMaterializerTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionMaterializerTest.java
@@ -27,12 +27,18 @@ import com.openmemind.ai.memory.core.store.InMemoryMemoryStore;
 import com.openmemind.ai.memory.core.store.graph.EntityCooccurrence;
 import com.openmemind.ai.memory.core.store.graph.InMemoryGraphOperations;
 import com.openmemind.ai.memory.core.store.graph.ItemEntityMention;
+import com.openmemind.ai.memory.core.store.graph.ItemLink;
+import com.openmemind.ai.memory.core.store.graph.ItemLinkType;
 import com.openmemind.ai.memory.core.store.item.InMemoryItemOperations;
 import com.openmemind.ai.memory.core.support.TestMemoryIds;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ThreadProjectionMaterializerTest {
@@ -476,6 +482,73 @@ class ThreadProjectionMaterializerTest {
     }
 
     @Test
+    void materializeUpToUsesBoundedItemMentionAndAdjacentLinkReads() {
+        MemoryId memoryId = TestMemoryIds.userAgent();
+        TrackingItemOperations itemOperations = new TrackingItemOperations();
+        TrackingGraphOperations graphOperations = new TrackingGraphOperations();
+        ThreadProjectionMaterializer materializer =
+                new ThreadProjectionMaterializer(
+                        itemOperations, graphOperations, ThreadMaterializationPolicy.v1());
+
+        itemOperations.insertItems(
+                memoryId,
+                List.of(
+                        item(301L, "The user planned a trip."),
+                        item(302L, "The user booked the trip."),
+                        item(999L, "This future item is outside the cutoff.")));
+        graphOperations.upsertItemEntityMentions(
+                memoryId,
+                List.of(
+                        mention(memoryId, 301L, "concept:travel"),
+                        mention(memoryId, 302L, "concept:travel"),
+                        mention(memoryId, 999L, "concept:future")));
+        graphOperations.upsertItemLinks(
+                memoryId,
+                List.of(
+                        new ItemLink(
+                                memoryId.toIdentifier(),
+                                301L,
+                                302L,
+                                ItemLinkType.SEMANTIC,
+                                null,
+                                "entity_overlap",
+                                0.8d,
+                                Map.of("source", "test"),
+                                Instant.parse("2026-04-20T09:00:00Z")),
+                        new ItemLink(
+                                memoryId.toIdentifier(),
+                                302L,
+                                999L,
+                                ItemLinkType.SEMANTIC,
+                                null,
+                                "entity_overlap",
+                                0.6d,
+                                Map.of("source", "cross-cutoff-test"),
+                                Instant.parse("2026-04-20T09:00:00Z")),
+                        new ItemLink(
+                                memoryId.toIdentifier(),
+                                1000L,
+                                301L,
+                                ItemLinkType.SEMANTIC,
+                                null,
+                                "entity_overlap",
+                                0.7d,
+                                Map.of("source", "target-side-test"),
+                                Instant.parse("2026-04-20T09:00:00Z"))));
+
+        ThreadProjectionMaterializer.MaterializedProjection projection =
+                materializer.materializeUpTo(memoryId, 302L);
+
+        assertThat(projection.lastProcessedItemId()).isEqualTo(302L);
+        assertThat(itemOperations.listItemsUpToCutoffs).containsExactly(302L);
+        assertThat(graphOperations.mentionItemIds).containsExactlyInAnyOrder(301L, 302L);
+        assertThat(graphOperations.adjacentSeedItemIds).containsExactlyInAnyOrder(301L, 302L);
+        assertThat(graphOperations.adjacentLinkPairs)
+                .containsExactlyInAnyOrder("301->302", "302->999", "1000->301");
+        assertThat(graphOperations.fullCooccurrenceReads).isEqualTo(1);
+    }
+
+    @Test
     void exactAnchorShortCircuitsBeforeMaxCandidateThreadsTruncation() {
         MemoryId memoryId = TestMemoryIds.userAgent();
         InMemoryMemoryStore store = new InMemoryMemoryStore();
@@ -661,6 +734,68 @@ class ThreadProjectionMaterializerTest {
                                     .containsEntry("lastEnrichedMeaningfulEventCount", 2L)
                                     .containsEntry("headlineSource", "THREAD_LLM");
                         });
+    }
+
+    private static final class TrackingItemOperations extends InMemoryItemOperations {
+        private final List<Long> listItemsUpToCutoffs = new ArrayList<>();
+
+        @Override
+        public List<MemoryItem> listItems(MemoryId id) {
+            throw new AssertionError("materializeUpTo must not read all memory items");
+        }
+
+        @Override
+        public List<MemoryItem> listItemsUpTo(MemoryId id, long cutoffItemId) {
+            listItemsUpToCutoffs.add(cutoffItemId);
+            return super.listItems(id).stream()
+                    .filter(item -> item.id() != null && item.id() <= cutoffItemId)
+                    .sorted(java.util.Comparator.comparing(MemoryItem::id))
+                    .toList();
+        }
+    }
+
+    private static final class TrackingGraphOperations extends InMemoryGraphOperations {
+        private final Set<Long> mentionItemIds = new LinkedHashSet<>();
+        private final Set<Long> adjacentSeedItemIds = new LinkedHashSet<>();
+        private final Set<String> adjacentLinkPairs = new LinkedHashSet<>();
+        private int fullCooccurrenceReads;
+
+        @Override
+        public List<ItemEntityMention> listItemEntityMentions(MemoryId memoryId) {
+            throw new AssertionError("materializeUpTo must not read all item entity mentions");
+        }
+
+        @Override
+        public List<ItemEntityMention> listItemEntityMentions(
+                MemoryId memoryId, Collection<Long> itemIds) {
+            mentionItemIds.addAll(itemIds);
+            return super.listItemEntityMentions(memoryId, itemIds);
+        }
+
+        @Override
+        public List<ItemLink> listItemLinks(MemoryId memoryId) {
+            throw new AssertionError("materializeUpTo must not read all item links");
+        }
+
+        @Override
+        public List<ItemLink> listAdjacentItemLinks(
+                MemoryId memoryId,
+                Collection<Long> seedItemIds,
+                Collection<ItemLinkType> linkTypes) {
+            adjacentSeedItemIds.addAll(seedItemIds);
+            List<ItemLink> links = super.listAdjacentItemLinks(memoryId, seedItemIds, linkTypes);
+            links.forEach(
+                    link ->
+                            adjacentLinkPairs.add(
+                                    link.sourceItemId() + "->" + link.targetItemId()));
+            return links;
+        }
+
+        @Override
+        public List<EntityCooccurrence> listEntityCooccurrences(MemoryId memoryId) {
+            fullCooccurrenceReads++;
+            return super.listEntityCooccurrences(memoryId);
+        }
     }
 
     private static ThreadProjectionMaterializer materializer(InMemoryMemoryStore store) {

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionRebuilderTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/thread/ThreadProjectionRebuilderTest.java
@@ -29,14 +29,17 @@ import com.openmemind.ai.memory.core.data.enums.MemoryItemType;
 import com.openmemind.ai.memory.core.data.enums.MemoryScope;
 import com.openmemind.ai.memory.core.data.enums.MemoryThreadIntakeStatus;
 import com.openmemind.ai.memory.core.data.enums.MemoryThreadProjectionState;
+import com.openmemind.ai.memory.core.data.thread.MemoryThreadRuntimeState;
 import com.openmemind.ai.memory.core.store.InMemoryMemoryStore;
 import com.openmemind.ai.memory.core.store.graph.ItemEntityMention;
+import com.openmemind.ai.memory.core.store.item.InMemoryItemOperations;
 import com.openmemind.ai.memory.core.store.thread.InMemoryThreadProjectionStore;
 import com.openmemind.ai.memory.core.support.TestMemoryIds;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 
 class ThreadProjectionRebuilderTest {
@@ -205,6 +208,78 @@ class ThreadProjectionRebuilderTest {
 
         assertThat(metrics.replayOrigins()).containsExactly(ThreadReplayOrigin.REBUILD);
         assertThat(metrics.groupRelationshipPublishedCount()).isEqualTo(1);
+        assertThat(metrics.replayMetricEvents())
+                .containsExactly(
+                        "published:" + ThreadReplayOrigin.REBUILD,
+                        "stats:" + ThreadReplayOrigin.REBUILD);
+        assertThat(metrics.replayStats())
+                .singleElement()
+                .satisfies(
+                        stats -> {
+                            assertThat(stats.origin()).isEqualTo(ThreadReplayOrigin.REBUILD);
+                            assertThat(stats.cutoffItemId()).isEqualTo(322L);
+                            assertThat(stats.loadedItemCount()).isEqualTo(2);
+                            assertThat(stats.replacedThreadCount()).isEqualTo(1);
+                            assertThat(stats.replacedMembershipCount()).isEqualTo(2);
+                            assertThat(stats.durationMillis()).isGreaterThanOrEqualTo(0L);
+                        });
+    }
+
+    @Test
+    void rebuildWithoutExplicitCutoffUsesMaxItemIdLookup() {
+        MemoryId memoryId = TestMemoryIds.userAgent();
+        MaxOnlyItemOperations itemOperations = new MaxOnlyItemOperations();
+        InMemoryMemoryStore graphBackingStore = new InMemoryMemoryStore();
+        itemOperations.insertItems(
+                memoryId,
+                List.of(
+                        item(301L, "The user planned a trip."),
+                        item(302L, "The user booked the trip.")));
+        graphBackingStore
+                .graphOperations()
+                .upsertItemEntityMentions(
+                        memoryId,
+                        List.of(
+                                mention(memoryId, 301L, "concept:travel"),
+                                mention(memoryId, 302L, "concept:travel")));
+
+        ThreadProjectionRebuilder rebuilder =
+                new ThreadProjectionRebuilder(
+                        graphBackingStore.threadOperations(),
+                        itemOperations,
+                        graphBackingStore.graphOperations(),
+                        ThreadMaterializationPolicy.v1());
+
+        rebuilder.rebuild(memoryId);
+
+        assertThat(itemOperations.maxItemIdCalls).isEqualTo(1);
+        assertThat(graphBackingStore.threadOperations().getRuntime(memoryId))
+                .get()
+                .extracting(MemoryThreadRuntimeState::lastProcessedItemId)
+                .isEqualTo(302L);
+    }
+
+    private static final class MaxOnlyItemOperations extends InMemoryItemOperations {
+        private int maxItemIdCalls;
+
+        @Override
+        public List<MemoryItem> listItems(MemoryId id) {
+            throw new AssertionError("rebuild(memoryId) must use maxItemId for cutoff discovery");
+        }
+
+        @Override
+        public List<MemoryItem> listItemsUpTo(MemoryId id, long cutoffItemId) {
+            return super.listItems(id).stream()
+                    .filter(item -> item.id() != null && item.id() <= cutoffItemId)
+                    .sorted(java.util.Comparator.comparing(MemoryItem::id))
+                    .toList();
+        }
+
+        @Override
+        public OptionalLong maxItemId(MemoryId id) {
+            maxItemIdCalls++;
+            return super.maxItemId(id);
+        }
     }
 
     private static MemoryItem item(long itemId, String content) {

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/store/item/ItemOperationsRangeTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/store/item/ItemOperationsRangeTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.store.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.data.DefaultMemoryId;
+import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.data.MemoryItem;
+import com.openmemind.ai.memory.core.data.enums.MemoryCategory;
+import com.openmemind.ai.memory.core.data.enums.MemoryItemType;
+import com.openmemind.ai.memory.core.data.enums.MemoryScope;
+import com.openmemind.ai.memory.core.store.InMemoryMemoryStore;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ItemOperationsRangeTest {
+
+    private static final MemoryId MEMORY_ID = DefaultMemoryId.of("user-1", "agent-1");
+    private static final Instant NOW = Instant.parse("2026-05-09T00:00:00Z");
+
+    @Test
+    void defaultListItemsUpToReturnsDomainIdsInAscendingOrder() {
+        ItemOperations ops =
+                new StaticItemOperations(
+                        List.of(item(8L), item(2L), item(null), item(5L), item(12L)));
+
+        assertThat(ops.listItemsUpTo(MEMORY_ID, 8L))
+                .extracting(MemoryItem::id)
+                .containsExactly(2L, 5L, 8L);
+    }
+
+    @Test
+    void defaultListItemsAfterHonorsDomainIdOrderAndLimit() {
+        ItemOperations ops =
+                new StaticItemOperations(List.of(item(30L), item(10L), item(20L), item(40L)));
+
+        assertThat(ops.listItemsAfter(MEMORY_ID, 10L, 2))
+                .extracting(MemoryItem::id)
+                .containsExactly(20L, 30L);
+        assertThat(ops.listItemsAfter(MEMORY_ID, 10L, 0)).isEmpty();
+    }
+
+    @Test
+    void defaultMaxItemIdIsEmptyWhenNoDomainIdsExist() {
+        assertThat(new StaticItemOperations(List.of(item(null))).maxItemId(MEMORY_ID)).isEmpty();
+        assertThat(new StaticItemOperations(List.of(item(1L), item(7L))).maxItemId(MEMORY_ID))
+                .hasValue(7L);
+    }
+
+    @Test
+    void memoryStoreDefaultsItemCapabilitiesToDisabledAndInMemoryOverridesThem() {
+        assertThat(ItemOperationsCapabilities.defaults().boundedIdLookup()).isFalse();
+        assertThat(ItemOperationsCapabilities.defaults().boundedRangeReads()).isFalse();
+        assertThat(ItemOperationsCapabilities.defaults().maxItemIdLookup()).isFalse();
+
+        assertThat(new InMemoryMemoryStore().itemOperationsCapabilities().boundedIdLookup())
+                .isTrue();
+        assertThat(new InMemoryMemoryStore().itemOperationsCapabilities().boundedRangeReads())
+                .isTrue();
+        assertThat(new InMemoryMemoryStore().itemOperationsCapabilities().maxItemIdLookup())
+                .isTrue();
+    }
+
+    private static MemoryItem item(Long id) {
+        return new MemoryItem(
+                id,
+                MEMORY_ID.toIdentifier(),
+                id == null ? "null id" : "item " + id,
+                MemoryScope.USER,
+                MemoryCategory.PROFILE,
+                "conversation",
+                id == null ? null : "vector-" + id,
+                id == null ? null : "raw-" + id,
+                id == null ? null : "hash-" + id,
+                NOW,
+                NOW,
+                Map.of(),
+                NOW,
+                MemoryItemType.FACT);
+    }
+
+    private record StaticItemOperations(List<MemoryItem> items) implements ItemOperations {
+        @Override
+        public void insertItems(MemoryId id, List<MemoryItem> items) {}
+
+        @Override
+        public List<MemoryItem> getItemsByIds(MemoryId id, Collection<Long> itemIds) {
+            return List.of();
+        }
+
+        @Override
+        public List<MemoryItem> getItemsByVectorIds(MemoryId id, Collection<String> vectorIds) {
+            return List.of();
+        }
+
+        @Override
+        public List<MemoryItem> getItemsByContentHashes(
+                MemoryId id, Collection<String> contentHashes) {
+            return List.of();
+        }
+
+        @Override
+        public List<MemoryItem> listItems(MemoryId id) {
+            return items;
+        }
+
+        @Override
+        public boolean hasItems(MemoryId id) {
+            return !items.isEmpty();
+        }
+
+        @Override
+        public void deleteItems(MemoryId id, Collection<Long> itemIds) {}
+    }
+}

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlMemoryStore.java
@@ -39,6 +39,7 @@ import com.openmemind.ai.memory.core.store.graph.GraphOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.graph.ItemGraphCommitOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateMatch;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateRequest;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
@@ -66,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
@@ -86,6 +88,8 @@ public class MysqlMemoryStore
     private static final TypeReference<List<Float>> FLOAT_LIST_TYPE = new TypeReference<>() {};
     private static final TypeReference<List<InsightPoint>> INSIGHT_POINT_LIST_TYPE =
             new TypeReference<>() {};
+    static final ItemOperationsCapabilities ITEM_OPERATIONS_CAPABILITIES =
+            new ItemOperationsCapabilities(true, true, true);
 
     private final DataSource dataSource;
     private final Jdbi jdbi;
@@ -135,6 +139,11 @@ public class MysqlMemoryStore
     @Override
     public ItemOperations itemOperations() {
         return this;
+    }
+
+    @Override
+    public ItemOperationsCapabilities itemOperationsCapabilities() {
+        return ITEM_OPERATIONS_CAPABILITIES;
     }
 
     @Override
@@ -420,6 +429,62 @@ public class MysqlMemoryStore
                 this::mapItem,
                 scope.userId(),
                 scope.agentId());
+    }
+
+    @Override
+    public List<MemoryItem> listItemsUpTo(MemoryId memoryId, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = 0 AND biz_id <= ?
+                ORDER BY biz_id ASC
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                cutoffItemId);
+    }
+
+    @Override
+    public List<MemoryItem> listItemsAfter(MemoryId memoryId, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = 0 AND biz_id > ?
+                ORDER BY biz_id ASC
+                LIMIT ?
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                afterItemId,
+                limit);
+    }
+
+    @Override
+    public OptionalLong maxItemId(MemoryId memoryId) {
+        ScopeContext scope = scopeOf(memoryId);
+        Long value =
+                queryOne(
+                        """
+                        SELECT MAX(biz_id) FROM memory_item
+                        WHERE user_id = ? AND agent_id = ? AND deleted = 0
+                        """,
+                        resultSet -> {
+                            long max = resultSet.getLong(1);
+                            return resultSet.wasNull() ? null : max;
+                        },
+                        scope.userId(),
+                        scope.agentId());
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
     }
 
     @Override

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/test/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlJdbcPluginTest.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/test/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlJdbcPluginTest.java
@@ -16,9 +16,12 @@ package com.openmemind.ai.memory.plugin.jdbc.mysql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.plugin.jdbc.internal.schema.JdbcDialectSchema;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
@@ -52,6 +55,24 @@ class MysqlJdbcPluginTest {
                         normalizedCreateTableStatement(
                                 JdbcDialectSchema.MYSQL.scriptPath(), "memory_insight"))
                 .doesNotContain(" confidence ");
+    }
+
+    @Test
+    void mysqlStoreDeclaresStoreSideItemRangeOverrides() throws Exception {
+        assertDeclaredRangeOverride("listItemsUpTo", MemoryId.class, long.class);
+        assertDeclaredRangeOverride("listItemsAfter", MemoryId.class, long.class, int.class);
+        assertDeclaredRangeOverride("maxItemId", MemoryId.class);
+
+        ItemOperationsCapabilities capabilities = MysqlMemoryStore.ITEM_OPERATIONS_CAPABILITIES;
+        assertThat(capabilities.boundedIdLookup()).isTrue();
+        assertThat(capabilities.boundedRangeReads()).isTrue();
+        assertThat(capabilities.maxItemIdLookup()).isTrue();
+    }
+
+    private static void assertDeclaredRangeOverride(String methodName, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        Method method = MysqlMemoryStore.class.getMethod(methodName, parameterTypes);
+        assertThat(method.getDeclaringClass()).isEqualTo(MysqlMemoryStore.class);
     }
 
     private String normalizedCreateTableStatement(String classpathResource, String tableName) {

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlMemoryStore.java
@@ -39,6 +39,7 @@ import com.openmemind.ai.memory.core.store.graph.GraphOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.graph.ItemGraphCommitOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateMatch;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateRequest;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
@@ -66,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
@@ -87,6 +89,8 @@ public class PostgresqlMemoryStore
     private static final TypeReference<List<Float>> FLOAT_LIST_TYPE = new TypeReference<>() {};
     private static final TypeReference<List<InsightPoint>> INSIGHT_POINT_LIST_TYPE =
             new TypeReference<>() {};
+    static final ItemOperationsCapabilities ITEM_OPERATIONS_CAPABILITIES =
+            new ItemOperationsCapabilities(true, true, true);
 
     private final DataSource dataSource;
     private final Jdbi jdbi;
@@ -136,6 +140,11 @@ public class PostgresqlMemoryStore
     @Override
     public ItemOperations itemOperations() {
         return this;
+    }
+
+    @Override
+    public ItemOperationsCapabilities itemOperationsCapabilities() {
+        return ITEM_OPERATIONS_CAPABILITIES;
     }
 
     @Override
@@ -421,6 +430,62 @@ public class PostgresqlMemoryStore
                 this::mapItem,
                 scope.userId(),
                 scope.agentId());
+    }
+
+    @Override
+    public List<MemoryItem> listItemsUpTo(MemoryId memoryId, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = FALSE AND biz_id <= ?
+                ORDER BY biz_id ASC
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                cutoffItemId);
+    }
+
+    @Override
+    public List<MemoryItem> listItemsAfter(MemoryId memoryId, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = FALSE AND biz_id > ?
+                ORDER BY biz_id ASC
+                LIMIT ?
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                afterItemId,
+                limit);
+    }
+
+    @Override
+    public OptionalLong maxItemId(MemoryId memoryId) {
+        ScopeContext scope = scopeOf(memoryId);
+        Long value =
+                queryOne(
+                        """
+                        SELECT MAX(biz_id) FROM memory_item
+                        WHERE user_id = ? AND agent_id = ? AND deleted = FALSE
+                        """,
+                        resultSet -> {
+                            long max = resultSet.getLong(1);
+                            return resultSet.wasNull() ? null : max;
+                        },
+                        scope.userId(),
+                        scope.agentId());
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
     }
 
     @Override

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/test/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlJdbcPluginTest.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/test/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlJdbcPluginTest.java
@@ -16,9 +16,12 @@ package com.openmemind.ai.memory.plugin.jdbc.postgresql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.openmemind.ai.memory.core.data.MemoryId;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.plugin.jdbc.internal.schema.JdbcDialectSchema;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
@@ -52,6 +55,25 @@ class PostgresqlJdbcPluginTest {
                         normalizedCreateTableStatement(
                                 JdbcDialectSchema.POSTGRESQL.scriptPath(), "memory_insight"))
                 .doesNotContain(" confidence ");
+    }
+
+    @Test
+    void postgresqlStoreDeclaresStoreSideItemRangeOverrides() throws Exception {
+        assertDeclaredRangeOverride("listItemsUpTo", MemoryId.class, long.class);
+        assertDeclaredRangeOverride("listItemsAfter", MemoryId.class, long.class, int.class);
+        assertDeclaredRangeOverride("maxItemId", MemoryId.class);
+
+        ItemOperationsCapabilities capabilities =
+                PostgresqlMemoryStore.ITEM_OPERATIONS_CAPABILITIES;
+        assertThat(capabilities.boundedIdLookup()).isTrue();
+        assertThat(capabilities.boundedRangeReads()).isTrue();
+        assertThat(capabilities.maxItemIdLookup()).isTrue();
+    }
+
+    private static void assertDeclaredRangeOverride(String methodName, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        Method method = PostgresqlMemoryStore.class.getMethod(methodName, parameterTypes);
+        assertThat(method.getDeclaringClass()).isEqualTo(PostgresqlMemoryStore.class);
     }
 
     private String normalizedCreateTableStatement(String classpathResource, String tableName) {

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/main/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/main/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStore.java
@@ -39,6 +39,7 @@ import com.openmemind.ai.memory.core.store.graph.GraphOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.graph.ItemGraphCommitOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateMatch;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateRequest;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
@@ -72,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
@@ -148,6 +150,11 @@ public class SqliteMemoryStore
     @Override
     public ItemOperations itemOperations() {
         return this;
+    }
+
+    @Override
+    public ItemOperationsCapabilities itemOperationsCapabilities() {
+        return new ItemOperationsCapabilities(true, true, true);
     }
 
     @Override
@@ -434,6 +441,62 @@ public class SqliteMemoryStore
                 this::mapItem,
                 scope.userId(),
                 scope.agentId());
+    }
+
+    @Override
+    public List<MemoryItem> listItemsUpTo(MemoryId memoryId, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = 0 AND biz_id <= ?
+                ORDER BY biz_id ASC
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                cutoffItemId);
+    }
+
+    @Override
+    public List<MemoryItem> listItemsAfter(MemoryId memoryId, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        ScopeContext scope = scopeOf(memoryId);
+        return queryList(
+                """
+                SELECT * FROM memory_item
+                WHERE user_id = ? AND agent_id = ? AND deleted = 0 AND biz_id > ?
+                ORDER BY biz_id ASC
+                LIMIT ?
+                """,
+                this::mapItem,
+                scope.userId(),
+                scope.agentId(),
+                afterItemId,
+                limit);
+    }
+
+    @Override
+    public OptionalLong maxItemId(MemoryId memoryId) {
+        ScopeContext scope = scopeOf(memoryId);
+        Long value =
+                queryOne(
+                        """
+                        SELECT MAX(biz_id) FROM memory_item
+                        WHERE user_id = ? AND agent_id = ? AND deleted = 0
+                        """,
+                        resultSet -> {
+                            long max = resultSet.getLong(1);
+                            return resultSet.wasNull() ? null : max;
+                        },
+                        scope.userId(),
+                        scope.agentId());
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
     }
 
     @Override

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/test/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStoreTest.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/test/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStoreTest.java
@@ -35,17 +35,25 @@ import com.openmemind.ai.memory.core.extraction.rawdata.segment.CharBoundary;
 import com.openmemind.ai.memory.core.extraction.rawdata.segment.MessageBoundary;
 import com.openmemind.ai.memory.core.extraction.rawdata.segment.Segment;
 import com.openmemind.ai.memory.core.extraction.rawdata.segment.SegmentRuntimeContext;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateMatch;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateRequest;
 import com.openmemind.ai.memory.plugin.rawdata.toolcall.content.ToolCallContent;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -377,6 +385,109 @@ class SqliteMemoryStoreTest {
     }
 
     @Test
+    void itemRangeReadsUseDomainBizIdOrderingInsteadOfStorageRowId() throws Exception {
+        store.insertItems(
+                memoryId,
+                List.of(
+                        item(30L, "thirty", "vec-30", "hash-30", "raw-30"),
+                        item(2L, "two", "vec-2", "hash-2", "raw-2"),
+                        item(10L, "ten", "vec-10", "hash-10", "raw-10")));
+
+        assertThat(store.listItemsUpTo(memoryId, 10L))
+                .extracting(MemoryItem::id)
+                .containsExactly(2L, 10L);
+        assertThat(store.listItemsAfter(memoryId, 2L, 2))
+                .extracting(MemoryItem::id)
+                .containsExactly(10L, 30L);
+        assertThat(store.listItemsAfter(memoryId, 2L, 0)).isEmpty();
+        assertThat(store.maxItemId(memoryId)).hasValue(30L);
+
+        ItemOperationsCapabilities capabilities = store.itemOperationsCapabilities();
+        assertThat(capabilities.boundedIdLookup()).isTrue();
+        assertThat(capabilities.boundedRangeReads()).isTrue();
+        assertThat(capabilities.maxItemIdLookup()).isTrue();
+
+        assertDeclaredRangeOverride("listItemsUpTo", MemoryId.class, long.class);
+        assertDeclaredRangeOverride("listItemsAfter", MemoryId.class, long.class, int.class);
+        assertDeclaredRangeOverride("maxItemId", MemoryId.class);
+    }
+
+    @Test
+    void itemRangeReadsExecuteIndexedBizIdSql() throws Exception {
+        List<String> recordedSql = new CopyOnWriteArrayList<>();
+        SqliteMemoryStore recordingStore =
+                new SqliteMemoryStore(recordingDataSource("range-sql.db", recordedSql));
+        recordingStore.insertItems(
+                memoryId,
+                List.of(
+                        item(30L, "thirty", "vec-30", "hash-30", "raw-30"),
+                        item(2L, "two", "vec-2", "hash-2", "raw-2"),
+                        item(10L, "ten", "vec-10", "hash-10", "raw-10")));
+
+        recordedSql.clear();
+        assertThat(recordingStore.listItemsUpTo(memoryId, 10L))
+                .extracting(MemoryItem::id)
+                .containsExactly(2L, 10L);
+        assertThat(recordedSql)
+                .anySatisfy(
+                        sql ->
+                                assertThat(sql)
+                                        .contains("biz_id <= ?")
+                                        .contains("order by biz_id asc"));
+
+        String listItemsUpToSql = singleRecordedSqlContaining(recordedSql, "biz_id <= ?");
+
+        recordedSql.clear();
+        assertThat(recordingStore.listItemsAfter(memoryId, 2L, 2))
+                .extracting(MemoryItem::id)
+                .containsExactly(10L, 30L);
+        assertThat(recordedSql)
+                .anySatisfy(
+                        sql ->
+                                assertThat(sql)
+                                        .contains("biz_id > ?")
+                                        .contains("order by biz_id asc")
+                                        .contains("limit ?"));
+
+        String listItemsAfterSql = singleRecordedSqlContaining(recordedSql, "biz_id > ?");
+
+        recordedSql.clear();
+        assertThat(recordingStore.maxItemId(memoryId)).hasValue(30L);
+        assertThat(recordedSql).anySatisfy(sql -> assertThat(sql).contains("max(biz_id)"));
+
+        String maxItemIdSql = singleRecordedSqlContaining(recordedSql, "max(biz_id)");
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(
+                            explainQueryPlan(
+                                    connection,
+                                    listItemsUpToSql,
+                                    memoryId.userId(),
+                                    memoryId.agentId(),
+                                    10L))
+                    .anySatisfy(plan -> assertThat(plan).contains("uk_item_biz_id"));
+
+            assertThat(
+                            explainQueryPlan(
+                                    connection,
+                                    listItemsAfterSql,
+                                    memoryId.userId(),
+                                    memoryId.agentId(),
+                                    2L,
+                                    2))
+                    .anySatisfy(plan -> assertThat(plan).contains("uk_item_biz_id"));
+
+            assertThat(
+                            explainQueryPlan(
+                                    connection,
+                                    maxItemIdSql,
+                                    memoryId.userId(),
+                                    memoryId.agentId()))
+                    .anySatisfy(plan -> assertThat(plan).contains("uk_item_biz_id"));
+        }
+    }
+
+    @Test
     void itemsCanPersistWithNullOccurredAt() {
         Instant observedAt = BASE_TIME.plusSeconds(30);
         MemoryItem itemWithoutOccurredAt =
@@ -613,6 +724,96 @@ class SqliteMemoryStoreTest {
         assertThat(store.listInsights(memoryId))
                 .extracting(MemoryInsight::id)
                 .containsExactly(302L);
+    }
+
+    private static void assertDeclaredRangeOverride(String methodName, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        Method method = SqliteMemoryStore.class.getMethod(methodName, parameterTypes);
+        assertThat(method.getDeclaringClass()).isEqualTo(SqliteMemoryStore.class);
+    }
+
+    private DataSource recordingDataSource(String fileName, List<String> recordedSql) {
+        DataSource delegate = dataSource(fileName);
+        return (DataSource)
+                Proxy.newProxyInstance(
+                        DataSource.class.getClassLoader(),
+                        new Class<?>[] {DataSource.class},
+                        (proxy, method, args) -> {
+                            Object result = invoke(delegate, method, args);
+                            if ("getConnection".equals(method.getName())
+                                    && result instanceof Connection connection) {
+                                return recordingConnection(connection, recordedSql);
+                            }
+                            return result;
+                        });
+    }
+
+    private static Connection recordingConnection(Connection delegate, List<String> recordedSql) {
+        return (Connection)
+                Proxy.newProxyInstance(
+                        Connection.class.getClassLoader(),
+                        new Class<?>[] {Connection.class},
+                        (proxy, method, args) -> {
+                            if ("prepareStatement".equals(method.getName())
+                                    && args != null
+                                    && args.length > 0
+                                    && args[0] instanceof String sql) {
+                                recordedSql.add(normalizeSql(sql));
+                            }
+                            return invoke(delegate, method, args);
+                        });
+    }
+
+    private static String normalizeSql(String sql) {
+        return sql.replaceAll("\\s+", " ").trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String singleRecordedSqlContaining(List<String> recordedSql, String needle) {
+        return recordedSql.stream()
+                .filter(sql -> sql.contains(needle))
+                .reduce(
+                        (left, right) -> {
+                            throw new AssertionError("Expected one SQL containing " + needle);
+                        })
+                .orElseThrow(() -> new AssertionError("Missing SQL containing " + needle));
+    }
+
+    private static Object invoke(Object target, Method method, Object[] args) throws Throwable {
+        if (method.getDeclaringClass() == Object.class) {
+            return switch (method.getName()) {
+                case "toString" -> target.toString();
+                case "hashCode" -> System.identityHashCode(target);
+                case "equals" -> args != null && args.length == 1 && target == args[0];
+                default -> method.invoke(target, args);
+            };
+        }
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    private static List<String> explainQueryPlan(
+            Connection connection, String sql, Object... parameters) throws SQLException {
+        List<String> plan = new ArrayList<>();
+        try (PreparedStatement statement =
+                connection.prepareStatement("EXPLAIN QUERY PLAN " + sql)) {
+            for (int i = 0; i < parameters.length; i++) {
+                statement.setObject(i + 1, parameters[i]);
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    plan.add(
+                            resultSet
+                                    .getString("detail")
+                                    .replaceAll("\\s+", " ")
+                                    .trim()
+                                    .toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        return plan;
     }
 
     private DataSource dataSource(String fileName) {

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStore.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStore.java
@@ -15,6 +15,7 @@ package com.openmemind.ai.memory.plugin.store.mybatis;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.openmemind.ai.memory.core.data.MemoryId;
 import com.openmemind.ai.memory.core.data.MemoryInsight;
 import com.openmemind.ai.memory.core.data.MemoryInsightType;
@@ -45,6 +46,7 @@ import com.openmemind.ai.memory.core.store.graph.NoOpGraphOperations;
 import com.openmemind.ai.memory.core.store.graph.NoOpItemGraphCommitOperations;
 import com.openmemind.ai.memory.core.store.insight.InsightOperations;
 import com.openmemind.ai.memory.core.store.item.ItemOperations;
+import com.openmemind.ai.memory.core.store.item.ItemOperationsCapabilities;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateMatch;
 import com.openmemind.ai.memory.core.store.item.TemporalCandidateRequest;
 import com.openmemind.ai.memory.core.store.rawdata.RawDataOperations;
@@ -94,6 +96,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.transaction.annotation.Transactional;
@@ -256,6 +259,11 @@ public class MybatisPlusMemoryStore
     @Override
     public ItemOperations itemOperations() {
         return this;
+    }
+
+    @Override
+    public ItemOperationsCapabilities itemOperationsCapabilities() {
+        return new ItemOperationsCapabilities(true, true, true);
     }
 
     @Override
@@ -548,6 +556,53 @@ public class MybatisPlusMemoryStore
         return itemMapper.selectList(memoryQuery(id, MemoryItemDO.class)).stream()
                 .map(ItemConverter::toRecord)
                 .toList();
+    }
+
+    @Override
+    public List<MemoryItem> listItemsUpTo(MemoryId id, long cutoffItemId) {
+        if (cutoffItemId <= 0L) {
+            return List.of();
+        }
+        return itemMapper
+                .selectList(
+                        memoryQuery(id, MemoryItemDO.class)
+                                .le("biz_id", cutoffItemId)
+                                .orderByAsc("biz_id"))
+                .stream()
+                .map(ItemConverter::toRecord)
+                .toList();
+    }
+
+    @Override
+    public List<MemoryItem> listItemsAfter(MemoryId id, long afterItemId, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        Page<MemoryItemDO> page = Page.of(1, limit, false);
+        return itemMapper
+                .selectPage(
+                        page,
+                        memoryQuery(id, MemoryItemDO.class)
+                                .gt("biz_id", afterItemId)
+                                .orderByAsc("biz_id"))
+                .getRecords()
+                .stream()
+                .map(ItemConverter::toRecord)
+                .toList();
+    }
+
+    @Override
+    public OptionalLong maxItemId(MemoryId id) {
+        List<Object> values =
+                itemMapper.selectObjs(memoryQuery(id, MemoryItemDO.class).select("MAX(biz_id)"));
+        if (values == null || values.isEmpty() || values.getFirst() == null) {
+            return OptionalLong.empty();
+        }
+        Object value = values.getFirst();
+        if (value instanceof Number number) {
+            return OptionalLong.of(number.longValue());
+        }
+        return OptionalLong.empty();
     }
 
     @Override

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStoreBatchOperationsTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStoreBatchOperationsTest.java
@@ -40,13 +40,23 @@ import com.openmemind.ai.memory.plugin.store.mybatis.mapper.MemoryRawDataMapper;
 import com.openmemind.ai.memory.plugin.store.mybatis.schema.MemorySchemaAutoConfiguration;
 import java.lang.reflect.Proxy;
 import java.nio.file.Path;
+import java.sql.Connection;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.sql.DataSource;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Plugin;
+import org.apache.ibatis.plugin.Signature;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -140,6 +150,60 @@ class MybatisPlusMemoryStoreBatchOperationsTest {
                             assertThat(itemOps.listItems(MEMORY_ID))
                                     .extracting(MemoryItem::id)
                                     .containsExactly(1L);
+                        });
+    }
+
+    @Test
+    @DisplayName("item range reads use domain biz id ordering")
+    void itemRangeReadsUseDomainBizIdOrdering() {
+        newContextRunner(tempDir.resolve("item-range-reads.db"))
+                .run(
+                        context -> {
+                            MemoryStore store = context.getBean(MemoryStore.class);
+                            ItemOperations itemOps = store.itemOperations();
+                            SqlStatementRecorder sqlRecorder =
+                                    context.getBean(SqlStatementRecorder.class);
+
+                            itemOps.insertItems(
+                                    MEMORY_ID,
+                                    List.of(
+                                            memoryItem(30L, "thirty"),
+                                            memoryItem(2L, "two"),
+                                            memoryItem(10L, "ten")));
+
+                            sqlRecorder.clear();
+                            assertThat(itemOps.listItemsUpTo(MEMORY_ID, 10L))
+                                    .extracting(MemoryItem::id)
+                                    .containsExactly(2L, 10L);
+                            assertThat(sqlRecorder.sql())
+                                    .anySatisfy(
+                                            sql ->
+                                                    assertThat(sql)
+                                                            .contains("biz_id <= ?")
+                                                            .contains("order by biz_id asc"));
+
+                            sqlRecorder.clear();
+                            assertThat(itemOps.listItemsAfter(MEMORY_ID, 2L, 2))
+                                    .extracting(MemoryItem::id)
+                                    .containsExactly(10L, 30L);
+                            assertThat(sqlRecorder.sql())
+                                    .anySatisfy(
+                                            sql ->
+                                                    assertThat(sql)
+                                                            .contains("biz_id > ?")
+                                                            .contains("order by biz_id asc")
+                                                            .contains("limit"));
+
+                            sqlRecorder.clear();
+                            assertThat(itemOps.maxItemId(MEMORY_ID)).hasValue(30L);
+                            assertThat(sqlRecorder.sql())
+                                    .anySatisfy(sql -> assertThat(sql).contains("max(biz_id)"));
+                            assertThat(store.itemOperationsCapabilities().boundedIdLookup())
+                                    .isTrue();
+                            assertThat(store.itemOperationsCapabilities().boundedRangeReads())
+                                    .isTrue();
+                            assertThat(store.itemOperationsCapabilities().maxItemIdLookup())
+                                    .isTrue();
                         });
     }
 
@@ -683,6 +747,17 @@ class MybatisPlusMemoryStoreBatchOperationsTest {
         }
 
         @Bean
+        SqlStatementRecorder sqlStatementRecorder() {
+            return new SqlStatementRecorder();
+        }
+
+        @Bean
+        ConfigurationCustomizer sqlRecordingCustomizer(SqlStatementRecorder recorder) {
+            return configuration ->
+                    configuration.addInterceptor(new SqlRecordingInterceptor(recorder));
+        }
+
+        @Bean
         BeanPostProcessor countingMapperBeanPostProcessor(MapperMethodCounter counter) {
             return new CountingMapperBeanPostProcessor(counter);
         }
@@ -719,6 +794,52 @@ class MybatisPlusMemoryStoreBatchOperationsTest {
         @Bean
         InitializingBean ddlRunnerInitializer(DdlApplicationRunner ddlApplicationRunner) {
             return () -> ddlApplicationRunner.run(new DefaultApplicationArguments(new String[0]));
+        }
+    }
+
+    private static final class SqlStatementRecorder {
+
+        private final List<String> sql = new CopyOnWriteArrayList<>();
+
+        void record(String statement) {
+            sql.add(statement.replaceAll("\\s+", " ").trim().toLowerCase(Locale.ROOT));
+        }
+
+        void clear() {
+            sql.clear();
+        }
+
+        List<String> sql() {
+            return List.copyOf(sql);
+        }
+    }
+
+    @Intercepts(
+            @Signature(
+                    type = StatementHandler.class,
+                    method = "prepare",
+                    args = {Connection.class, Integer.class}))
+    private static final class SqlRecordingInterceptor implements Interceptor {
+
+        private final SqlStatementRecorder recorder;
+
+        private SqlRecordingInterceptor(SqlStatementRecorder recorder) {
+            this.recorder = recorder;
+        }
+
+        @Override
+        public Object intercept(Invocation invocation) throws Throwable {
+            StatementHandler statementHandler = (StatementHandler) invocation.getTarget();
+            BoundSql boundSql = statementHandler.getBoundSql();
+            if (boundSql != null && boundSql.getSql() != null) {
+                recorder.record(boundSql.getSql());
+            }
+            return invocation.proceed();
+        }
+
+        @Override
+        public Object plugin(Object target) {
+            return Plugin.wrap(target, this);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add bounded item range APIs and capabilities so thread replay can push cutoff reads into stores.
- Update thread materialization and rebuild paths to use bounded item reads, bounded mention reads, adjacent-link reads, and replay stats metrics.
- Add JDBC SQLite/MySQL/PostgreSQL and MyBatis-Plus store-side implementations with focused coverage.

## Test Plan
- [x] mvn test