### PR TITLE
Add official Go API client

### DIFF
--- a/.github/workflows/go-client.yml
+++ b/.github/workflows/go-client.yml
@@ -1,0 +1,46 @@
+name: Go Client CI
+
+on:
+  push:
+    paths:
+      - 'memind-clients/go/**'
+      - '.github/workflows/go-client.yml'
+  pull_request:
+    paths:
+      - 'memind-clients/go/**'
+      - '.github/workflows/go-client.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - '1.25.x'
+          - 'stable'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false
+
+      - name: Test
+        working-directory: memind-clients/go
+        run: go test ./...
+
+      - name: Race test
+        working-directory: memind-clients/go
+        run: go test -race ./...
+
+      - name: Vet
+        working-directory: memind-clients/go
+        run: go vet ./...
+
+      - name: Format check
+        working-directory: memind-clients/go
+        run: test -z "$(gofmt -l .)"

--- a/README.md
+++ b/README.md
@@ -324,7 +324,12 @@ and clear their local retry state only when the returned extraction status is `S
 `/open/v1/memory/sync/add-message` and `/open/v1/memory/sync/commit` report immediate server-buffer success or
 failure, but they are not durable replay boundaries because the server owns the buffered conversation state.
 
-The official TypeScript client lives in [`memind-clients/typescript`](./memind-clients/typescript).
+Official API clients:
+
+- TypeScript: [`memind-clients/typescript`](./memind-clients/typescript)
+- Python: [`memind-clients/python`](./memind-clients/python)
+- Java: [`memind-clients/java`](./memind-clients/java)
+- Go: [`github.com/openmemind/memind/memind-clients/go`](./memind-clients/go)
 
 ---
 

--- a/memind-clients/go/LICENSE
+++ b/memind-clients/go/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 OpenMemind
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/memind-clients/go/README.md
+++ b/memind-clients/go/README.md
@@ -1,0 +1,140 @@
+# Memind Go Client
+
+Official Go client for the Memind memory engine Open API.
+
+## Installation
+
+```bash
+go get github.com/openmemind/memind/memind-clients/go
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+
+	memind "github.com/openmemind/memind/memind-clients/go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := memind.NewClient(
+		memind.WithBaseURL("http://localhost:8366"),
+		memind.WithAPIToken(os.Getenv("MEMIND_API_TOKEN")),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	health, err := client.Health(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(health.Status)
+
+	extract, err := client.Memory.Extract(ctx, memind.ExtractMemoryRequest{
+		UserID:     "user-1",
+		AgentID:    "agent-1",
+		RawContent: memind.Conversation(memind.UserMessage("Remember that I prefer concise answers.")),
+	})
+	if err != nil {
+		var apiErr *memind.APIError
+		if errors.As(err, &apiErr) {
+			log.Printf("memind API error: status=%d code=%s requestID=%s", apiErr.StatusCode, apiErr.ErrorCode, apiErr.RequestID)
+		}
+		log.Fatal(err)
+	}
+	log.Println(extract.Status)
+
+	result, err := client.Memory.Retrieve(ctx, memind.RetrieveMemoryRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Query:    "What does the user like?",
+		Strategy: memind.StrategySimple,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(len(result.Items))
+}
+```
+
+## Configuration
+
+Configuration precedence:
+
+1. Constructor options
+2. Environment variables: `MEMIND_BASE_URL`, `MEMIND_API_TOKEN`
+3. Defaults
+
+| Setting | Option | Default |
+| --- | --- | --- |
+| Base URL | `WithBaseURL` | Required |
+| API token | `WithAPIToken` | Omitted |
+| Timeout | `WithTimeout` | `30s` |
+| Max retries | `WithMaxRetries` | `2` |
+| HTTP client | `WithHTTPClient` | `http.DefaultClient` |
+| Extra header | `WithHeader` | None |
+| User agent | `WithUserAgent` | `memind-go/<version>` |
+
+`Authorization` is sent only when an API token is configured. SDK-owned headers cannot be overridden by custom headers.
+
+## Raw Content
+
+Use conversation raw content for chat-like memory extraction:
+
+```go
+raw := memind.Conversation(
+	memind.UserMessage("My preferred timezone is Asia/Shanghai."),
+	memind.AssistantMessage("I will remember that."),
+)
+```
+
+Use map raw content for plugin-specific object payloads:
+
+```go
+raw, err := memind.RawMap("document", map[string]any{
+	"title": "Project note",
+	"body":  "The release checklist is ready.",
+})
+```
+
+Custom raw content types can implement `json.Marshaler`. The client validates the marshaled root object and required `type` field before network I/O.
+
+## Retry Behavior
+
+`Health` and `Retrieve` retry transient failures by default. `Extract`, `AddMessage`, `Commit`, and async enqueue methods do not retry by default because they mutate server state.
+
+Opt into retries for mutating calls only when duplicate side effects are acceptable:
+
+```go
+resp, err := client.Memory.Extract(ctx, req, memind.WithRequestMaxRetries(1))
+```
+
+Treat only `ExtractMemoryResponse.Status == "SUCCESS"` as safe to clear caller-owned retry payloads. `PARTIAL_SUCCESS` is returned as successful data so applications can decide whether to keep or re-enqueue the original payload.
+
+## Async Enqueue
+
+Async methods enqueue server work and return accepted operation metadata only:
+
+```go
+accepted, err := client.Memory.EnqueueExtract(ctx, req)
+```
+
+The Open API currently does not expose polling endpoints, so this client does not provide completion tracking.
+
+## Development
+
+```bash
+go test ./...
+go test -race ./...
+go vet ./...
+gofmt -w .
+```

--- a/memind-clients/go/client.go
+++ b/memind-clients/go/client.go
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type Client struct {
+	Memory *MemoryService
+
+	config clientConfig
+}
+
+type Option func(*clientConfig) error
+
+func NewClient(opts ...Option) (*Client, error) {
+	cfg := defaultClientConfig()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.baseURL == "" {
+		return nil, fmt.Errorf("baseURL is required; pass WithBaseURL or set MEMIND_BASE_URL")
+	}
+	if err := validateBaseURL(cfg.baseURL); err != nil {
+		return nil, err
+	}
+	client := &Client{config: cfg}
+	client.Memory = &MemoryService{client: client}
+	return client, nil
+}
+
+func (c *Client) Health(ctx context.Context, opts ...RequestOption) (*HealthResponse, error) {
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	var out HealthResponse
+	if err := c.do(ctx, http.MethodGet, "/health", nil, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/memind-clients/go/client_test.go
+++ b/memind-clients/go/client_test.go
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestVersion(t *testing.T) {
+	if Version != "0.2.0" {
+		t.Fatalf("Version = %q, want 0.2.0", Version)
+	}
+}
+
+func TestNewClientRequiresBaseURL(t *testing.T) {
+	t.Setenv("MEMIND_BASE_URL", "")
+
+	client, err := NewClient()
+	if err == nil {
+		t.Fatal("NewClient() error = nil, want error")
+	}
+	if client != nil {
+		t.Fatalf("NewClient() client = %#v, want nil", client)
+	}
+}
+
+func TestNewClientUsesEnvBaseURL(t *testing.T) {
+	t.Setenv("MEMIND_BASE_URL", " http://localhost:8366/ ")
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if got := client.config.baseURL; got != "http://localhost:8366" {
+		t.Fatalf("baseURL = %q, want normalized env URL", got)
+	}
+}
+
+func TestInvalidBaseURLRejected(t *testing.T) {
+	for _, baseURL := range []string{"localhost:8366", "ftp://localhost:8366", "http://"} {
+		_, err := NewClient(WithBaseURL(baseURL))
+		if err == nil {
+			t.Fatalf("WithBaseURL(%q) error = nil, want invalid baseURL error", baseURL)
+		}
+	}
+}
+
+func TestConstructorOptionsOverrideEnv(t *testing.T) {
+	t.Setenv("MEMIND_BASE_URL", "http://env.example")
+	t.Setenv("MEMIND_API_TOKEN", "env-token")
+
+	client, err := NewClient(
+		WithBaseURL("http://explicit.example/"),
+		WithAPIToken(" explicit-token "),
+		WithTimeout(10*time.Second),
+		WithMaxRetries(4),
+		WithUserAgent("custom-agent"),
+		WithHeader("X-Memind-Test", "true"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if client.config.baseURL != "http://explicit.example" {
+		t.Fatalf("baseURL = %q", client.config.baseURL)
+	}
+	if client.config.apiToken != "explicit-token" {
+		t.Fatalf("apiToken = %q", client.config.apiToken)
+	}
+	if client.config.timeout != 10*time.Second {
+		t.Fatalf("timeout = %s", client.config.timeout)
+	}
+	if client.config.maxRetries != 4 {
+		t.Fatalf("maxRetries = %d", client.config.maxRetries)
+	}
+	if client.config.userAgent != "custom-agent" {
+		t.Fatalf("userAgent = %q", client.config.userAgent)
+	}
+	if client.config.headers.Get("X-Memind-Test") != "true" {
+		t.Fatalf("custom header missing")
+	}
+}
+
+func TestBlankAPITokenIsIgnored(t *testing.T) {
+	client, err := NewClient(
+		WithBaseURL("http://localhost:8366"),
+		WithAPIToken("   "),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if client.config.apiToken != "" {
+		t.Fatalf("apiToken = %q, want empty", client.config.apiToken)
+	}
+}
+
+func TestWithHTTPClientNilRejected(t *testing.T) {
+	_, err := NewClient(
+		WithBaseURL("http://localhost:8366"),
+		WithHTTPClient(nil),
+	)
+	if err == nil {
+		t.Fatal("NewClient() error = nil, want nil http client error")
+	}
+}
+
+func TestTimeoutsRejectZeroAndNegative(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		_, err := NewClient(
+			WithBaseURL("http://localhost:8366"),
+			WithTimeout(timeout),
+		)
+		if err == nil {
+			t.Fatalf("WithTimeout(%s) error = nil, want error", timeout)
+		}
+
+		var cfg requestConfig
+		if err := WithRequestTimeout(timeout)(&cfg); err == nil {
+			t.Fatalf("WithRequestTimeout(%s) error = nil, want error", timeout)
+		}
+	}
+}
+
+func TestNegativeRetriesRejected(t *testing.T) {
+	_, err := NewClient(
+		WithBaseURL("http://localhost:8366"),
+		WithMaxRetries(-1),
+	)
+	if err == nil {
+		t.Fatal("WithMaxRetries(-1) error = nil, want error")
+	}
+
+	var cfg requestConfig
+	if err := WithRequestMaxRetries(-1)(&cfg); err == nil {
+		t.Fatal("WithRequestMaxRetries(-1) error = nil, want error")
+	}
+}
+
+func TestSDKOwnedHeadersRejected(t *testing.T) {
+	for _, name := range []string{"Accept", "content-type", "AUTHORIZATION", "User-Agent"} {
+		_, err := NewClient(
+			WithBaseURL("http://localhost:8366"),
+			WithHeader(name, "bad"),
+		)
+		if err == nil {
+			t.Fatalf("WithHeader(%q) error = nil, want error", name)
+		}
+
+		var cfg requestConfig
+		if err := WithRequestHeader(name, "bad")(&cfg); err == nil {
+			t.Fatalf("WithRequestHeader(%q) error = nil, want error", name)
+		}
+	}
+}
+
+func TestDefaultHTTPClientAndMemoryService(t *testing.T) {
+	client, err := NewClient(WithBaseURL("http://localhost:8366"))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if client.config.httpClient != http.DefaultClient {
+		t.Fatalf("httpClient = %#v, want http.DefaultClient", client.config.httpClient)
+	}
+	if client.Memory == nil || client.Memory.client != client {
+		t.Fatalf("Memory service not wired")
+	}
+}

--- a/memind-clients/go/content.go
+++ b/memind-clients/go/content.go
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ContentBlock interface {
+	contentBlock()
+	json.Marshaler
+}
+
+type TextContentBlock struct {
+	Text string
+}
+
+func (TextContentBlock) contentBlock() {}
+
+func (b TextContentBlock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Text string `json:"text"`
+		Type string `json:"type"`
+	}{Text: b.Text, Type: "text"})
+}
+
+type ContentBlockType string
+
+const (
+	ContentBlockImage ContentBlockType = "image"
+	ContentBlockAudio ContentBlockType = "audio"
+	ContentBlockVideo ContentBlockType = "video"
+)
+
+type MediaContentBlock struct {
+	Type   ContentBlockType
+	Source Source
+}
+
+func (MediaContentBlock) contentBlock() {}
+
+func (b MediaContentBlock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Source Source           `json:"source"`
+		Type   ContentBlockType `json:"type"`
+	}{Source: b.Source, Type: b.Type})
+}
+
+type SourceType string
+
+const (
+	SourceURL    SourceType = "url"
+	SourceBase64 SourceType = "base64"
+)
+
+type Source struct {
+	Type      SourceType `json:"type"`
+	URL       string     `json:"url,omitempty"`
+	MediaType string     `json:"media_type,omitempty"`
+	Data      string     `json:"data,omitempty"`
+}
+
+type MessageOption func(*Message)
+
+func WithMessageTimestamp(timestamp time.Time) MessageOption {
+	return func(msg *Message) {
+		msg.Timestamp = &timestamp
+	}
+}
+
+func WithMessageUserName(userName string) MessageOption {
+	return func(msg *Message) {
+		msg.UserName = userName
+	}
+}
+
+func WithMessageSourceClient(sourceClient string) MessageOption {
+	return func(msg *Message) {
+		msg.SourceClient = sourceClient
+	}
+}
+
+func UserMessage(text string, opts ...MessageOption) Message {
+	return messageWithText(RoleUser, text, opts...)
+}
+
+func AssistantMessage(text string, opts ...MessageOption) Message {
+	return messageWithText(RoleAssistant, text, opts...)
+}
+
+func messageWithText(role Role, text string, opts ...MessageOption) Message {
+	msg := Message{Role: role, Content: []ContentBlock{TextBlock(text)}}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&msg)
+		}
+	}
+	return msg
+}
+
+func TextBlock(text string) ContentBlock {
+	return TextContentBlock{Text: text}
+}
+
+func ImageURL(url string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockImage, Source: Source{Type: SourceURL, URL: url}}
+}
+
+func ImageBase64(mediaType, data string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockImage, Source: Source{Type: SourceBase64, MediaType: mediaType, Data: data}}
+}
+
+func AudioURL(url string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockAudio, Source: Source{Type: SourceURL, URL: url}}
+}
+
+func AudioBase64(mediaType, data string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockAudio, Source: Source{Type: SourceBase64, MediaType: mediaType, Data: data}}
+}
+
+func VideoURL(url string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockVideo, Source: Source{Type: SourceURL, URL: url}}
+}
+
+func VideoBase64(mediaType, data string) ContentBlock {
+	return MediaContentBlock{Type: ContentBlockVideo, Source: Source{Type: SourceBase64, MediaType: mediaType, Data: data}}
+}
+
+type RawContent interface {
+	json.Marshaler
+}
+
+type ConversationContent struct {
+	Messages []Message `json:"messages"`
+}
+
+func Conversation(messages ...Message) ConversationContent {
+	return ConversationContent{Messages: messages}
+}
+
+func (c ConversationContent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Messages []Message `json:"messages"`
+		Type     string    `json:"type"`
+	}{Messages: c.Messages, Type: "conversation"})
+}
+
+type MapRawContent struct {
+	Type   string
+	Fields map[string]any
+}
+
+func RawMap(contentType string, fields map[string]any) (MapRawContent, error) {
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return MapRawContent{}, fmt.Errorf("raw content type must not be blank")
+	}
+	if contentType == "conversation" {
+		return MapRawContent{}, fmt.Errorf(`raw content type "conversation" must use Conversation`)
+	}
+	if _, exists := fields["type"]; exists {
+		return MapRawContent{}, fmt.Errorf(`raw content fields must not contain "type"`)
+	}
+	if fields != nil {
+		if _, err := json.Marshal(fields); err != nil {
+			return MapRawContent{}, fmt.Errorf("raw content fields must be JSON-serializable: %w", err)
+		}
+	}
+	return MapRawContent{Type: contentType, Fields: fields}, nil
+}
+
+func MustRawMap(contentType string, fields map[string]any) MapRawContent {
+	raw, err := RawMap(contentType, fields)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func (m MapRawContent) MarshalJSON() ([]byte, error) {
+	obj := make(map[string]any, len(m.Fields)+1)
+	for key, value := range m.Fields {
+		obj[key] = value
+	}
+	obj["type"] = m.Type
+	return json.Marshal(obj)
+}
+
+type RawJSON struct {
+	Value json.RawMessage
+}
+
+func (r RawJSON) MarshalJSON() ([]byte, error) {
+	return r.Value.MarshalJSON()
+}

--- a/memind-clients/go/content_test.go
+++ b/memind-clients/go/content_test.go
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type customRawContent struct{}
+
+func (customRawContent) MarshalJSON() ([]byte, error) {
+	return []byte(`{"type":"plugin","value":1}`), nil
+}
+
+func TestTextBlockSerializesTextEvenWhenEmpty(t *testing.T) {
+	got, err := json.Marshal(TextBlock(""))
+	if err != nil {
+		t.Fatalf("Marshal TextBlock error = %v", err)
+	}
+	want := `{"text":"","type":"text"}`
+	if string(got) != want {
+		t.Fatalf("TextBlock JSON = %s, want %s", got, want)
+	}
+}
+
+func TestConversationRawContentSerializes(t *testing.T) {
+	got, err := json.Marshal(Conversation(UserMessage("remember this")))
+	if err != nil {
+		t.Fatalf("Marshal Conversation error = %v", err)
+	}
+	want := `{"messages":[{"role":"USER","content":[{"text":"remember this","type":"text"}]}],"type":"conversation"}`
+	if string(got) != want {
+		t.Fatalf("Conversation JSON = %s, want %s", got, want)
+	}
+}
+
+func TestRawMapFlattensFields(t *testing.T) {
+	raw, err := RawMap("document", map[string]any{"title": "T", "body": "B"})
+	if err != nil {
+		t.Fatalf("RawMap error = %v", err)
+	}
+	got, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("Marshal RawMap error = %v", err)
+	}
+	want := `{"body":"B","title":"T","type":"document"}`
+	if string(got) != want {
+		t.Fatalf("RawMap JSON = %s, want %s", got, want)
+	}
+}
+
+func TestRawMapRejectsInvalidInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  string
+		body map[string]any
+	}{
+		{name: "blank type", typ: " ", body: nil},
+		{name: "conversation type", typ: "conversation", body: nil},
+		{name: "type field", typ: "document", body: map[string]any{"type": "bad"}},
+		{name: "unencodable", typ: "document", body: map[string]any{"bad": func() {}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := RawMap(tc.typ, tc.body); err == nil {
+				t.Fatal("RawMap error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestValidateRawContentAcceptsCustomMarshaler(t *testing.T) {
+	if err := validateRawContent(customRawContent{}); err != nil {
+		t.Fatalf("validateRawContent(custom) error = %v", err)
+	}
+}
+
+func TestValidateRawContentRejectsBadRawJSON(t *testing.T) {
+	for _, raw := range []RawJSON{
+		{Value: json.RawMessage(`[]`)},
+		{Value: json.RawMessage(`{"type":" "}`)},
+		{Value: json.RawMessage(`{"type":"document"} {}`)},
+		{Value: json.RawMessage(`{"type":"conversation","messages":[]}`)},
+		{Value: json.RawMessage(`{"type":"conversation","messages":[{"role":"USER","content":[{"type":"text","text":null}]}]}`)},
+		{Value: json.RawMessage(`{"type":"conversation","messages":[{"role":"USER","content":[{"type":"image","source":{"type":"url","url":" "}}]}]}`)},
+	} {
+		if err := validateRawContent(raw); err == nil {
+			t.Fatalf("validateRawContent(%s) error = nil, want error", raw.Value)
+		}
+	}
+}

--- a/memind-clients/go/errors.go
+++ b/memind-clients/go/errors.go
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Error struct {
+	Message string
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+type APIError struct {
+	StatusCode int
+	ErrorCode  string
+	Message    string
+	RequestID  string
+	Details    json.RawMessage
+	Body       []byte
+	RetryAfter *time.Duration
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.ErrorCode != "" {
+		return fmt.Sprintf("memind API error: status=%d code=%s message=%s", e.StatusCode, e.ErrorCode, e.Message)
+	}
+	return fmt.Sprintf("memind API error: status=%d message=%s", e.StatusCode, e.Message)
+}
+
+type AuthenticationError struct {
+	*APIError
+}
+
+func (e *AuthenticationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.APIError
+}
+
+type RateLimitError struct {
+	*APIError
+}
+
+func (e *RateLimitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.APIError
+}
+
+type ConnectionError struct {
+	Op  string
+	URL string
+	Err error
+}
+
+func (e *ConnectionError) Error() string {
+	return fmt.Sprintf("memind connection error: %s %s: %v", e.Op, e.URL, e.Err)
+}
+
+func (e *ConnectionError) Unwrap() error {
+	return e.Err
+}
+
+type TimeoutError struct {
+	Op      string
+	URL     string
+	Timeout time.Duration
+	Err     error
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("memind timeout: %s %s after %s", e.Op, e.URL, e.Timeout)
+}
+
+func (e *TimeoutError) Unwrap() error {
+	return e.Err
+}
+
+type ValidationIssue struct {
+	Field   string
+	Message string
+}
+
+type ValidationError struct {
+	Issues []ValidationIssue
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil || len(e.Issues) == 0 {
+		return "memind validation error"
+	}
+	parts := make([]string, 0, len(e.Issues))
+	for _, issue := range e.Issues {
+		parts = append(parts, issue.Field+": "+issue.Message)
+	}
+	return "memind validation error: " + strings.Join(parts, "; ")
+}

--- a/memind-clients/go/go.mod
+++ b/memind-clients/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/openmemind/memind/memind-clients/go
+
+go 1.25

--- a/memind-clients/go/http.go
+++ b/memind-clients/go/http.go
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type rawEnvelope struct {
+	Data  *json.RawMessage `json:"data"`
+	Error *apiErrorBody    `json:"error"`
+}
+
+type apiErrorBody struct {
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details,omitempty"`
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any, opts requestConfig) error {
+	if ctx == nil {
+		return &ValidationError{Issues: []ValidationIssue{{Field: "context", Message: "context must not be nil"}}}
+	}
+
+	effectiveTimeout := c.config.timeout
+	if opts.timeoutSet {
+		effectiveTimeout = opts.timeout
+	}
+	effectiveRetries := c.config.maxRetries
+	if opts.maxRetriesSet {
+		effectiveRetries = opts.maxRetries
+	}
+
+	var bodyBytes []byte
+	var err error
+	if body != nil {
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			return &ConnectionError{Op: method, URL: c.url(path), Err: fmt.Errorf("marshal request body: %w", err)}
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= effectiveRetries; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, effectiveTimeout)
+		req, err := c.newRequest(attemptCtx, method, path, bodyBytes, opts.headers)
+		if err != nil {
+			cancel()
+			return err
+		}
+
+		resp, err := c.config.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			if isTimeoutError(err) {
+				return &TimeoutError{Op: method, URL: req.URL.String(), Timeout: effectiveTimeout, Err: err}
+			}
+			lastErr = &ConnectionError{Op: method, URL: req.URL.String(), Err: err}
+			if attempt < effectiveRetries {
+				if waitErr := sleepWithContext(ctx, retryDelay(attempt, nil)); waitErr != nil {
+					return waitErr
+				}
+				continue
+			}
+			return lastErr
+		}
+
+		respBody, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		cancel()
+		if readErr != nil {
+			return &ConnectionError{Op: method, URL: req.URL.String(), Err: readErr}
+		}
+		if closeErr != nil {
+			return &ConnectionError{Op: method, URL: req.URL.String(), Err: closeErr}
+		}
+		if isRetryableStatus(resp.StatusCode) && attempt < effectiveRetries {
+			delay := retryDelay(attempt, parseRetryAfter(resp.Header, time.Now()))
+			if waitErr := sleepWithContext(ctx, delay); waitErr != nil {
+				return waitErr
+			}
+			continue
+		}
+		return parseEnvelope(resp, respBody, out)
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+	return &ConnectionError{Op: method, URL: c.url(path), Err: fmt.Errorf("request failed after retries")}
+}
+
+func (c *Client) newRequest(ctx context.Context, method, path string, body []byte, requestHeaders http.Header) (*http.Request, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.url(path), reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.config.userAgent)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.config.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.config.apiToken)
+	}
+	for key, values := range c.config.headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	for key, values := range requestHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	return req, nil
+}
+
+func (c *Client) url(path string) string {
+	normalized := path
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/" + normalized
+	}
+	return c.config.baseURL + "/open/v1" + normalized
+}
+
+func parseEnvelope(resp *http.Response, body []byte, out any) error {
+	requestID := resp.Header.Get("X-Request-Id")
+	contentType := resp.Header.Get("Content-Type")
+	if len(body) > 0 && !strings.Contains(strings.ToLower(contentType), "application/json") {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "parse_error", Message: "non-JSON response", RequestID: requestID, Body: body}
+	}
+	var envelope rawEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "parse_error", Message: "failed to parse response JSON", RequestID: requestID, Body: body}
+	}
+	if envelope.Error != nil {
+		apiErr := &APIError{
+			StatusCode: resp.StatusCode,
+			ErrorCode:  envelope.Error.Code,
+			Message:    envelope.Error.Message,
+			RequestID:  requestID,
+			Details:    envelope.Error.Details,
+			Body:       body,
+			RetryAfter: parseRetryAfter(resp.Header, time.Now()),
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return &AuthenticationError{APIError: apiErr}
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return &RateLimitError{APIError: apiErr}
+		}
+		return apiErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "http_error", Message: resp.Status, RequestID: requestID, Body: body}
+	}
+	if envelope.Data == nil {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "parse_error", Message: "missing data envelope", RequestID: requestID, Body: body}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := rejectNullRequiredArrays(*envelope.Data, out); err != nil {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "parse_error", Message: err.Error(), RequestID: requestID, Body: body}
+	}
+	if err := json.Unmarshal(*envelope.Data, out); err != nil {
+		return &APIError{StatusCode: resp.StatusCode, ErrorCode: "parse_error", Message: "failed to decode data envelope", RequestID: requestID, Body: body}
+	}
+	normalizeResponse(out)
+	return nil
+}
+
+func normalizeResponse(out any) {
+	switch response := out.(type) {
+	case *ExtractMemoryResponse:
+		if response.RawDataIDs == nil {
+			response.RawDataIDs = []string{}
+		}
+		if response.ItemIDs == nil {
+			response.ItemIDs = []int64{}
+		}
+		if response.InsightIDs == nil {
+			response.InsightIDs = []int64{}
+		}
+	case *RetrieveMemoryResponse:
+		if response.Items == nil {
+			response.Items = []RetrievedItem{}
+		}
+		if response.Insights == nil {
+			response.Insights = []RetrievedInsight{}
+		}
+		if response.RawData == nil {
+			response.RawData = []RetrievedRawData{}
+		}
+		if response.Evidences == nil {
+			response.Evidences = []string{}
+		}
+		if response.Trace != nil && response.Trace.Stages == nil {
+			response.Trace.Stages = []StageView{}
+		}
+	}
+}
+
+func rejectNullRequiredArrays(data json.RawMessage, out any) error {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil || obj == nil {
+		return nil
+	}
+	required := requiredArrayFields(out)
+	for _, field := range required {
+		raw, ok := obj[field]
+		if !ok {
+			continue
+		}
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return fmt.Errorf("required array field %q must not be null", field)
+		}
+	}
+	if _, ok := out.(*RetrieveMemoryResponse); ok {
+		if traceRaw, ok := obj["trace"]; ok && !bytes.Equal(bytes.TrimSpace(traceRaw), []byte("null")) {
+			var trace map[string]json.RawMessage
+			if err := json.Unmarshal(traceRaw, &trace); err == nil && trace != nil {
+				if stages, ok := trace["stages"]; ok && bytes.Equal(bytes.TrimSpace(stages), []byte("null")) {
+					return fmt.Errorf(`required array field "trace.stages" must not be null`)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func requiredArrayFields(out any) []string {
+	switch out.(type) {
+	case *ExtractMemoryResponse:
+		return []string{"rawDataIds", "itemIds", "insightIds"}
+	case *RetrieveMemoryResponse:
+		return []string{"items", "insights", "rawData", "evidences"}
+	default:
+		return nil
+	}
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	if urlErr, ok := err.(*url.Error); ok {
+		return isTimeoutError(urlErr.Err)
+	}
+	return false
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/memind-clients/go/http_test.go
+++ b/memind-clients/go/http_test.go
@@ -1,0 +1,424 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type closeTrackingBody struct {
+	*bytes.Reader
+	closed *atomic.Bool
+}
+
+func (b closeTrackingBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+func TestDoSetsHeadersAndParsesDataEnvelope(t *testing.T) {
+	var gotAuth string
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","service":"memind-server"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(
+		WithBaseURL(server.URL),
+		WithAPIToken("token"),
+		WithHeader("X-Test", "true"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var out HealthResponse
+	if err := client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{}); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if out.Status != "UP" || out.Service != "memind-server" {
+		t.Fatalf("out = %#v", out)
+	}
+	if gotAuth != "Bearer token" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.HasPrefix(gotUA, "memind-go/") {
+		t.Fatalf("User-Agent = %q", gotUA)
+	}
+}
+
+func TestDoRetriesPostWithFullBody(t *testing.T) {
+	var attempts atomic.Int32
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		w.Header().Set("Content-Type", "application/json")
+		if attempts.Load() == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"retry"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","service":"memind-server"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	cfg := requestConfig{maxRetriesSet: true, maxRetries: 1}
+	var out HealthResponse
+	if err := client.do(context.Background(), http.MethodPost, "/health", map[string]string{"a": "b"}, &out, cfg); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if len(bodies) != 2 || bodies[0] != `{"a":"b"}` || bodies[1] != `{"a":"b"}` {
+		t.Fatalf("bodies = %#v", bodies)
+	}
+}
+
+func TestDoMapsErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "req-1")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"unauthorized","message":"bad token","details":{"reason":"missing"}}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var authErr *AuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("error = %T, want *AuthenticationError", err)
+	}
+	if authErr.RequestID != "req-1" || authErr.ErrorCode != "unauthorized" {
+		t.Fatalf("authErr = %#v", authErr.APIError)
+	}
+}
+
+func TestDoMapsRateLimitAndRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limited","message":"slow down"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var rateErr *RateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("error = %T, want *RateLimitError", err)
+	}
+	if rateErr.ErrorCode != "rate_limited" {
+		t.Fatalf("ErrorCode = %q, want rate_limited", rateErr.ErrorCode)
+	}
+	if rateErr.RetryAfter == nil || *rateErr.RetryAfter != 3*time.Second {
+		t.Fatalf("RetryAfter = %v, want 3s", rateErr.RetryAfter)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T, want *APIError chain", err)
+	}
+}
+
+func TestDoRejectsInvalidSuccessEnvelope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode != "parse_error" {
+		t.Fatalf("error = %#v, want parse APIError", err)
+	}
+}
+
+func TestDoContextCancellationReturnsPromptly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var out HealthResponse
+	err = client.do(ctx, http.MethodGet, "/health", nil, &out, requestConfig{})
+	if err == nil {
+		t.Fatal("do error = nil, want cancellation error")
+	}
+}
+
+func TestDoClosesResponseBody(t *testing.T) {
+	var closed atomic.Bool
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := closeTrackingBody{
+				Reader: bytes.NewReader([]byte(`{"data":{"status":"UP","service":"memind-server"}}`)),
+				closed: &closed,
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		}),
+	}
+	client, err := NewClient(
+		WithBaseURL("http://memind.test"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	if err := client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{}); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if !closed.Load() {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestDoClosesAPIErrorResponseBody(t *testing.T) {
+	var closed atomic.Bool
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := closeTrackingBody{
+				Reader: bytes.NewReader([]byte(`{"error":{"code":"unauthorized","message":"bad token"}}`)),
+				closed: &closed,
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     "401 Unauthorized",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		}),
+	}
+	client, err := NewClient(
+		WithBaseURL("http://memind.test"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T, want *APIError", err)
+	}
+	if !closed.Load() {
+		t.Fatal("API error response body was not closed")
+	}
+}
+
+func TestDoClosesParseErrorResponseBody(t *testing.T) {
+	var closed atomic.Bool
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := closeTrackingBody{
+				Reader: bytes.NewReader([]byte(`not-json`)),
+				closed: &closed,
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		}),
+	}
+	client, err := NewClient(
+		WithBaseURL("http://memind.test"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out HealthResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode != "parse_error" {
+		t.Fatalf("error = %#v, want parse APIError", err)
+	}
+	if !closed.Load() {
+		t.Fatal("parse error response body was not closed")
+	}
+}
+
+func TestDoClosesRetryResponseBodies(t *testing.T) {
+	var attempts atomic.Int32
+	var firstClosed atomic.Bool
+	var secondClosed atomic.Bool
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempt := attempts.Add(1)
+			if attempt == 1 {
+				body := closeTrackingBody{
+					Reader: bytes.NewReader([]byte(`{"error":{"code":"unavailable","message":"retry"}}`)),
+					closed: &firstClosed,
+				}
+				return &http.Response{
+					StatusCode: http.StatusServiceUnavailable,
+					Status:     "503 Service Unavailable",
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+						"Retry-After":  []string{"0"},
+					},
+					Body:    body,
+					Request: req,
+				}, nil
+			}
+			body := closeTrackingBody{
+				Reader: bytes.NewReader([]byte(`{"data":{"status":"UP","service":"memind-server"}}`)),
+				closed: &secondClosed,
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		}),
+	}
+	client, err := NewClient(
+		WithBaseURL("http://memind.test"),
+		WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	cfg := requestConfig{maxRetriesSet: true, maxRetries: 1}
+	var out HealthResponse
+	if err := client.do(context.Background(), http.MethodGet, "/health", nil, &out, cfg); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts.Load())
+	}
+	if !firstClosed.Load() || !secondClosed.Load() {
+		t.Fatalf("retry response bodies closed = %v, %v; want both true", firstClosed.Load(), secondClosed.Load())
+	}
+}
+
+func TestMissingRequiredArraysDecodeToEmptySlices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"status":"SUCCESS"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out ExtractMemoryResponse
+	if err := client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{}); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if out.RawDataIDs == nil || out.ItemIDs == nil || out.InsightIDs == nil {
+		t.Fatalf("arrays were not normalized: %#v", out)
+	}
+}
+
+func TestNullRequiredArraysReturnParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"items":null,"insights":[],"rawData":[],"evidences":[]}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out RetrieveMemoryResponse
+	err = client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode != "parse_error" {
+		t.Fatalf("error = %#v, want parse APIError", err)
+	}
+}
+
+func TestTraceResponsesDecodeTypedViews(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"items":[],"insights":[],"rawData":[],"evidences":[],"trace":{"stages":[{"stage":"vector","degraded":false,"skipped":false}],"merge":{"inputCount":2,"outputCount":1,"deduplicatedCount":1,"sourceCount":1,"status":"OK"},"finalResults":{"strategy":"SIMPLE","status":"OK","itemCount":1,"insightCount":0,"rawDataCount":1,"evidenceCount":1}}}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	var out RetrieveMemoryResponse
+	if err := client.do(context.Background(), http.MethodGet, "/health", nil, &out, requestConfig{}); err != nil {
+		t.Fatalf("do error = %v", err)
+	}
+	if out.Trace == nil || len(out.Trace.Stages) != 1 || out.Trace.Merge == nil || out.Trace.FinalResults == nil {
+		t.Fatalf("trace = %#v", out.Trace)
+	}
+	if out.Trace.Merge.DeduplicatedCount != 1 || out.Trace.FinalResults.EvidenceCount != 1 {
+		t.Fatalf("trace values = %#v", out.Trace)
+	}
+}

