### PR TITLE
fix: handle point-in-time temporal overlap

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalItemLinker.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalItemLinker.java
@@ -256,6 +256,9 @@ public class TemporalItemLinker {
         MemoryItem leftItem = source.item();
         MemoryItem rightItem = candidate.item();
         int compare = classifier.compare(left, right);
+        if (compare == 0) {
+            compare = Long.compare(leftItem.id(), rightItem.id());
+        }
         TemporalWindow earlierWindow = compare <= 0 ? left : right;
         TemporalWindow laterWindow = earlierWindow == left ? right : left;
         MemoryItem earlier = compare <= 0 ? leftItem : rightItem;

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalRelationClassifier.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalRelationClassifier.java
@@ -67,8 +67,8 @@ public final class TemporalRelationClassifier {
     }
 
     private static boolean windowsOverlap(TemporalWindow left, TemporalWindow right) {
-        return left.start().isBefore(right.endOrAnchor())
-                && right.start().isBefore(left.endOrAnchor());
+        return left.start().isBefore(right.effectiveEndExclusive())
+                && right.start().isBefore(left.effectiveEndExclusive());
     }
 
     @SafeVarargs

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalWindow.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalWindow.java
@@ -29,4 +29,9 @@ public record TemporalWindow(Instant start, Instant end, Instant anchor) {
     public Instant endOrAnchor() {
         return end != null ? end : anchor;
     }
+
+    public Instant effectiveEndExclusive() {
+        Instant resolvedEnd = endOrAnchor();
+        return resolvedEnd.isAfter(start) ? resolvedEnd : start.plusMillis(1);
+    }
 }

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateLookupSupport.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateLookupSupport.java
@@ -68,8 +68,8 @@ public final class TemporalCandidateLookupSupport {
                     continue;
                 }
                 var ranked = new RankedTemporalCandidate(candidate, window);
-                if (window.start().isBefore(request.sourceEndOrAnchor())
-                        && request.sourceStart().isBefore(window.endOrAnchor())) {
+                if (window.start().isBefore(request.effectiveSourceEndExclusive())
+                        && request.sourceStart().isBefore(window.effectiveEndExclusive())) {
                     overlap.add(ranked);
                 } else if (window.anchor().isBefore(request.sourceAnchor())) {
                     before.add(ranked);

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateRequest.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateRequest.java
@@ -39,4 +39,10 @@ public record TemporalCandidateRequest(
         Objects.requireNonNull(sourceAnchor, "sourceAnchor");
         Objects.requireNonNull(itemType, "itemType");
     }
+
+    public Instant effectiveSourceEndExclusive() {
+        return sourceEndOrAnchor.isAfter(sourceStart)
+                ? sourceEndOrAnchor
+                : sourceStart.plusMillis(1);
+    }
 }

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalItemLinkerTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalItemLinkerTest.java
@@ -91,6 +91,81 @@ class TemporalItemLinkerTest {
     }
 
     @Test
+    void linkerShouldPersistSameBatchSameInstantPointEventsAsOverlap() {
+        var itemOps = new InMemoryItemOperations();
+        var graphOps = new InMemoryGraphOperations();
+        var linker =
+                new TemporalItemLinker(
+                        itemOps,
+                        graphOps,
+                        new TemporalRelationClassifier(),
+                        new ItemGraphOptions(true, 8, 4, 1, 5, 0.82d, 4, 1, 128));
+
+        var incoming =
+                List.of(
+                        temporalItem(
+                                101L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z"),
+                        temporalItem(
+                                102L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z"));
+
+        var stats = linker.link(MEMORY_ID, incoming).block();
+
+        assertThat(stats.createdLinkCount()).isEqualTo(1);
+        assertThat(graphOps.listItemLinks(MEMORY_ID))
+                .extracting(
+                        ItemLink::sourceItemId,
+                        ItemLink::targetItemId,
+                        link -> link.metadata().get("relationType"),
+                        ItemLink::strength)
+                .containsExactly(tuple(101L, 102L, "overlap", 1.0d));
+    }
+
+    @Test
+    void linkerShouldPersistHistoricalSameInstantPointCandidateAsOverlap() {
+        var itemOps = new InMemoryItemOperations();
+        var graphOps = new InMemoryGraphOperations();
+        itemOps.insertItems(
+                MEMORY_ID,
+                List.of(
+                        temporalItem(
+                                1L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z")));
+        var linker =
+                new TemporalItemLinker(
+                        itemOps,
+                        graphOps,
+                        new TemporalRelationClassifier(),
+                        new ItemGraphOptions(true, 8, 4, 1, 5, 0.82d, 4, 1, 128));
+
+        var incoming =
+                List.of(
+                        temporalItem(
+                                101L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z"));
+
+        var stats = linker.link(MEMORY_ID, incoming).block();
+
+        assertThat(stats.createdLinkCount()).isEqualTo(1);
+        assertThat(graphOps.listItemLinks(MEMORY_ID))
+                .extracting(
+                        ItemLink::sourceItemId,
+                        ItemLink::targetItemId,
+                        link -> link.metadata().get("relationType"),
+                        ItemLink::strength)
+                .containsExactly(tuple(1L, 101L, "overlap", 1.0d));
+    }
+
+    @Test
     void linkerShouldDegradeOnlyTheFailedHistoricalLookupSubBatch() {
         var itemOps =
                 new InMemoryItemOperations() {

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalRelationClassifierTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/extraction/item/graph/link/temporal/TemporalRelationClassifierTest.java
@@ -58,6 +58,16 @@ class TemporalRelationClassifierTest {
         assertThat(classifier.classify(nearby, far)).isEqualTo("before");
     }
 
+    @Test
+    void classifierShouldTreatSameInstantPointWindowsAsOverlap() {
+        var classifier = new TemporalRelationClassifier();
+
+        var left = classifier.resolveWindow(item(201L, "left", "2026-04-10T09:00:00Z"));
+        var right = classifier.resolveWindow(item(202L, "right", "2026-04-10T09:00:00Z"));
+
+        assertThat(classifier.classify(left, right)).isEqualTo("overlap");
+    }
+
     private static MemoryItem item(Long id, String content, String occurredAt) {
         return new MemoryItem(
                 id,

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateLookupSupportTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/store/item/TemporalCandidateLookupSupportTest.java
@@ -35,6 +35,45 @@ class TemporalCandidateLookupSupportTest {
     private static final Instant CREATED_AT = Instant.parse("2026-04-16T00:00:00Z");
 
     @Test
+    void defaultLookupShouldReturnSameInstantPointEventsAsOverlapCandidates() {
+        ItemOperations ops = new InMemoryItemOperations();
+        ops.insertItems(
+                MEMORY_ID,
+                List.of(
+                        temporalItem(
+                                1L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z"),
+                        temporalItem(
+                                2L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:00:00Z"),
+                        temporalItem(
+                                3L,
+                                MemoryItemType.FACT,
+                                MemoryCategory.EVENT,
+                                "2026-04-10T10:01:00Z")));
+
+        var request =
+                new TemporalCandidateRequest(
+                        1L,
+                        Instant.parse("2026-04-10T10:00:00Z"),
+                        Instant.parse("2026-04-10T10:00:00Z"),
+                        Instant.parse("2026-04-10T10:00:00Z"),
+                        MemoryItemType.FACT,
+                        MemoryCategory.EVENT,
+                        4,
+                        0,
+                        0);
+
+        assertThat(ops.listTemporalCandidateMatches(MEMORY_ID, List.of(request), Set.of(1L)))
+                .extracting(match -> match.candidateItem().id())
+                .containsExactly(2L);
+    }
+
+    @Test
     void defaultLookupShouldReturnOverlapBeforeAndAfterMatchesWithScopeFilters() {
         ItemOperations ops = new InMemoryItemOperations();
         ops.insertItems(

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-mysql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/mysql/MysqlMemoryStore.java
@@ -608,9 +608,16 @@ public class MysqlMemoryStore
                             memoryId,
                             request,
                             effectiveExcludeIds,
-                            "AND temporal_start < ? AND ? < temporal_end_or_anchor",
+                            """
+                            AND temporal_start < ?
+                            AND ? < CASE
+                                WHEN temporal_start < temporal_end_or_anchor
+                                THEN temporal_end_or_anchor
+                                ELSE DATE_ADD(temporal_start, INTERVAL 1000 MICROSECOND)
+                            END
+                            """,
                             "ABS(TIMESTAMPDIFF(MICROSECOND, temporal_anchor, ?)) ASC, biz_id ASC",
-                            request.sourceEndOrAnchor(),
+                            request.effectiveSourceEndExclusive(),
                             request.sourceStart(),
                             request.sourceAnchor(),
                             request.overlapLimit()));

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-postgresql/src/main/java/com/openmemind/ai/memory/plugin/jdbc/postgresql/PostgresqlMemoryStore.java
@@ -610,10 +610,17 @@ public class PostgresqlMemoryStore
                             memoryId,
                             request,
                             effectiveExcludeIds,
-                            "AND temporal_start < ? AND ? < temporal_end_or_anchor",
+                            """
+                            AND temporal_start < ?
+                            AND ? < CASE
+                                WHEN temporal_start < temporal_end_or_anchor
+                                THEN temporal_end_or_anchor
+                                ELSE temporal_start + INTERVAL '1 millisecond'
+                            END
+                            """,
                             "ABS(EXTRACT(EPOCH FROM (temporal_anchor - CAST(? AS TIMESTAMPTZ))))"
                                     + " ASC, biz_id ASC",
-                            request.sourceEndOrAnchor(),
+                            request.effectiveSourceEndExclusive(),
                             request.sourceStart(),
                             request.sourceAnchor(),
                             request.overlapLimit()));

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/main/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStore.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/main/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStore.java
@@ -609,9 +609,20 @@ public class SqliteMemoryStore
                             memoryId,
                             request,
                             effectiveExcludeIds,
-                            "AND temporal_start < ? AND ? < temporal_end_or_anchor",
+                            """
+                            AND julianday(temporal_start) < julianday(?)
+                            AND julianday(?) < julianday(
+                                CASE
+                                    WHEN julianday(temporal_start) < julianday(temporal_end_or_anchor)
+                                    THEN temporal_end_or_anchor
+                                    ELSE strftime('%Y-%m-%dT%H:%M:%fZ',
+                                                  temporal_start,
+                                                  '+0.001 seconds')
+                                END
+                            )
+                            """,
                             "ABS(unixepoch(temporal_anchor) - unixepoch(?)) ASC, biz_id ASC",
-                            request.sourceEndOrAnchor(),
+                            request.effectiveSourceEndExclusive(),
                             request.sourceStart(),
                             request.sourceAnchor(),
                             request.overlapLimit()));

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/test/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStoreTest.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-sqlite/src/test/java/com/openmemind/ai/memory/plugin/jdbc/sqlite/SqliteMemoryStoreTest.java
@@ -272,6 +272,42 @@ class SqliteMemoryStoreTest {
     }
 
     @Test
+    void listTemporalCandidateMatchesReturnsSameInstantPointEvents() {
+        MemoryItem source =
+                temporalPointItem(
+                        1L, "source", BASE_TIME, MemoryCategory.EVENT, MemoryItemType.FACT);
+        MemoryItem candidate =
+                temporalPointItem(
+                        2L, "candidate", BASE_TIME, MemoryCategory.EVENT, MemoryItemType.FACT);
+        MemoryItem later =
+                temporalPointItem(
+                        3L,
+                        "later",
+                        BASE_TIME.plusSeconds(60),
+                        MemoryCategory.EVENT,
+                        MemoryItemType.FACT);
+        store.insertItems(memoryId, List.of(source, candidate, later));
+
+        List<TemporalCandidateMatch> matches =
+                store.listTemporalCandidateMatches(
+                        memoryId,
+                        List.of(
+                                new TemporalCandidateRequest(
+                                        1L,
+                                        BASE_TIME,
+                                        BASE_TIME,
+                                        BASE_TIME,
+                                        MemoryItemType.FACT,
+                                        MemoryCategory.EVENT,
+                                        4,
+                                        0,
+                                        0)),
+                        List.of(1L));
+
+        assertThat(matches).extracting(match -> match.candidateItem().id()).containsExactly(2L);
+    }
+
+    @Test
     void listTemporalItemMatchesMatchesFallbackSemantics() {
         MemoryItem source = temporalItem(1L, "source", BASE_TIME, BASE_TIME.plusSeconds(60));
         MemoryItem closest =

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStore.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStore.java
@@ -697,7 +697,7 @@ public class MybatisPlusMemoryStore
                             categoryName,
                             effectiveExcludeIds,
                             request.sourceStart(),
-                            request.sourceEndOrAnchor(),
+                            request.effectiveSourceEndExclusive(),
                             request.sourceAnchor(),
                             request.overlapLimit()));
             appendNativeMatches(

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/mapper/sql/MemoryItemQuerySqlProvider.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/mapper/sql/MemoryItemQuerySqlProvider.java
@@ -82,7 +82,7 @@ public final class MemoryItemQuerySqlProvider {
         <script>
         SELECT *
         FROM memory_item
-        WHERE deleted = 0
+        WHERE %s
           AND memory_id = #{memoryId}
           AND type = #{itemType}
           %s
@@ -95,13 +95,16 @@ public final class MemoryItemQuerySqlProvider {
           AND temporal_start IS NOT NULL
           AND temporal_end_or_anchor IS NOT NULL
           AND temporal_anchor IS NOT NULL
-          AND temporal_start <![CDATA[<]]> #{sourceEndOrAnchor}
-          AND #{sourceStart} <![CDATA[<]]> temporal_end_or_anchor
+          AND %s
         ORDER BY %s ASC, biz_id ASC
         LIMIT #{limit}
         </script>
         """
-                .formatted(categoryPredicate(), anchorDistanceExpression(dialect));
+                .formatted(
+                        deletedPredicate(dialect),
+                        categoryPredicate(),
+                        temporalCandidateOverlapPredicate(dialect),
+                        anchorDistanceExpression(dialect));
     }
 
     public String selectTemporalBeforeCandidates(Map<String, Object> params) {
@@ -110,7 +113,7 @@ public final class MemoryItemQuerySqlProvider {
         <script>
         SELECT *
         FROM memory_item
-        WHERE deleted = 0
+        WHERE %s
           AND memory_id = #{memoryId}
           AND type = #{itemType}
           %s
@@ -126,7 +129,10 @@ public final class MemoryItemQuerySqlProvider {
         LIMIT #{limit}
         </script>
         """
-                .formatted(categoryPredicate(), anchorDistanceExpression(dialect));
+                .formatted(
+                        deletedPredicate(dialect),
+                        categoryPredicate(),
+                        anchorDistanceExpression(dialect));
     }
 
     public String selectTemporalAfterCandidates(Map<String, Object> params) {
@@ -135,7 +141,7 @@ public final class MemoryItemQuerySqlProvider {
         <script>
         SELECT *
         FROM memory_item
-        WHERE deleted = 0
+        WHERE %s
           AND memory_id = #{memoryId}
           AND type = #{itemType}
           %s
@@ -151,7 +157,10 @@ public final class MemoryItemQuerySqlProvider {
         LIMIT #{limit}
         </script>
         """
-                .formatted(categoryPredicate(), anchorDistanceExpression(dialect));
+                .formatted(
+                        deletedPredicate(dialect),
+                        categoryPredicate(),
+                        anchorDistanceExpression(dialect));
     }
 
     private static String categoryPredicate() {
@@ -207,6 +216,52 @@ public final class MemoryItemQuerySqlProvider {
                     semantic_start <![CDATA[<]]> #{endExclusive}
                       AND #{startInclusive} <![CDATA[<]]> semantic_end
                     """;
+        };
+    }
+
+    private static String temporalCandidateEffectiveEndExpression(DatabaseDialect dialect) {
+        return switch (effectiveDialect(dialect)) {
+            case SQLITE ->
+                    """
+                    CASE
+                        WHEN julianday(temporal_start) <![CDATA[<]]> julianday(temporal_end_or_anchor)
+                        THEN temporal_end_or_anchor
+                        ELSE strftime('%Y-%m-%dT%H:%M:%fZ', temporal_start, '+0.001 seconds')
+                    END
+                    """;
+            case MYSQL ->
+                    """
+                    CASE
+                        WHEN temporal_start <![CDATA[<]]> temporal_end_or_anchor
+                        THEN temporal_end_or_anchor
+                        ELSE DATE_ADD(temporal_start, INTERVAL 1000 MICROSECOND)
+                    END
+                    """;
+            case POSTGRESQL ->
+                    """
+                    CASE
+                        WHEN temporal_start <![CDATA[<]]> temporal_end_or_anchor
+                        THEN temporal_end_or_anchor
+                        ELSE temporal_start + INTERVAL '1 millisecond'
+                    END
+                    """;
+        };
+    }
+
+    private static String temporalCandidateOverlapPredicate(DatabaseDialect dialect) {
+        return switch (effectiveDialect(dialect)) {
+            case SQLITE ->
+                    """
+                    julianday(temporal_start) <![CDATA[<]]> julianday(#{sourceEndOrAnchor})
+                      AND julianday(#{sourceStart}) <![CDATA[<]]> julianday(%s)
+                    """
+                            .formatted(temporalCandidateEffectiveEndExpression(dialect));
+            case MYSQL, POSTGRESQL ->
+                    """
+                    temporal_start <![CDATA[<]]> #{sourceEndOrAnchor}
+                      AND #{sourceStart} <![CDATA[<]]> %s
+                    """
+                            .formatted(temporalCandidateEffectiveEndExpression(dialect));
         };
     }
 

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MemoryItemQuerySqlProviderTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MemoryItemQuerySqlProviderTest.java
@@ -55,4 +55,44 @@ class MemoryItemQuerySqlProviderTest {
         assertThat(mysqlSql).doesNotContain("observed_at");
         assertThat(postgresqlSql).doesNotContain("observed_at");
     }
+
+    @Test
+    @DisplayName("temporal overlap candidate lookup expands point windows by dialect")
+    void temporalOverlapCandidateLookupExpandsPointWindowsByDialect() {
+        var provider = new MemoryItemQuerySqlProvider();
+
+        String sqliteSql =
+                provider.selectTemporalOverlapCandidates(Map.of("dialect", DatabaseDialect.SQLITE));
+        String mysqlSql =
+                provider.selectTemporalOverlapCandidates(Map.of("dialect", DatabaseDialect.MYSQL));
+        String postgresqlSql =
+                provider.selectTemporalOverlapCandidates(
+                        Map.of("dialect", DatabaseDialect.POSTGRESQL));
+
+        assertThat(sqliteSql)
+                .contains("julianday(temporal_start)")
+                .contains("julianday(#{sourceEndOrAnchor})")
+                .contains("strftime('%Y-%m-%dT%H:%M:%fZ', temporal_start, '+0.001 seconds')");
+        assertThat(mysqlSql)
+                .contains("temporal_start <![CDATA[<]]> #{sourceEndOrAnchor}")
+                .contains("DATE_ADD(temporal_start, INTERVAL 1000 MICROSECOND)");
+        assertThat(postgresqlSql)
+                .contains("temporal_start <![CDATA[<]]> #{sourceEndOrAnchor}")
+                .contains("temporal_start + INTERVAL '1 millisecond'");
+        assertThat(sqliteSql).contains("WHERE deleted = 0");
+        assertThat(mysqlSql).contains("WHERE deleted = 0");
+        assertThat(postgresqlSql).contains("WHERE deleted = FALSE");
+        assertThat(
+                        provider.selectTemporalBeforeCandidates(
+                                Map.of("dialect", DatabaseDialect.POSTGRESQL)))
+                .contains("WHERE deleted = FALSE");
+        assertThat(
+                        provider.selectTemporalAfterCandidates(
+                                Map.of("dialect", DatabaseDialect.POSTGRESQL)))
+                .contains("WHERE deleted = FALSE");
+        assertThat(sqliteSql).doesNotContain("#{sourceStart} <![CDATA[<]]> temporal_end_or_anchor");
+        assertThat(mysqlSql).doesNotContain("#{sourceStart} <![CDATA[<]]> temporal_end_or_anchor");
+        assertThat(postgresqlSql)
+                .doesNotContain("#{sourceStart} <![CDATA[<]]> temporal_end_or_anchor");
+    }
 }

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStoreBatchOperationsTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/test/java/com/openmemind/ai/memory/plugin/store/mybatis/MybatisPlusMemoryStoreBatchOperationsTest.java
@@ -702,6 +702,68 @@ class MybatisPlusMemoryStoreBatchOperationsTest {
     }
 
     @Test
+    @DisplayName("native temporal lookup returns same-instant point overlap candidates")
+    void nativeTemporalLookupReturnsSameInstantPointOverlapCandidates() {
+        newContextRunner(tempDir.resolve("temporal-native-point-overlap.db"))
+                .run(
+                        context -> {
+                            ItemOperations itemOps =
+                                    context.getBean(MemoryStore.class).itemOperations();
+                            MapperMethodCounter counter =
+                                    context.getBean(MapperMethodCounter.class);
+
+                            itemOps.insertItems(
+                                    MEMORY_ID,
+                                    List.of(
+                                            memoryItem(
+                                                    1L, "source", BASE_TIME, BASE_TIME, null,
+                                                    "instant"),
+                                            memoryItem(
+                                                    2L,
+                                                    "candidate",
+                                                    BASE_TIME,
+                                                    BASE_TIME,
+                                                    null,
+                                                    "instant"),
+                                            memoryItem(
+                                                    3L,
+                                                    "later",
+                                                    BASE_TIME.plusSeconds(60),
+                                                    BASE_TIME.plusSeconds(60),
+                                                    null,
+                                                    "instant")));
+                            counter.reset();
+
+                            var request =
+                                    new TemporalCandidateRequest(
+                                            1L,
+                                            BASE_TIME,
+                                            BASE_TIME,
+                                            BASE_TIME,
+                                            MemoryItemType.FACT,
+                                            MemoryCategory.EVENT,
+                                            4,
+                                            0,
+                                            0);
+
+                            var matches =
+                                    itemOps.listTemporalCandidateMatches(
+                                            MEMORY_ID, List.of(request), Set.of(1L));
+
+                            assertThat(matches)
+                                    .extracting(match -> match.candidateItem().id())
+                                    .containsExactly(2L);
+                            assertThat(
+                                            counter.count(
+                                                    MemoryItemMapper.class,
+                                                    "selectTemporalOverlapCandidates"))
+                                    .isEqualTo(1);
+                            assertThat(counter.count(MemoryItemMapper.class, "selectList"))
+                                    .isZero();
+                        });
+    }
+
+    @Test
     @DisplayName("native temporal item lookup matches fallback semantics without broad item scan")
     void nativeTemporalItemLookupMatchesFallbackSemantics() {
         newContextRunner(tempDir.resolve("temporal-item-native-lookup.db"))


### PR DESCRIPTION
## Summary
- Treat zero-length temporal point windows as one-millisecond effective windows for overlap comparisons.
- Apply the same overlap semantics across core fallback lookup, final relation classification, JDBC stores, and MyBatis native lookup.
- Add regression coverage for same-instant point events and deterministic same-batch temporal links.

## Verification
- mvn clean install
- git diff --check