--- a/memind-clients/go/memory.go
+++ b/memind-clients/go/memory.go
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"context"
+	"net/http"
+)
+
+type MemoryService struct {
+	client *Client
+}
+
+func (s *MemoryService) Extract(ctx context.Context, req ExtractMemoryRequest, opts ...RequestOption) (*ExtractMemoryResponse, error) {
+	if err := validateExtractRequest(req); err != nil {
+		return nil, err
+	}
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.maxRetriesSet {
+		cfg.maxRetriesSet = true
+		cfg.maxRetries = 0
+	}
+	var out ExtractMemoryResponse
+	if err := s.client.do(ctx, http.MethodPost, "/memory/sync/extract", req, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *MemoryService) AddMessage(ctx context.Context, req AddMessageRequest, opts ...RequestOption) (*AddMessageResponse, error) {
+	if err := validateAddMessageRequest(req); err != nil {
+		return nil, err
+	}
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.maxRetriesSet {
+		cfg.maxRetriesSet = true
+		cfg.maxRetries = 0
+	}
+	var out AddMessageResponse
+	if err := s.client.do(ctx, http.MethodPost, "/memory/sync/add-message", req, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *MemoryService) Commit(ctx context.Context, req CommitMemoryRequest, opts ...RequestOption) (*ExtractMemoryResponse, error) {
+	if err := validateCommitRequest(req); err != nil {
+		return nil, err
+	}
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.maxRetriesSet {
+		cfg.maxRetriesSet = true
+		cfg.maxRetries = 0
+	}
+	var out ExtractMemoryResponse
+	if err := s.client.do(ctx, http.MethodPost, "/memory/sync/commit", req, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *MemoryService) Retrieve(ctx context.Context, req RetrieveMemoryRequest, opts ...RequestOption) (*RetrieveMemoryResponse, error) {
+	if err := validateRetrieveRequest(req); err != nil {
+		return nil, err
+	}
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	var out RetrieveMemoryResponse
+	if err := s.client.do(ctx, http.MethodPost, "/memory/retrieve", req, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *MemoryService) EnqueueExtract(ctx context.Context, req ExtractMemoryRequest, opts ...RequestOption) (*OperationAccepted, error) {
+	if err := validateExtractRequest(req); err != nil {
+		return nil, err
+	}
+	return s.enqueue(ctx, "/memory/async/extract", req, opts...)
+}
+
+func (s *MemoryService) EnqueueAddMessage(ctx context.Context, req AddMessageRequest, opts ...RequestOption) (*OperationAccepted, error) {
+	if err := validateAddMessageRequest(req); err != nil {
+		return nil, err
+	}
+	return s.enqueue(ctx, "/memory/async/add-message", req, opts...)
+}
+
+func (s *MemoryService) EnqueueCommit(ctx context.Context, req CommitMemoryRequest, opts ...RequestOption) (*OperationAccepted, error) {
+	if err := validateCommitRequest(req); err != nil {
+		return nil, err
+	}
+	return s.enqueue(ctx, "/memory/async/commit", req, opts...)
+}
+
+func (s *MemoryService) enqueue(ctx context.Context, path string, req any, opts ...RequestOption) (*OperationAccepted, error) {
+	cfg, err := applyRequestOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.maxRetriesSet {
+		cfg.maxRetriesSet = true
+		cfg.maxRetries = 0
+	}
+	var out OperationAccepted
+	if err := s.client.do(ctx, http.MethodPost, path, req, &out, cfg); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func applyRequestOptions(opts []RequestOption) (requestConfig, error) {
+	var cfg requestConfig
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&cfg); err != nil {
+			return requestConfig{}, err
+		}
+	}
+	return cfg, nil
+}

--- a/memind-clients/go/memory_test.go
+++ b/memind-clients/go/memory_test.go
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHealthCallsEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/open/v1/health" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","service":"memind-server"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	resp, err := client.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health error = %v", err)
+	}
+	if resp.Status != "UP" {
+		t.Fatalf("status = %q", resp.Status)
+	}
+}
+
+func TestMemoryMethodsCallEndpoints(t *testing.T) {
+	expected := []string{
+		"POST /open/v1/memory/sync/extract",
+		"POST /open/v1/memory/sync/add-message",
+		"POST /open/v1/memory/sync/commit",
+		"POST /open/v1/memory/retrieve",
+		"POST /open/v1/memory/async/extract",
+		"POST /open/v1/memory/async/add-message",
+		"POST /open/v1/memory/async/commit",
+	}
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/open/v1/memory/sync/add-message":
+			_, _ = w.Write([]byte(`{"data":{"triggered":false}}`))
+		case "/open/v1/memory/retrieve":
+			_, _ = w.Write([]byte(`{"data":{"items":[],"insights":[],"rawData":[],"evidences":[]}}`))
+		case "/open/v1/memory/async/extract", "/open/v1/memory/async/add-message", "/open/v1/memory/async/commit":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"data":{"operationId":"op_1","status":"accepted","mode":"async"}}`))
+		default:
+			_, _ = w.Write([]byte(`{"data":{"status":"SUCCESS","rawDataIds":[],"itemIds":[],"insightIds":[],"insightPending":false}}`))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	ctx := context.Background()
+	extractReq := ExtractMemoryRequest{UserID: "u", AgentID: "a", RawContent: Conversation(UserMessage("hello"))}
+	addReq := AddMessageRequest{UserID: "u", AgentID: "a", Message: UserMessage("hello")}
+	commitReq := CommitMemoryRequest{UserID: "u", AgentID: "a"}
+	retrieveReq := RetrieveMemoryRequest{UserID: "u", AgentID: "a", Query: "q", Strategy: StrategySimple}
+
+	_, _ = client.Memory.Extract(ctx, extractReq)
+	_, _ = client.Memory.AddMessage(ctx, addReq)
+	_, _ = client.Memory.Commit(ctx, commitReq)
+	_, _ = client.Memory.Retrieve(ctx, retrieveReq)
+	_, _ = client.Memory.EnqueueExtract(ctx, extractReq)
+	_, _ = client.Memory.EnqueueAddMessage(ctx, addReq)
+	_, _ = client.Memory.EnqueueCommit(ctx, commitReq)
+
+	if len(seen) != len(expected) {
+		t.Fatalf("seen = %#v", seen)
+	}
+	for i := range expected {
+		if seen[i] != expected[i] {
+			t.Fatalf("seen[%d] = %q, want %q", i, seen[i], expected[i])
+		}
+	}
+}
+
+func TestMutatingMethodsDoNotRetryByDefault(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"retry"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, _ = client.Memory.Extract(context.Background(), ExtractMemoryRequest{UserID: "u", AgentID: "a", RawContent: Conversation(UserMessage("hello"))})
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestMutatingMethodsRespectRequestRetryOverride(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"retry"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"status":"SUCCESS","rawDataIds":[],"itemIds":[],"insightIds":[],"insightPending":false}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	resp, err := client.Memory.Extract(
+		context.Background(),
+		ExtractMemoryRequest{UserID: "u", AgentID: "a", RawContent: Conversation(UserMessage("hello"))},
+		WithRequestMaxRetries(1),
+	)
+	if err != nil {
+		t.Fatalf("Extract error = %v", err)
+	}
+	if resp.Status != "SUCCESS" || attempts != 2 {
+		t.Fatalf("status=%q attempts=%d, want SUCCESS and 2 attempts", resp.Status, attempts)
+	}
+}
+
+func TestRetrieveRequestRetryOverrideCanDisableDefaultRetries(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"retry"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(WithBaseURL(server.URL), WithMaxRetries(2))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, _ = client.Memory.Retrieve(
+		context.Background(),
+		RetrieveMemoryRequest{UserID: "u", AgentID: "a", Query: "q", Strategy: StrategySimple},
+		WithRequestMaxRetries(0),
+	)
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRequestTimeoutOverridesClientTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","service":"memind-server"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(
+		WithBaseURL(server.URL),
+		WithTimeout(10*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if _, err := client.Health(context.Background(), WithRequestTimeout(200*time.Millisecond)); err != nil {
+		t.Fatalf("Health with request timeout override error = %v", err)
+	}
+}

--- a/memind-clients/go/models.go
+++ b/memind-clients/go/models.go
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import "time"
+
+type Role string
+
+const (
+	RoleUser      Role = "USER"
+	RoleAssistant Role = "ASSISTANT"
+)
+
+type Strategy string
+
+const (
+	StrategySimple Strategy = "SIMPLE"
+	StrategyDeep   Strategy = "DEEP"
+)
+
+type Message struct {
+	Role         Role           `json:"role"`
+	Content      []ContentBlock `json:"content"`
+	Timestamp    *time.Time     `json:"timestamp,omitempty"`
+	UserName     string         `json:"userName,omitempty"`
+	SourceClient string         `json:"sourceClient,omitempty"`
+}
+
+type ExtractMemoryRequest struct {
+	UserID       string     `json:"userId"`
+	AgentID      string     `json:"agentId"`
+	RawContent   RawContent `json:"rawContent"`
+	SourceClient string     `json:"sourceClient,omitempty"`
+}
+
+type AddMessageRequest struct {
+	UserID       string  `json:"userId"`
+	AgentID      string  `json:"agentId"`
+	Message      Message `json:"message"`
+	SourceClient string  `json:"sourceClient,omitempty"`
+}
+
+type CommitMemoryRequest struct {
+	UserID       string `json:"userId"`
+	AgentID      string `json:"agentId"`
+	SourceClient string `json:"sourceClient,omitempty"`
+}
+
+type RetrieveMemoryRequest struct {
+	UserID   string   `json:"userId"`
+	AgentID  string   `json:"agentId"`
+	Query    string   `json:"query"`
+	Strategy Strategy `json:"strategy"`
+	Trace    *bool    `json:"trace,omitempty"`
+}
+
+type HealthResponse struct {
+	Status  string `json:"status"`
+	Service string `json:"service"`
+}
+
+type ExtractMemoryResponse struct {
+	Status         string   `json:"status"`
+	RawDataIDs     []string `json:"rawDataIds"`
+	ItemIDs        []int64  `json:"itemIds"`
+	InsightIDs     []int64  `json:"insightIds"`
+	InsightPending bool     `json:"insightPending"`
+	DurationMillis *int64   `json:"durationMillis,omitempty"`
+	ErrorMessage   string   `json:"errorMessage,omitempty"`
+}
+
+type AddMessageResponse struct {
+	Triggered bool                   `json:"triggered"`
+	Result    *ExtractMemoryResponse `json:"result,omitempty"`
+}
+
+type OperationAccepted struct {
+	OperationID string `json:"operationId"`
+	Status      string `json:"status"`
+	Mode        string `json:"mode"`
+}
+
+type RetrieveMemoryResponse struct {
+	Status    string              `json:"status,omitempty"`
+	Items     []RetrievedItem     `json:"items"`
+	Insights  []RetrievedInsight  `json:"insights"`
+	RawData   []RetrievedRawData  `json:"rawData"`
+	Evidences []string            `json:"evidences"`
+	Strategy  string              `json:"strategy,omitempty"`
+	Query     string              `json:"query,omitempty"`
+	Trace     *RetrievalTraceView `json:"trace,omitempty"`
+}
+
+type RetrievedItem struct {
+	ID          string     `json:"id"`
+	Text        string     `json:"text"`
+	VectorScore float32    `json:"vectorScore"`
+	FinalScore  float64    `json:"finalScore"`
+	OccurredAt  *time.Time `json:"occurredAt,omitempty"`
+}
+
+type RetrievedInsight struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+	Tier string `json:"tier,omitempty"`
+}
+
+type RetrievedRawData struct {
+	RawDataID string   `json:"rawDataId"`
+	Caption   string   `json:"caption,omitempty"`
+	MaxScore  float64  `json:"maxScore"`
+	ItemIDs   []string `json:"itemIds,omitempty"`
+}
+
+type RetrievalTraceView struct {
+	TraceID      string      `json:"traceId,omitempty"`
+	StartedAt    *time.Time  `json:"startedAt,omitempty"`
+	CompletedAt  *time.Time  `json:"completedAt,omitempty"`
+	Truncated    *bool       `json:"truncated,omitempty"`
+	Stages       []StageView `json:"stages"`
+	Merge        *MergeView  `json:"merge,omitempty"`
+	FinalResults *FinalView  `json:"finalResults,omitempty"`
+}
+
+type StageView struct {
+	Stage          string           `json:"stage,omitempty"`
+	Tier           string           `json:"tier,omitempty"`
+	Method         string           `json:"method,omitempty"`
+	Status         string           `json:"status,omitempty"`
+	InputCount     *int             `json:"inputCount,omitempty"`
+	CandidateCount *int             `json:"candidateCount,omitempty"`
+	ResultCount    *int             `json:"resultCount,omitempty"`
+	Degraded       bool             `json:"degraded"`
+	Skipped        bool             `json:"skipped"`
+	StartedAt      *time.Time       `json:"startedAt,omitempty"`
+	DurationMillis *int64           `json:"durationMillis,omitempty"`
+	Attributes     map[string]any   `json:"attributes,omitempty"`
+	Candidates     []map[string]any `json:"candidates,omitempty"`
+}
+
+type MergeView struct {
+	InputCount        int    `json:"inputCount"`
+	OutputCount       int    `json:"outputCount"`
+	DeduplicatedCount int    `json:"deduplicatedCount"`
+	SourceCount       int    `json:"sourceCount"`
+	Status            string `json:"status,omitempty"`
+}
+
+type FinalView struct {
+	Strategy      string `json:"strategy,omitempty"`
+	Status        string `json:"status,omitempty"`
+	ItemCount     int    `json:"itemCount"`
+	InsightCount  int    `json:"insightCount"`
+	RawDataCount  int    `json:"rawDataCount"`
+	EvidenceCount int    `json:"evidenceCount"`
+}

--- a/memind-clients/go/options.go
+++ b/memind-clients/go/options.go
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	envBaseURL  = "MEMIND_BASE_URL"
+	envAPIToken = "MEMIND_API_TOKEN"
+)
+
+var sdkOwnedHeaders = map[string]struct{}{
+	"accept":        {},
+	"content-type":  {},
+	"authorization": {},
+	"user-agent":    {},
+}
+
+type clientConfig struct {
+	baseURL    string
+	apiToken   string
+	timeout    time.Duration
+	maxRetries int
+	httpClient *http.Client
+	headers    http.Header
+	userAgent  string
+}
+
+type requestConfig struct {
+	timeoutSet    bool
+	timeout       time.Duration
+	maxRetriesSet bool
+	maxRetries    int
+	headers       http.Header
+}
+
+func WithBaseURL(baseURL string) Option {
+	return func(cfg *clientConfig) error {
+		cfg.baseURL = normalizeBaseURL(baseURL)
+		return nil
+	}
+}
+
+func WithAPIToken(token string) Option {
+	return func(cfg *clientConfig) error {
+		cfg.apiToken = strings.TrimSpace(token)
+		return nil
+	}
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(cfg *clientConfig) error {
+		if client == nil {
+			return fmt.Errorf("http client must not be nil")
+		}
+		cfg.httpClient = client
+		return nil
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(cfg *clientConfig) error {
+		if timeout <= 0 {
+			return fmt.Errorf("timeout must be greater than zero")
+		}
+		cfg.timeout = timeout
+		return nil
+	}
+}
+
+func WithMaxRetries(maxRetries int) Option {
+	return func(cfg *clientConfig) error {
+		if maxRetries < 0 {
+			return fmt.Errorf("maxRetries must be non-negative")
+		}
+		cfg.maxRetries = maxRetries
+		return nil
+	}
+}
+
+func WithHeader(name, value string) Option {
+	return func(cfg *clientConfig) error {
+		if err := validateCustomHeader(name); err != nil {
+			return err
+		}
+		cfg.headers.Set(name, value)
+		return nil
+	}
+}
+
+func WithUserAgent(userAgent string) Option {
+	return func(cfg *clientConfig) error {
+		userAgent = strings.TrimSpace(userAgent)
+		if userAgent == "" {
+			return fmt.Errorf("userAgent must not be blank")
+		}
+		cfg.userAgent = userAgent
+		return nil
+	}
+}
+
+type RequestOption func(*requestConfig) error
+
+func WithRequestTimeout(timeout time.Duration) RequestOption {
+	return func(cfg *requestConfig) error {
+		if timeout <= 0 {
+			return fmt.Errorf("request timeout must be greater than zero")
+		}
+		cfg.timeoutSet = true
+		cfg.timeout = timeout
+		return nil
+	}
+}
+
+func WithRequestMaxRetries(maxRetries int) RequestOption {
+	return func(cfg *requestConfig) error {
+		if maxRetries < 0 {
+			return fmt.Errorf("request maxRetries must be non-negative")
+		}
+		cfg.maxRetriesSet = true
+		cfg.maxRetries = maxRetries
+		return nil
+	}
+}
+
+func WithRequestHeader(name, value string) RequestOption {
+	return func(cfg *requestConfig) error {
+		if err := validateCustomHeader(name); err != nil {
+			return err
+		}
+		if cfg.headers == nil {
+			cfg.headers = make(http.Header)
+		}
+		cfg.headers.Set(name, value)
+		return nil
+	}
+}
+
+func defaultClientConfig() clientConfig {
+	return clientConfig{
+		baseURL:    normalizeBaseURL(os.Getenv(envBaseURL)),
+		apiToken:   strings.TrimSpace(os.Getenv(envAPIToken)),
+		timeout:    30 * time.Second,
+		maxRetries: 2,
+		httpClient: http.DefaultClient,
+		headers:    make(http.Header),
+		userAgent:  "memind-go/" + Version,
+	}
+}
+
+func normalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func validateBaseURL(baseURL string) error {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("baseURL must be an absolute URL with http or https scheme")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("baseURL scheme must be http or https")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("baseURL must not include query or fragment")
+	}
+	return nil
+}
+
+func validateCustomHeader(name string) error {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return fmt.Errorf("header name must not be blank")
+	}
+	if _, ok := sdkOwnedHeaders[normalized]; ok {
+		return fmt.Errorf("header %q is managed by the SDK", name)
+	}
+	return nil
+}

--- a/memind-clients/go/readme_examples_test.go
+++ b/memind-clients/go/readme_examples_test.go
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	memind "github.com/openmemind/memind/memind-clients/go"
+)
+
+func Example_readmeQuickStart() {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/open/v1/health":
+			_, _ = w.Write([]byte(`{"data":{"status":"UP","service":"memind-server"}}`))
+		case "/open/v1/memory/sync/extract":
+			_, _ = w.Write([]byte(`{"data":{"status":"SUCCESS","rawDataIds":[],"itemIds":[],"insightIds":[],"insightPending":false}}`))
+		case "/open/v1/memory/retrieve":
+			_, _ = w.Write([]byte(`{"data":{"items":[],"insights":[],"rawData":[],"evidences":[]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"not found"}}`))
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	client, err := memind.NewClient(
+		memind.WithBaseURL(server.URL),
+		memind.WithAPIToken(os.Getenv("MEMIND_API_TOKEN")),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	health, err := client.Health(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(health.Status)
+
+	extract, err := client.Memory.Extract(ctx, memind.ExtractMemoryRequest{
+		UserID:     "user-1",
+		AgentID:    "agent-1",
+		RawContent: memind.Conversation(memind.UserMessage("Remember that I prefer concise answers.")),
+	})
+	if err != nil {
+		var apiErr *memind.APIError
+		if errors.As(err, &apiErr) {
+			fmt.Println(apiErr.StatusCode, apiErr.ErrorCode, apiErr.RequestID)
+		}
+		panic(err)
+	}
+	fmt.Println(extract.Status)
+
+	result, err := client.Memory.Retrieve(ctx, memind.RetrieveMemoryRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Query:    "What does the user like?",
+		Strategy: memind.StrategySimple,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(len(result.Items))
+
+	// Output:
+	// UP
+	// SUCCESS
+	// 0
+}
+
+func Example_rawContent() {
+	raw := memind.Conversation(
+		memind.UserMessage("My preferred timezone is Asia/Shanghai."),
+		memind.AssistantMessage("I will remember that."),
+	)
+	fmt.Printf("%T\n", raw)
+
+	mapped, err := memind.RawMap("document", map[string]any{
+		"title": "Project note",
+		"body":  "The release checklist is ready.",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%T\n", mapped)
+
+	// Output:
+	// memind.ConversationContent
+	// memind.MapRawContent
+}

--- a/memind-clients/go/retry.go
+++ b/memind-clients/go/retry.go
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func isRetryableStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseRetryAfter(header http.Header, now time.Time) *time.Duration {
+	value := header.Get("Retry-After")
+	if value == "" {
+		return nil
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		duration := time.Duration(seconds) * time.Second
+		return &duration
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		duration := retryAt.Sub(now)
+		if duration < 0 {
+			duration = 0
+		}
+		return &duration
+	}
+	return nil
+}
+
+func retryDelay(attempt int, retryAfter *time.Duration) time.Duration {
+	if retryAfter != nil {
+		return *retryAfter
+	}
+	delay := 500 * time.Millisecond
+	for i := 0; i < attempt; i++ {
+		delay *= 2
+	}
+	if delay > 2*time.Second {
+		delay = 2 * time.Second
+	}
+	jitter := time.Duration(rand.Int63n(int64(100 * time.Millisecond)))
+	return delay + jitter
+}

--- a/memind-clients/go/retry_test.go
+++ b/memind-clients/go/retry_test.go
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestIsRetryableStatus(t *testing.T) {
+	for _, status := range []int{408, 429, 500, 502, 503, 504} {
+		if !isRetryableStatus(status) {
+			t.Fatalf("isRetryableStatus(%d) = false", status)
+		}
+	}
+	for _, status := range []int{400, 401, 403, 404, 409, 422, 501} {
+		if isRetryableStatus(status) {
+			t.Fatalf("isRetryableStatus(%d) = true", status)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Retry-After", "3")
+	got := parseRetryAfter(headers, time.Now())
+	if got == nil || *got != 3*time.Second {
+		t.Fatalf("Retry-After seconds = %v, want 3s", got)
+	}
+
+	when := time.Now().Add(5 * time.Second).UTC().Format(http.TimeFormat)
+	headers.Set("Retry-After", when)
+	got = parseRetryAfter(headers, time.Now())
+	if got == nil || *got <= 0 {
+		t.Fatalf("Retry-After date = %v, want positive duration", got)
+	}
+}
+
+func TestAPIErrorSupportsErrorsAs(t *testing.T) {
+	base := &APIError{StatusCode: 401, ErrorCode: "unauthorized", Message: "bad token"}
+	err := &AuthenticationError{APIError: base}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatal("errors.As(AuthenticationError, *APIError) = false")
+	}
+	if apiErr.StatusCode != 401 {
+		t.Fatalf("StatusCode = %d", apiErr.StatusCode)
+	}
+}

--- a/memind-clients/go/validation.go
+++ b/memind-clients/go/validation.go
@@ -1,0 +1,241 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func validateExtractRequest(req ExtractMemoryRequest) error {
+	var issues []ValidationIssue
+	requireNonBlank(&issues, "userId", req.UserID)
+	requireNonBlank(&issues, "agentId", req.AgentID)
+	if req.RawContent == nil {
+		issues = append(issues, ValidationIssue{Field: "rawContent", Message: "rawContent is required"})
+	} else if err := validateRawContent(req.RawContent); err != nil {
+		issues = append(issues, ValidationIssue{Field: "rawContent", Message: err.Error()})
+	}
+	return validationErrorOrNil(issues)
+}
+
+func validateAddMessageRequest(req AddMessageRequest) error {
+	var issues []ValidationIssue
+	requireNonBlank(&issues, "userId", req.UserID)
+	requireNonBlank(&issues, "agentId", req.AgentID)
+	if err := validateMessage(req.Message, "message"); err != nil {
+		issues = append(issues, ValidationIssue{Field: "message", Message: err.Error()})
+	}
+	return validationErrorOrNil(issues)
+}
+
+func validateCommitRequest(req CommitMemoryRequest) error {
+	var issues []ValidationIssue
+	requireNonBlank(&issues, "userId", req.UserID)
+	requireNonBlank(&issues, "agentId", req.AgentID)
+	return validationErrorOrNil(issues)
+}
+
+func validateRetrieveRequest(req RetrieveMemoryRequest) error {
+	var issues []ValidationIssue
+	requireNonBlank(&issues, "userId", req.UserID)
+	requireNonBlank(&issues, "agentId", req.AgentID)
+	requireNonBlank(&issues, "query", req.Query)
+	if strings.TrimSpace(string(req.Strategy)) == "" {
+		issues = append(issues, ValidationIssue{Field: "strategy", Message: "strategy is required"})
+	}
+	return validationErrorOrNil(issues)
+}
+
+func validateRawContent(raw RawContent) error {
+	payload, err := raw.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("marshal raw content: %w", err)
+	}
+	var obj map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if err := decoder.Decode(&obj); err != nil {
+		return fmt.Errorf("raw content must be a JSON object: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("raw content must contain exactly one JSON value")
+	}
+	if obj == nil {
+		return fmt.Errorf("raw content must be a JSON object")
+	}
+	var contentType string
+	if err := json.Unmarshal(obj["type"], &contentType); err != nil || strings.TrimSpace(contentType) == "" {
+		return fmt.Errorf("raw content type must be a non-blank string")
+	}
+	if contentType == "conversation" {
+		if conv, ok := raw.(ConversationContent); ok {
+			if len(conv.Messages) == 0 {
+				return fmt.Errorf("conversation raw content requires non-empty messages")
+			}
+			for i, message := range conv.Messages {
+				if err := validateMessage(message, fmt.Sprintf("messages[%d]", i)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		messagesRaw, ok := obj["messages"]
+		if !ok {
+			return fmt.Errorf("conversation raw content requires non-empty messages")
+		}
+		var messages []json.RawMessage
+		if err := json.Unmarshal(messagesRaw, &messages); err != nil || len(messages) == 0 {
+			return fmt.Errorf("conversation raw content requires non-empty messages")
+		}
+		for i, messageRaw := range messages {
+			if err := validateMarshaledConversationMessage(messageRaw, fmt.Sprintf("messages[%d]", i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateMarshaledConversationMessage(raw json.RawMessage, field string) error {
+	var message struct {
+		Role    Role              `json:"role"`
+		Content []json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &message); err != nil {
+		return fmt.Errorf("%s must be a valid message object: %w", field, err)
+	}
+	if message.Role != RoleUser && message.Role != RoleAssistant {
+		return fmt.Errorf("%s.role must be USER or ASSISTANT", field)
+	}
+	if len(message.Content) == 0 {
+		return fmt.Errorf("%s.content must be non-empty", field)
+	}
+	for i, blockRaw := range message.Content {
+		if err := validateMarshaledContentBlock(blockRaw); err != nil {
+			return fmt.Errorf("%s.content[%d]: %w", field, i, err)
+		}
+	}
+	return nil
+}
+
+func validateMarshaledContentBlock(raw json.RawMessage) error {
+	var block map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &block); err != nil || block == nil {
+		return fmt.Errorf("content block must be an object")
+	}
+	var typ string
+	if err := json.Unmarshal(block["type"], &typ); err != nil || strings.TrimSpace(typ) == "" {
+		return fmt.Errorf("content block type must be valid")
+	}
+	switch ContentBlockType(typ) {
+	case "text":
+		textRaw, ok := block["text"]
+		if !ok || bytes.Equal(bytes.TrimSpace(textRaw), []byte("null")) {
+			return fmt.Errorf("text content block requires text")
+		}
+		var text string
+		if err := json.Unmarshal(textRaw, &text); err != nil {
+			return fmt.Errorf("text content block requires text")
+		}
+	case ContentBlockImage, ContentBlockAudio, ContentBlockVideo:
+		var media MediaContentBlock
+		if err := json.Unmarshal(raw, &media); err != nil {
+			return fmt.Errorf("media content block is invalid: %w", err)
+		}
+		return validateSource(media.Source)
+	default:
+		return fmt.Errorf("unsupported content block type %q", typ)
+	}
+	return nil
+}
+
+func validateMessage(message Message, field string) error {
+	if message.Role != RoleUser && message.Role != RoleAssistant {
+		return fmt.Errorf("%s.role must be USER or ASSISTANT", field)
+	}
+	if len(message.Content) == 0 {
+		return fmt.Errorf("%s.content must be non-empty", field)
+	}
+	for i, block := range message.Content {
+		if err := validateContentBlock(block); err != nil {
+			return fmt.Errorf("%s.content[%d]: %w", field, i, err)
+		}
+	}
+	return nil
+}
+
+func validateContentBlock(block ContentBlock) error {
+	if block == nil {
+		return fmt.Errorf("content block is required")
+	}
+	switch b := block.(type) {
+	case TextContentBlock:
+		return nil
+	case MediaContentBlock:
+		if b.Type != ContentBlockImage && b.Type != ContentBlockAudio && b.Type != ContentBlockVideo {
+			return fmt.Errorf("unsupported media content block type %q", b.Type)
+		}
+		return validateSource(b.Source)
+	default:
+		payload, err := block.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("marshal content block: %w", err)
+		}
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &obj); err != nil || obj == nil {
+			return fmt.Errorf("content block must marshal to an object")
+		}
+		var typ string
+		if err := json.Unmarshal(obj["type"], &typ); err != nil || strings.TrimSpace(typ) == "" {
+			return fmt.Errorf("content block type must be valid")
+		}
+		return nil
+	}
+}
+
+func validateSource(source Source) error {
+	switch source.Type {
+	case SourceURL:
+		if strings.TrimSpace(source.URL) == "" {
+			return fmt.Errorf("url source requires a non-blank url")
+		}
+	case SourceBase64:
+		if strings.TrimSpace(source.MediaType) == "" {
+			return fmt.Errorf("base64 source requires a non-blank media_type")
+		}
+		if source.Data == "" {
+			return fmt.Errorf("base64 source requires data")
+		}
+	default:
+		return fmt.Errorf("unsupported source type %q", source.Type)
+	}
+	return nil
+}
+
+func requireNonBlank(issues *[]ValidationIssue, field, value string) {
+	if strings.TrimSpace(value) == "" {
+		*issues = append(*issues, ValidationIssue{Field: field, Message: field + " is required"})
+	}
+}
+
+func validationErrorOrNil(issues []ValidationIssue) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	return &ValidationError{Issues: issues}
+}

--- a/memind-clients/go/validation_test.go
+++ b/memind-clients/go/validation_test.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+import "testing"
+
+func TestValidateMessageRejectsInvalidBlocks(t *testing.T) {
+	cases := []Message{
+		{},
+		{Role: Role("SYSTEM"), Content: []ContentBlock{TextBlock("x")}},
+		{Role: RoleUser},
+		{Role: RoleUser, Content: []ContentBlock{MediaContentBlock{Type: "pdf"}}},
+		{Role: RoleUser, Content: []ContentBlock{ImageURL(" ")}},
+		{Role: RoleUser, Content: []ContentBlock{ImageBase64("", "abc")}},
+		{Role: RoleUser, Content: []ContentBlock{ImageBase64("image/png", "")}},
+	}
+	for _, msg := range cases {
+		if err := validateMessage(msg, "message"); err == nil {
+			t.Fatalf("validateMessage(%#v) error = nil, want error", msg)
+		}
+	}
+}
+
+func TestValidateRequestAggregatesIssues(t *testing.T) {
+	err := validateExtractRequest(ExtractMemoryRequest{})
+	if err == nil {
+		t.Fatal("validateExtractRequest error = nil, want error")
+	}
+	validationErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("error type = %T, want *ValidationError", err)
+	}
+	if len(validationErr.Issues) < 3 {
+		t.Fatalf("issues = %#v, want multiple issues", validationErr.Issues)
+	}
+}
+
+func TestValidateExtractAcceptsConversation(t *testing.T) {
+	err := validateExtractRequest(ExtractMemoryRequest{
+		UserID:     "u",
+		AgentID:    "a",
+		RawContent: Conversation(UserMessage("remember this")),
+	})
+	if err != nil {
+		t.Fatalf("validateExtractRequest conversation error = %v", err)
+	}
+}

--- a/memind-clients/go/version.go
+++ b/memind-clients/go/version.go
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memind
+
+const Version = "0.2.0"


### PR DESCRIPTION
## Summary
- Add the official standard-library-only Go client module under `memind-clients/go`.
- Implement typed models, raw content helpers, validation, retry handling, envelope parsing, and Memory/Health API methods.
- Add Go client README examples, root README client listing, and focused Go client CI.

## Test Plan
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `test -z "$(gofmt -l .)"`