### PR TITLE
feat(rust-client): add official Rust SDK

### DIFF
--- a/.github/workflows/release-rust-client.yml
+++ b/.github/workflows/release-rust-client.yml
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Rust Client to crates.io
+
+# Release prerequisites:
+# - The `memind` crate name must be available on crates.io or owned by OpenMemind maintainers.
+# - The GitHub repository must define an environment named `crates-io`.
+# - The `crates-io` environment must expose a `CARGO_REGISTRY_TOKEN` secret.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Rust client release version, for example 0.2.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build and publish Rust client
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: crates-io
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate release version
+        working-directory: memind-clients/rust
+        shell: bash
+        run: |
+          version="${{ inputs.version }}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release version must be a stable semver version like 0.2.0." >&2
+            exit 1
+          fi
+          package_version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          if [[ "${package_version}" != "${version}" ]]; then
+            echo "Workflow version ${version} does not match Cargo.toml version ${package_version}." >&2
+            exit 1
+          fi
+
+      - name: Verify
+        working-directory: memind-clients/rust
+        run: |
+          rustup toolchain install 1.86.0 --profile minimal
+          cargo +1.86.0 check --lib --all-features
+          cargo fmt --check
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo test --all-features
+          cargo doc --all-features --no-deps
+          cargo package
+
+      - name: Publish to crates.io
+        working-directory: memind-clients/rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/.github/workflows/rust-client.yml
+++ b/.github/workflows/rust-client.yml
@@ -1,0 +1,82 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Rust Client CI
+
+on:
+  push:
+    paths:
+      - 'memind-clients/rust/**'
+      - '.github/workflows/rust-client.yml'
+      - '.github/workflows/release-rust-client.yml'
+  pull_request:
+    paths:
+      - 'memind-clients/rust/**'
+      - '.github/workflows/rust-client.yml'
+      - '.github/workflows/release-rust-client.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Rust ${{ matrix.toolchain }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [1.86.0, stable]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
+
+      - name: Cargo check MSRV
+        if: matrix.toolchain == '1.86.0'
+        working-directory: memind-clients/rust
+        run: cargo check --lib --all-features
+
+      - name: Cargo check stable
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo check --all-targets --all-features
+
+      - name: Format check
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo fmt --check
+
+      - name: Clippy
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo test --all-features
+
+      - name: Docs
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo doc --all-features --no-deps
+
+      - name: Package check
+        if: matrix.toolchain == 'stable'
+        working-directory: memind-clients/rust
+        run: cargo package

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Official API clients:
 - Python: [`memind-clients/python`](./memind-clients/python)
 - Java: [`memind-clients/java`](./memind-clients/java)
 - Go: [`github.com/openmemind/memind/memind-clients/go`](./memind-clients/go)
+- Rust: [`memind-clients/rust`](./memind-clients/rust)
 
 ---
 

--- a/memind-clients/rust/.gitignore
+++ b/memind-clients/rust/.gitignore
@@ -1,0 +1,13 @@
+# Cargo build output.
+/target/
+
+# This directory is a library crate; Cargo generates this during local checks,
+# but published dependencies are resolved by Cargo for downstream applications.
+/Cargo.lock
+
+# Local packaging and publishing scratch files.
+*.crate
+
+# Local environment files used for integration testing.
+.env
+.env.*

--- a/memind-clients/rust/Cargo.toml
+++ b/memind-clients/rust/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "memind"
+version = "0.2.0"
+edition = "2021"
+resolver = "3"
+rust-version = "1.86"
+license = "Apache-2.0"
+description = "Official Rust client for the Memind memory engine API"
+homepage = "https://github.com/openmemind/memind"
+repository = "https://github.com/openmemind/memind"
+readme = "README.md"
+keywords = ["memind", "memory", "ai", "client"]
+categories = ["api-bindings", "web-programming::http-client"]
+include = [
+    "Cargo.toml",
+    "LICENSE",
+    "README.md",
+    "src/**/*.rs",
+    "tests/**/*.rs",
+]
+
+[features]
+default = ["rustls"]
+rustls = ["reqwest/rustls"]
+native-tls = ["reqwest/native-tls"]
+tracing = ["dep:tracing"]
+
+[dependencies]
+fastrand = "2"
+httpdate = "1"
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+time = { version = "0.3", features = ["serde", "serde-well-known", "formatting", "parsing"] }
+tokio = { version = "1", default-features = false, features = ["time"] }
+tracing = { version = "0.1", optional = true }
+url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+wiremock = "0.6"

--- a/memind-clients/rust/LICENSE
+++ b/memind-clients/rust/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 OpenMemind
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/memind-clients/rust/README.md
+++ b/memind-clients/rust/README.md
@@ -1,0 +1,101 @@
+# Memind Rust Client
+
+Official Rust client for the Memind memory engine Open API.
+
+## Installation
+
+```toml
+[dependencies]
+memind = "0.2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+## Quick Start
+
+```rust,no_run
+use memind::{
+    ExtractMemoryRequest, MemindClient, Message, RawContent, RetrieveMemoryRequest, Strategy,
+};
+
+#[tokio::main]
+async fn main() -> memind::Result<()> {
+    let client = MemindClient::builder()
+        .base_url("http://localhost:8366")
+        .api_token_from_env()
+        .build()?;
+
+    client.health().await?;
+
+    let raw_content = RawContent::conversation(vec![
+        Message::user("Remember that I prefer concise answers."),
+    ])?;
+
+    let extraction = client
+        .memory()
+        .extract(ExtractMemoryRequest::new("user-1", "agent-1", raw_content))
+        .await?;
+
+    println!("extraction status: {:?}", extraction.status);
+
+    let result = client
+        .memory()
+        .retrieve(
+            RetrieveMemoryRequest::new(
+                "user-1",
+                "agent-1",
+                "What does the user prefer?",
+                Strategy::Simple,
+            )
+            .trace(true),
+        )
+        .await?;
+
+    println!("evidences: {:?}", result.evidences);
+    Ok(())
+}
+```
+
+## Retry Behavior
+
+`health` and `retrieve` retry transient failures by default. `extract`,
+`add_message`, and `commit` do not retry by default because retrying mutating
+operations can duplicate extraction, buffered messages, or commits after an
+ambiguous network failure.
+
+```rust,no_run
+use std::time::Duration;
+
+# async fn example(client: memind::MemindClient, request: memind::ExtractMemoryRequest) -> memind::Result<()> {
+let response = client
+    .memory()
+    .extract_with_options(
+        request,
+        memind::RequestOptions::new()
+            .timeout(Duration::from_secs(60))
+            .max_retries(1),
+    )
+    .await?;
+# let _ = response;
+# Ok(())
+# }
+```
+
+## Error Handling
+
+```rust,no_run
+# async fn example(client: memind::MemindClient, request: memind::RetrieveMemoryRequest) -> memind::Result<()> {
+match client.memory().retrieve(request).await {
+    Ok(response) => {
+        println!("items: {}", response.items.len());
+    }
+    Err(memind::MemindError::Api(err)) => {
+        eprintln!(
+            "api error: status={} code={} request_id={:?}",
+            err.status, err.code, err.request_id
+        );
+    }
+    Err(err) => return Err(err),
+}
+# Ok(())
+# }
+```

--- a/memind-clients/rust/src/client.rs
+++ b/memind-clients/rust/src/client.rs
@@ -1,0 +1,224 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
+use crate::config::{
+    normalize_base_url, normalize_token, reject_sdk_header, validate_timeout, ClientConfig,
+    DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, ENV_API_TOKEN, ENV_BASE_URL,
+};
+use crate::models::HealthResponse;
+use crate::resources::MemoryClient;
+use crate::{http, MemindError, RequestOptions, Result};
+
+#[derive(Clone, Default)]
+pub struct ClientBuilder {
+    base_url: Option<String>,
+    use_base_url_env: bool,
+    api_token: Option<String>,
+    use_api_token_env: bool,
+    timeout: Option<Duration>,
+    max_retries: Option<u32>,
+    user_agent: Option<String>,
+    extra_headers: HeaderMap,
+    http_client: Option<reqwest::Client>,
+}
+
+impl std::fmt::Debug for ClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientBuilder")
+            .field("base_url", &self.base_url)
+            .field("use_base_url_env", &self.use_base_url_env)
+            .field("api_token_configured", &self.api_token.is_some())
+            .field("use_api_token_env", &self.use_api_token_env)
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("user_agent", &self.user_agent)
+            .field("extra_header_count", &self.extra_headers.len())
+            .field("custom_http_client", &self.http_client.is_some())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct MemindClient {
+    pub(crate) inner: Arc<ClientInner>,
+    memory: MemoryClient,
+}
+
+impl std::fmt::Debug for MemindClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemindClient")
+            .field("base_url", &self.inner.config.base_url)
+            .field(
+                "api_token_configured",
+                &self.inner.config.api_token.is_some(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) struct ClientInner {
+    pub http_client: reqwest::Client,
+    pub config: ClientConfig,
+}
+
+impl std::fmt::Debug for ClientInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientInner")
+            .field("config", &self.config)
+            .field("http_client", &"<reqwest::Client>")
+            .finish()
+    }
+}
+
+impl MemindClient {
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    pub fn from_env() -> Result<Self> {
+        Self::builder()
+            .base_url_from_env()
+            .api_token_from_env()
+            .build()
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.inner.config.base_url
+    }
+
+    pub fn memory(&self) -> &MemoryClient {
+        &self.memory
+    }
+
+    pub async fn health(&self) -> Result<HealthResponse> {
+        self.health_with_options(RequestOptions::new()).await
+    }
+
+    pub async fn health_with_options(&self, options: RequestOptions) -> Result<HealthResponse> {
+        http::get_json(
+            &self.inner,
+            "/health",
+            options,
+            self.inner.config.max_retries,
+        )
+        .await
+    }
+}
+
+impl ClientBuilder {
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+
+    pub fn base_url_from_env(mut self) -> Self {
+        self.use_base_url_env = true;
+        self
+    }
+
+    pub fn api_token(mut self, api_token: impl Into<String>) -> Self {
+        self.api_token = Some(api_token.into());
+        self
+    }
+
+    pub fn api_token_from_env(mut self) -> Self {
+        self.use_api_token_env = true;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = Some(max_retries);
+        self
+    }
+
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = Some(user_agent.into());
+        self
+    }
+
+    pub fn extra_header(mut self, name: HeaderName, value: HeaderValue) -> Result<Self> {
+        reject_sdk_header(&name).map_err(MemindError::config)?;
+        self.extra_headers.insert(name, value);
+        Ok(self)
+    }
+
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = Some(client);
+        self
+    }
+
+    pub fn build(self) -> Result<MemindClient> {
+        let base_url_source = self
+            .base_url
+            .or_else(|| {
+                self.use_base_url_env
+                    .then(|| std::env::var(ENV_BASE_URL).unwrap_or_default())
+            })
+            .unwrap_or_else(|| std::env::var(ENV_BASE_URL).unwrap_or_default());
+        let (base_url, api_base_url) = normalize_base_url(base_url_source)?;
+
+        let api_token_source = self
+            .api_token
+            .or_else(|| {
+                self.use_api_token_env
+                    .then(|| std::env::var(ENV_API_TOKEN).ok())
+                    .flatten()
+            })
+            .or_else(|| std::env::var(ENV_API_TOKEN).ok());
+        let api_token = normalize_token(api_token_source);
+
+        let user_agent = self
+            .user_agent
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| format!("memind-rust/{}", env!("CARGO_PKG_VERSION")));
+
+        let config = ClientConfig {
+            base_url,
+            api_base_url,
+            api_token,
+            timeout: validate_timeout(self.timeout.unwrap_or(DEFAULT_TIMEOUT), "client timeout")
+                .map_err(MemindError::config)?,
+            max_retries: self.max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+            user_agent,
+            extra_headers: self.extra_headers,
+        };
+
+        let http_client = match self.http_client {
+            Some(client) => client,
+            None => reqwest::Client::builder()
+                .timeout(config.timeout)
+                .build()
+                .map_err(|err| MemindError::Config {
+                    message: "failed to build HTTP client".to_string(),
+                    source: Some(Box::new(err)),
+                })?,
+        };
+
+        let inner = Arc::new(ClientInner {
+            http_client,
+            config,
+        });
+        let memory = MemoryClient::new(Arc::clone(&inner));
+        Ok(MemindClient { inner, memory })
+    }
+}

--- a/memind-clients/rust/src/config.rs
+++ b/memind-clients/rust/src/config.rs
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use reqwest::header::{
+    HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT,
+};
+use url::Url;
+
+use crate::{MemindError, Result};
+
+pub(crate) const ENV_BASE_URL: &str = "MEMIND_BASE_URL";
+pub(crate) const ENV_API_TOKEN: &str = "MEMIND_API_TOKEN";
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
+
+#[derive(Clone)]
+pub(crate) struct ClientConfig {
+    pub base_url: String,
+    pub api_base_url: Url,
+    pub api_token: Option<String>,
+    pub timeout: Duration,
+    pub max_retries: u32,
+    pub user_agent: String,
+    pub extra_headers: HeaderMap,
+}
+
+impl std::fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("base_url", &self.base_url)
+            .field("api_token_configured", &self.api_token.is_some())
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("user_agent", &self.user_agent)
+            .field("extra_header_count", &self.extra_headers.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct RequestOptions {
+    timeout: Option<Duration>,
+    max_retries: Option<u32>,
+    headers: HeaderMap,
+}
+
+impl std::fmt::Debug for RequestOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestOptions")
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("header_count", &self.headers.len())
+            .finish()
+    }
+}
+
+impl RequestOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = Some(max_retries);
+        self
+    }
+
+    pub fn header(mut self, name: HeaderName, value: HeaderValue) -> Result<Self> {
+        reject_sdk_header(&name).map_err(MemindError::invalid_request)?;
+        self.headers.insert(name, value);
+        Ok(self)
+    }
+
+    pub(crate) fn timeout_override(&self) -> Option<Duration> {
+        self.timeout
+    }
+
+    pub(crate) fn max_retries_override(&self) -> Option<u32> {
+        self.max_retries
+    }
+
+    pub(crate) fn header_overrides(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+
+pub(crate) fn normalize_base_url(value: impl Into<String>) -> Result<(String, Url)> {
+    let value = value.into();
+    let trimmed = value.trim().trim_end_matches('/').to_string();
+    if trimmed.is_empty() {
+        return Err(MemindError::config(
+            "base_url is required; pass base_url or set MEMIND_BASE_URL",
+        ));
+    }
+    let parsed = Url::parse(&trimmed).map_err(|err| MemindError::Config {
+        message: format!("invalid base_url {trimmed}"),
+        source: Some(Box::new(err)),
+    })?;
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(MemindError::config(
+            "base_url must not include query parameters or fragments",
+        ));
+    }
+
+    let mut api_base_url = parsed.clone();
+    let mut path = api_base_url.path().trim_end_matches('/').to_string();
+    path.push_str("/open/v1/");
+    api_base_url.set_path(&path);
+    Ok((trimmed, api_base_url))
+}
+
+pub(crate) fn normalize_token(value: Option<String>) -> Option<String> {
+    value.and_then(|token| {
+        let trimmed = token.trim().to_string();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+pub(crate) fn reject_sdk_header(name: &HeaderName) -> std::result::Result<(), String> {
+    let name = name.as_str();
+    if name.eq_ignore_ascii_case(ACCEPT.as_str())
+        || name.eq_ignore_ascii_case(CONTENT_TYPE.as_str())
+        || name.eq_ignore_ascii_case(AUTHORIZATION.as_str())
+        || name.eq_ignore_ascii_case(USER_AGENT.as_str())
+    {
+        Err(format!("header {name} is owned by the Memind SDK"))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn validate_timeout(
+    timeout: Duration,
+    label: &'static str,
+) -> std::result::Result<Duration, String> {
+    if timeout.is_zero() {
+        Err(format!("{label} must be greater than zero"))
+    } else {
+        Ok(timeout)
+    }
+}

--- a/memind-clients/rust/src/error.rs
+++ b/memind-clients/rust/src/error.rs
@@ -1,0 +1,176 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::time::Duration;
+
+pub type Result<T> = std::result::Result<T, MemindError>;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum MemindError {
+    #[non_exhaustive]
+    Config {
+        message: String,
+        source: Option<Box<dyn Error + Send + Sync>>,
+    },
+    #[non_exhaustive]
+    InvalidRequest {
+        message: String,
+    },
+    Api(Box<MemindApiError>),
+    #[non_exhaustive]
+    Timeout {
+        message: String,
+        source: Option<Box<dyn Error + Send + Sync>>,
+    },
+    #[non_exhaustive]
+    Connection {
+        message: String,
+        source: Option<Box<dyn Error + Send + Sync>>,
+    },
+    #[non_exhaustive]
+    Decode {
+        message: String,
+        body: Option<String>,
+        source: Option<Box<dyn Error + Send + Sync>>,
+    },
+}
+
+impl std::fmt::Display for MemindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config { message, .. } => write!(f, "configuration error: {message}"),
+            Self::InvalidRequest { message } => write!(f, "invalid request: {message}"),
+            Self::Api(error) => write!(f, "memind api error: {error}"),
+            Self::Timeout { message, .. } => write!(f, "request timed out: {message}"),
+            Self::Connection { message, .. } => write!(f, "connection error: {message}"),
+            Self::Decode { message, .. } => write!(f, "decode error: {message}"),
+        }
+    }
+}
+
+impl Error for MemindError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Config { source, .. }
+            | Self::Timeout { source, .. }
+            | Self::Connection { source, .. }
+            | Self::Decode { source, .. } => source
+                .as_deref()
+                .map(|source| source as &(dyn Error + 'static)),
+            Self::Api(error) => Some(error.as_ref()),
+            Self::InvalidRequest { .. } => None,
+        }
+    }
+}
+
+impl MemindError {
+    pub(crate) fn config(message: impl Into<String>) -> Self {
+        Self::Config {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn invalid_request(message: impl Into<String>) -> Self {
+        Self::InvalidRequest {
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("status={status} code={code} message={message}")]
+#[non_exhaustive]
+pub struct MemindApiError {
+    pub status: u16,
+    pub code: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+    pub request_id: Option<String>,
+    pub retry_after: Option<Duration>,
+}
+
+impl MemindApiError {
+    pub fn is_authentication_error(&self) -> bool {
+        self.status == 401 || self.status == 403
+    }
+
+    pub fn is_rate_limit_error(&self) -> bool {
+        self.status == 429
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        matches!(self.status, 408 | 429 | 500 | 502 | 503 | 504)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_error_helpers_classify_common_statuses() {
+        let auth = MemindApiError {
+            status: 401,
+            code: "unauthorized".to_string(),
+            message: "missing token".to_string(),
+            details: None,
+            request_id: Some("rid-auth".to_string()),
+            retry_after: None,
+        };
+        assert!(auth.is_authentication_error());
+        assert!(!auth.is_rate_limit_error());
+        assert!(!auth.is_retryable());
+
+        let rate = MemindApiError {
+            status: 429,
+            code: "rate_limited".to_string(),
+            message: "slow down".to_string(),
+            details: None,
+            request_id: Some("rid-rate".to_string()),
+            retry_after: Some(Duration::from_secs(3)),
+        };
+        assert!(!rate.is_authentication_error());
+        assert!(rate.is_rate_limit_error());
+        assert!(rate.is_retryable());
+    }
+
+    #[test]
+    fn boxed_source_is_exposed_through_error_source() {
+        let err = MemindError::Connection {
+            message: "transport failed".to_string(),
+            source: Some(Box::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "reset",
+            ))),
+        };
+
+        assert!(err.source().is_some());
+        assert!(err.to_string().contains("transport failed"));
+    }
+
+    #[test]
+    fn non_exhaustive_struct_variants_can_be_matched_with_rest_inside_crate() {
+        let err = MemindError::InvalidRequest {
+            message: "user_id must be non-blank".to_string(),
+        };
+
+        match err {
+            MemindError::InvalidRequest { message, .. } => {
+                assert_eq!(message, "user_id must be non-blank");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}

--- a/memind-clients/rust/src/http.rs
+++ b/memind-clients/rust/src/http.rs
@@ -1,0 +1,403 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+
+use reqwest::header::{
+    HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, RETRY_AFTER, USER_AGENT,
+};
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::client::ClientInner;
+use crate::config::{reject_sdk_header, validate_timeout};
+use crate::retry::{
+    apply_jitter, compute_delay, is_retryable_status, parse_retry_after, RetryPolicy,
+};
+use crate::{MemindApiError, MemindError, RequestOptions, Result};
+
+#[cfg(feature = "tracing")]
+macro_rules! trace_debug {
+    ($($arg:tt)*) => {
+        tracing::debug!($($arg)*);
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_debug {
+    ($($arg:tt)*) => {};
+}
+
+#[cfg(feature = "tracing")]
+macro_rules! trace_warn {
+    ($($arg:tt)*) => {
+        tracing::warn!($($arg)*);
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_warn {
+    ($($arg:tt)*) => {};
+}
+
+pub(crate) async fn get_json<TResp>(
+    inner: &ClientInner,
+    path: &str,
+    options: RequestOptions,
+    default_retries: u32,
+) -> Result<TResp>
+where
+    TResp: DeserializeOwned,
+{
+    send_json::<(), TResp>(inner, Method::GET, path, None, options, default_retries).await
+}
+
+pub(crate) async fn post_json<TReq, TResp>(
+    inner: &ClientInner,
+    path: &str,
+    body: &TReq,
+    options: RequestOptions,
+    default_retries: u32,
+) -> Result<TResp>
+where
+    TReq: Serialize + ?Sized,
+    TResp: DeserializeOwned,
+{
+    send_json(
+        inner,
+        Method::POST,
+        path,
+        Some(body),
+        options,
+        default_retries,
+    )
+    .await
+}
+
+async fn send_json<TReq, TResp>(
+    inner: &ClientInner,
+    method: Method,
+    path: &str,
+    body: Option<&TReq>,
+    options: RequestOptions,
+    default_retries: u32,
+) -> Result<TResp>
+where
+    TReq: Serialize + ?Sized,
+    TResp: DeserializeOwned,
+{
+    let url = build_url(inner, path)?;
+    let headers = build_headers(inner, body.is_some(), &options)?;
+    let max_retries = options.max_retries_override().unwrap_or(default_retries);
+    let timeout = validate_timeout(
+        options.timeout_override().unwrap_or(inner.config.timeout),
+        "request timeout",
+    )
+    .map_err(MemindError::invalid_request)?;
+    let policy = RetryPolicy::new(max_retries);
+    let mut attempt = 0;
+
+    loop {
+        trace_debug!(
+            method = %method,
+            url = %url,
+            attempt = attempt,
+            "sending memind request"
+        );
+        let mut request = inner
+            .http_client
+            .request(method.clone(), url.clone())
+            .headers(headers.clone())
+            .timeout(timeout);
+
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+
+        match request.send().await {
+            Ok(response) => {
+                let status = response.status();
+                trace_debug!(
+                    status = status.as_u16(),
+                    attempt = attempt,
+                    "received memind response"
+                );
+                let headers = response.headers().clone();
+                let retry_after = headers
+                    .get(RETRY_AFTER)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| parse_retry_after(value, SystemTime::now()));
+                let text = response.text().await.map_err(reqwest_error_to_memind)?;
+
+                if attempt < policy.max_retries && is_retryable_status(status.as_u16()) {
+                    trace_warn!(
+                        status = status.as_u16(),
+                        attempt = attempt,
+                        "retrying memind response"
+                    );
+                    sleep_before_retry(&policy, attempt, retry_after).await;
+                    attempt += 1;
+                    continue;
+                }
+
+                return parse_response(status, &headers, text);
+            }
+            Err(err) => {
+                let retryable_transport = err.is_timeout() || err.is_connect();
+                if attempt < policy.max_retries && retryable_transport {
+                    trace_warn!(
+                        error = %err,
+                        attempt = attempt,
+                        "retrying memind transport error"
+                    );
+                    sleep_before_retry(&policy, attempt, None).await;
+                    attempt += 1;
+                    continue;
+                }
+                return Err(reqwest_error_to_memind(err));
+            }
+        }
+    }
+}
+
+pub(crate) fn build_url(inner: &ClientInner, path: &str) -> Result<Url> {
+    let normalized_path = path.trim_start_matches('/');
+    inner
+        .config
+        .api_base_url
+        .join(normalized_path)
+        .map_err(|err| MemindError::Config {
+            message: format!(
+                "failed to join base_url {} with request path {path}",
+                inner.config.base_url
+            ),
+            source: Some(Box::new(err)),
+        })
+}
+
+fn build_headers(
+    inner: &ClientInner,
+    has_body: bool,
+    options: &RequestOptions,
+) -> Result<HeaderMap> {
+    validate_user_headers(&inner.config.extra_headers)?;
+    validate_user_headers(options.header_overrides())?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_str(&inner.config.user_agent).map_err(|err| {
+            MemindError::invalid_request(format!("invalid user agent header: {err}"))
+        })?,
+    );
+    if has_body {
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+    if let Some(token) = &inner.config.api_token {
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).map_err(|err| {
+                MemindError::invalid_request(format!("invalid authorization header: {err}"))
+            })?,
+        );
+    }
+    for (name, value) in &inner.config.extra_headers {
+        headers.insert(name.clone(), value.clone());
+    }
+    for (name, value) in options.header_overrides() {
+        headers.insert(name.clone(), value.clone());
+    }
+    Ok(headers)
+}
+
+fn validate_user_headers(headers: &HeaderMap) -> Result<()> {
+    for name in headers.keys() {
+        reject_sdk_header(name).map_err(MemindError::invalid_request)?;
+    }
+    Ok(())
+}
+
+fn parse_response<TResp>(status: StatusCode, headers: &HeaderMap, text: String) -> Result<TResp>
+where
+    TResp: DeserializeOwned,
+{
+    let envelope: ApiEnvelope<serde_json::Value> = match serde_json::from_str(&text) {
+        Ok(envelope) => envelope,
+        Err(err) if status.is_success() => {
+            return Err(MemindError::Decode {
+                message: "failed to parse response envelope".to_string(),
+                body: Some(text),
+                source: Some(Box::new(err)),
+            });
+        }
+        Err(_) => return Err(MemindError::Api(Box::new(http_error(status, headers)))),
+    };
+
+    if let Some(error) = envelope.error {
+        return Err(MemindError::Api(Box::new(api_error_from_payload(
+            status, headers, error,
+        ))));
+    }
+
+    if status.is_success() {
+        let data = envelope.data.ok_or_else(|| MemindError::Decode {
+            message: "response envelope missing data".to_string(),
+            body: Some(text.clone()),
+            source: None,
+        })?;
+        return serde_json::from_value(data).map_err(|err| MemindError::Decode {
+            message: "failed to decode response data".to_string(),
+            body: Some(text),
+            source: Some(Box::new(err)),
+        });
+    }
+
+    Err(MemindError::Api(Box::new(http_error(status, headers))))
+}
+
+fn api_error_from_payload(
+    status: StatusCode,
+    headers: &HeaderMap,
+    payload: ApiErrorPayload,
+) -> MemindApiError {
+    MemindApiError {
+        status: status.as_u16(),
+        code: payload.code,
+        message: payload.message,
+        details: payload.details,
+        request_id: header_to_string(headers, "x-request-id"),
+        retry_after: retry_after(headers),
+    }
+}
+
+fn http_error(status: StatusCode, headers: &HeaderMap) -> MemindApiError {
+    MemindApiError {
+        status: status.as_u16(),
+        code: "http_error".to_string(),
+        message: status
+            .canonical_reason()
+            .unwrap_or("HTTP request failed")
+            .to_string(),
+        details: None,
+        request_id: header_to_string(headers, "x-request-id"),
+        retry_after: retry_after(headers),
+    }
+}
+
+fn header_to_string(headers: &HeaderMap, name: &'static str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn retry_after(headers: &HeaderMap) -> Option<std::time::Duration> {
+    headers
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| parse_retry_after(value, SystemTime::now()))
+}
+
+async fn sleep_before_retry(
+    policy: &RetryPolicy,
+    attempt: u32,
+    retry_after: Option<std::time::Duration>,
+) {
+    let delay = retry_after
+        .unwrap_or_else(|| apply_jitter(compute_delay(policy, attempt), policy.jitter_ratio));
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+}
+
+fn reqwest_error_to_memind(err: reqwest::Error) -> MemindError {
+    if err.is_timeout() {
+        MemindError::Timeout {
+            message: err.to_string(),
+            source: Some(Box::new(err)),
+        }
+    } else {
+        MemindError::Connection {
+            message: err.to_string(),
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    #[serde(default)]
+    data: Option<T>,
+    #[serde(default)]
+    error: Option<ApiErrorPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorPayload {
+    code: String,
+    message: String,
+    #[serde(default)]
+    details: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn reqwest_timeout_maps_to_timeout_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(Duration::from_secs(2));
+        });
+
+        let err = reqwest::Client::builder()
+            .timeout(Duration::from_millis(25))
+            .build()
+            .unwrap()
+            .get(format!("http://{addr}"))
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            reqwest_error_to_memind(err),
+            MemindError::Timeout { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn reqwest_non_timeout_maps_to_connection_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let err = reqwest::Client::new()
+            .get(format!("http://{addr}"))
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(!err.is_timeout());
+        assert!(matches!(
+            reqwest_error_to_memind(err),
+            MemindError::Connection { .. }
+        ));
+    }
+}

--- a/memind-clients/rust/src/lib.rs
+++ b/memind-clients/rust/src/lib.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![forbid(unsafe_code)]
+
+mod client;
+mod config;
+mod error;
+mod http;
+mod retry;
+
+pub mod models;
+pub mod resources;
+
+pub use client::{ClientBuilder, MemindClient};
+pub use config::RequestOptions;
+pub use error::{MemindApiError, MemindError, Result};
+pub use models::{
+    AddMessageRequest, AddMessageResponse, CommitMemoryRequest, ContentBlock, ExtractMemoryRequest,
+    ExtractMemoryResponse, ExtractStatus, FinalView, HealthResponse, MergeView, Message,
+    RawContent, RetrievalTraceView, RetrieveMemoryRequest, RetrieveMemoryResponse,
+    RetrievedInsight, RetrievedItem, RetrievedRawData, Role, Source, StageView, Strategy,
+};
+pub use resources::MemoryClient;

--- a/memind-clients/rust/src/models/common.rs
+++ b/memind-clients/rust/src/models/common.rs
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    #[serde(rename = "USER")]
+    User,
+    #[serde(rename = "ASSISTANT")]
+    Assistant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Strategy {
+    #[serde(rename = "SIMPLE")]
+    Simple,
+    #[serde(rename = "DEEP")]
+    Deep,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExtractStatus {
+    Success,
+    PartialSuccess,
+    Failed,
+    Unknown(String),
+}
+
+impl Serialize for ExtractStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Success => serializer.serialize_str("SUCCESS"),
+            Self::PartialSuccess => serializer.serialize_str("PARTIAL_SUCCESS"),
+            Self::Failed => serializer.serialize_str("FAILED"),
+            Self::Unknown(value) => serializer.serialize_str(value),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtractStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "SUCCESS" => Self::Success,
+            "PARTIAL_SUCCESS" => Self::PartialSuccess,
+            "FAILED" => Self::Failed,
+            _ => Self::Unknown(value),
+        })
+    }
+}

--- a/memind-clients/rust/src/models/health.rs
+++ b/memind-clients/rust/src/models/health.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthResponse {
+    pub status: String,
+    pub service: String,
+}

--- a/memind-clients/rust/src/models/memory.rs
+++ b/memind-clients/rust/src/models/memory.rs
@@ -1,0 +1,346 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use super::{ExtractStatus, Message, RawContent, Strategy};
+use crate::{MemindError, Result};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractMemoryRequest {
+    pub user_id: String,
+    pub agent_id: String,
+    pub raw_content: RawContent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_client: Option<String>,
+}
+
+impl ExtractMemoryRequest {
+    pub fn new(
+        user_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        raw_content: RawContent,
+    ) -> Self {
+        Self {
+            user_id: user_id.into(),
+            agent_id: agent_id.into(),
+            raw_content,
+            source_client: None,
+        }
+    }
+
+    pub fn source_client(mut self, source_client: impl Into<String>) -> Self {
+        self.source_client = normalize_optional_string(source_client.into());
+        self
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_identity(&self.user_id, &self.agent_id)?;
+        self.raw_content.validate()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddMessageRequest {
+    pub user_id: String,
+    pub agent_id: String,
+    pub message: Message,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_client: Option<String>,
+}
+
+impl AddMessageRequest {
+    pub fn new(user_id: impl Into<String>, agent_id: impl Into<String>, message: Message) -> Self {
+        Self {
+            user_id: user_id.into(),
+            agent_id: agent_id.into(),
+            message,
+            source_client: None,
+        }
+    }
+
+    pub fn source_client(mut self, source_client: impl Into<String>) -> Self {
+        self.source_client = normalize_optional_string(source_client.into());
+        self
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_identity(&self.user_id, &self.agent_id)?;
+        self.message.validate()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitMemoryRequest {
+    pub user_id: String,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_client: Option<String>,
+}
+
+impl CommitMemoryRequest {
+    pub fn new(user_id: impl Into<String>, agent_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+            agent_id: agent_id.into(),
+            source_client: None,
+        }
+    }
+
+    pub fn source_client(mut self, source_client: impl Into<String>) -> Self {
+        self.source_client = normalize_optional_string(source_client.into());
+        self
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_identity(&self.user_id, &self.agent_id)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrieveMemoryRequest {
+    pub user_id: String,
+    pub agent_id: String,
+    pub query: String,
+    pub strategy: Strategy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace: Option<bool>,
+}
+
+impl RetrieveMemoryRequest {
+    pub fn new(
+        user_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        query: impl Into<String>,
+        strategy: Strategy,
+    ) -> Self {
+        Self {
+            user_id: user_id.into(),
+            agent_id: agent_id.into(),
+            query: query.into(),
+            strategy,
+            trace: None,
+        }
+    }
+
+    pub fn trace(mut self, trace: bool) -> Self {
+        self.trace = Some(trace);
+        self
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_identity(&self.user_id, &self.agent_id)?;
+        if self.query.trim().is_empty() {
+            return Err(MemindError::invalid_request("query must be non-blank"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractMemoryResponse {
+    pub status: ExtractStatus,
+    #[serde(default)]
+    pub raw_data_ids: Vec<String>,
+    #[serde(default)]
+    pub item_ids: Vec<i64>,
+    #[serde(default)]
+    pub insight_ids: Vec<i64>,
+    #[serde(default)]
+    pub insight_pending: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_millis: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddMessageResponse {
+    pub triggered: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<ExtractMemoryResponse>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrieveMemoryResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub items: Vec<RetrievedItem>,
+    #[serde(default)]
+    pub insights: Vec<RetrievedInsight>,
+    #[serde(default)]
+    pub raw_data: Vec<RetrievedRawData>,
+    #[serde(default)]
+    pub evidences: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace: Option<RetrievalTraceView>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrievedItem {
+    pub id: String,
+    pub text: String,
+    #[serde(default)]
+    pub vector_score: f64,
+    #[serde(default)]
+    pub final_score: f64,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub occurred_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrievedInsight {
+    pub id: String,
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrievedRawData {
+    pub raw_data_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+    #[serde(default)]
+    pub max_score: f64,
+    #[serde(default)]
+    pub item_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrievalTraceView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub started_at: Option<OffsetDateTime>,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub completed_at: Option<OffsetDateTime>,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(default)]
+    pub stages: Vec<StageView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge: Option<MergeView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_results: Option<FinalView>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_count: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_count: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_count: Option<i64>,
+    #[serde(default)]
+    pub degraded: bool,
+    #[serde(default)]
+    pub skipped: bool,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub started_at: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_millis: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<serde_json::Map<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidates: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeView {
+    #[serde(default)]
+    pub input_count: i64,
+    #[serde(default)]
+    pub output_count: i64,
+    #[serde(default)]
+    pub deduplicated_count: i64,
+    #[serde(default)]
+    pub source_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinalView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub item_count: i64,
+    #[serde(default)]
+    pub insight_count: i64,
+    #[serde(default)]
+    pub raw_data_count: i64,
+    #[serde(default)]
+    pub evidence_count: i64,
+}
+
+fn normalize_optional_string(value: String) -> Option<String> {
+    let trimmed = value.trim().to_string();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+fn validate_identity(user_id: &str, agent_id: &str) -> Result<()> {
+    if user_id.trim().is_empty() {
+        return Err(MemindError::invalid_request("user_id must be non-blank"));
+    }
+    if agent_id.trim().is_empty() {
+        return Err(MemindError::invalid_request("agent_id must be non-blank"));
+    }
+    Ok(())
+}

--- a/memind-clients/rust/src/models/message.rs
+++ b/memind-clients/rust/src/models/message.rs
@@ -1,0 +1,305 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::de;
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use time::OffsetDateTime;
+
+use super::Role;
+use crate::{MemindError, Result};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    pub role: Role,
+    pub content: Vec<ContentBlock>,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_client: Option<String>,
+}
+
+impl Message {
+    pub fn user(text: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: vec![ContentBlock::text(text)],
+            timestamp: None,
+            user_name: None,
+            source_client: None,
+        }
+    }
+
+    pub fn assistant(text: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: vec![ContentBlock::text(text)],
+            timestamp: None,
+            user_name: None,
+            source_client: None,
+        }
+    }
+
+    pub fn with_timestamp(mut self, timestamp: OffsetDateTime) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    pub fn with_user_name(mut self, user_name: impl Into<String>) -> Self {
+        let trimmed = user_name.into().trim().to_string();
+        self.user_name = (!trimmed.is_empty()).then_some(trimmed);
+        self
+    }
+
+    pub fn with_source_client(mut self, source_client: impl Into<String>) -> Self {
+        let trimmed = source_client.into().trim().to_string();
+        self.source_client = (!trimmed.is_empty()).then_some(trimmed);
+        self
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.content.is_empty() {
+            return Err(MemindError::invalid_request(
+                "message.content must contain at least one block",
+            ));
+        }
+        for block in &self.content {
+            block.validate()?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ContentBlock {
+    Text { text: String },
+    Image { source: Source },
+    Audio { source: Source },
+    Video { source: Source },
+}
+
+impl ContentBlock {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text { text: text.into() }
+    }
+
+    pub fn image(source: Source) -> Self {
+        Self::Image { source }
+    }
+
+    pub fn audio(source: Source) -> Self {
+        Self::Audio { source }
+    }
+
+    pub fn video(source: Source) -> Self {
+        Self::Video { source }
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        match self {
+            Self::Text { .. } => Ok(()),
+            Self::Image { source } | Self::Audio { source } | Self::Video { source } => {
+                source.validate()
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Source {
+    Url {
+        url: String,
+    },
+    Base64 {
+        #[serde(rename = "media_type")]
+        media_type: String,
+        data: String,
+    },
+}
+
+impl Source {
+    pub fn url(url: impl Into<String>) -> Self {
+        Self::Url { url: url.into() }
+    }
+
+    pub fn base64(media_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Base64 {
+            media_type: media_type.into(),
+            data: data.into(),
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        match self {
+            Self::Url { url } if url.trim().is_empty() => Err(MemindError::invalid_request(
+                "Source::Url requires a non-blank URL",
+            )),
+            Self::Base64 { media_type, .. } if media_type.trim().is_empty() => Err(
+                MemindError::invalid_request("Source::Base64 requires a non-blank media_type"),
+            ),
+            Self::Base64 { data, .. } if data.is_empty() => Err(MemindError::invalid_request(
+                "Source::Base64 requires non-empty data",
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RawContent {
+    Conversation {
+        messages: Vec<Message>,
+    },
+    Object {
+        content_type: String,
+        fields: serde_json::Map<String, serde_json::Value>,
+    },
+}
+
+impl RawContent {
+    pub fn conversation(messages: Vec<Message>) -> Result<Self> {
+        let raw = Self::Conversation { messages };
+        raw.validate()?;
+        Ok(raw)
+    }
+
+    pub fn object(
+        content_type: impl Into<String>,
+        fields: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Self> {
+        let content_type = content_type.into().trim().to_string();
+        if content_type.is_empty() {
+            return Err(MemindError::invalid_request(
+                "RawContent::object requires a non-blank content_type",
+            ));
+        }
+        if content_type == "conversation" {
+            return Err(MemindError::invalid_request(
+                "RawContent::object cannot use content_type \"conversation\"; use RawContent::conversation",
+            ));
+        }
+        if fields.contains_key("type") {
+            return Err(MemindError::invalid_request(
+                "RawContent::object fields must not contain \"type\"",
+            ));
+        }
+        Ok(Self::Object {
+            content_type,
+            fields,
+        })
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        match self {
+            Self::Conversation { messages } => {
+                if messages.is_empty() {
+                    return Err(MemindError::invalid_request(
+                        "conversation raw content requires at least one message",
+                    ));
+                }
+                for message in messages {
+                    message.validate()?;
+                }
+                Ok(())
+            }
+            Self::Object {
+                content_type,
+                fields,
+            } => {
+                if content_type.trim().is_empty() {
+                    return Err(MemindError::invalid_request(
+                        "RawContent::object requires a non-blank content_type",
+                    ));
+                }
+                if content_type == "conversation" {
+                    return Err(MemindError::invalid_request(
+                        "RawContent::object cannot use content_type \"conversation\"; use RawContent::conversation",
+                    ));
+                }
+                if fields.contains_key("type") {
+                    return Err(MemindError::invalid_request(
+                        "RawContent::object fields must not contain \"type\"",
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Serialize for RawContent {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Conversation { messages } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("type", "conversation")?;
+                map.serialize_entry("messages", messages)?;
+                map.end()
+            }
+            Self::Object {
+                content_type,
+                fields,
+            } => {
+                let mut map = serializer.serialize_map(Some(fields.len() + 1))?;
+                map.serialize_entry("type", content_type)?;
+                for (key, value) in fields {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RawContent {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let mut object = match value {
+            serde_json::Value::Object(object) => object,
+            _ => return Err(de::Error::custom("raw content must be a JSON object")),
+        };
+
+        let content_type = object
+            .remove("type")
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+            .ok_or_else(|| de::Error::custom("raw content requires string field \"type\""))?;
+
+        if content_type == "conversation" {
+            let messages_value = object
+                .remove("messages")
+                .ok_or_else(|| de::Error::custom("conversation raw content requires messages"))?;
+            let messages =
+                Vec::<Message>::deserialize(messages_value).map_err(de::Error::custom)?;
+            return Ok(Self::Conversation { messages });
+        }
+
+        Ok(Self::Object {
+            content_type,
+            fields: object,
+        })
+    }
+}

--- a/memind-clients/rust/src/models/mod.rs
+++ b/memind-clients/rust/src/models/mod.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+mod health;
+mod memory;
+mod message;
+
+pub use common::{ExtractStatus, Role, Strategy};
+pub use health::HealthResponse;
+pub use memory::{
+    AddMessageRequest, AddMessageResponse, CommitMemoryRequest, ExtractMemoryRequest,
+    ExtractMemoryResponse, FinalView, MergeView, RetrievalTraceView, RetrieveMemoryRequest,
+    RetrieveMemoryResponse, RetrievedInsight, RetrievedItem, RetrievedRawData, StageView,
+};
+pub use message::{ContentBlock, Message, RawContent, Source};

--- a/memind-clients/rust/src/resources/memory.rs
+++ b/memind-clients/rust/src/resources/memory.rs
@@ -1,0 +1,101 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::client::ClientInner;
+use crate::models::{
+    AddMessageRequest, AddMessageResponse, CommitMemoryRequest, ExtractMemoryRequest,
+    ExtractMemoryResponse, RetrieveMemoryRequest, RetrieveMemoryResponse,
+};
+use crate::{http, RequestOptions, Result};
+
+#[derive(Clone, Debug)]
+pub struct MemoryClient {
+    pub(crate) inner: Arc<ClientInner>,
+}
+
+impl MemoryClient {
+    pub(crate) fn new(inner: Arc<ClientInner>) -> Self {
+        Self { inner }
+    }
+
+    pub async fn extract(&self, request: ExtractMemoryRequest) -> Result<ExtractMemoryResponse> {
+        self.extract_with_options(request, RequestOptions::new())
+            .await
+    }
+
+    pub async fn extract_with_options(
+        &self,
+        request: ExtractMemoryRequest,
+        options: RequestOptions,
+    ) -> Result<ExtractMemoryResponse> {
+        request.validate()?;
+        http::post_json(&self.inner, "/memory/sync/extract", &request, options, 0).await
+    }
+
+    pub async fn add_message(&self, request: AddMessageRequest) -> Result<AddMessageResponse> {
+        self.add_message_with_options(request, RequestOptions::new())
+            .await
+    }
+
+    pub async fn add_message_with_options(
+        &self,
+        request: AddMessageRequest,
+        options: RequestOptions,
+    ) -> Result<AddMessageResponse> {
+        request.validate()?;
+        http::post_json(
+            &self.inner,
+            "/memory/sync/add-message",
+            &request,
+            options,
+            0,
+        )
+        .await
+    }
+
+    pub async fn commit(&self, request: CommitMemoryRequest) -> Result<ExtractMemoryResponse> {
+        self.commit_with_options(request, RequestOptions::new())
+            .await
+    }
+
+    pub async fn commit_with_options(
+        &self,
+        request: CommitMemoryRequest,
+        options: RequestOptions,
+    ) -> Result<ExtractMemoryResponse> {
+        request.validate()?;
+        http::post_json(&self.inner, "/memory/sync/commit", &request, options, 0).await
+    }
+
+    pub async fn retrieve(&self, request: RetrieveMemoryRequest) -> Result<RetrieveMemoryResponse> {
+        self.retrieve_with_options(request, RequestOptions::new())
+            .await
+    }
+
+    pub async fn retrieve_with_options(
+        &self,
+        request: RetrieveMemoryRequest,
+        options: RequestOptions,
+    ) -> Result<RetrieveMemoryResponse> {
+        request.validate()?;
+        http::post_json(
+            &self.inner,
+            "/memory/retrieve",
+            &request,
+            options,
+            self.inner.config.max_retries,
+        )
+        .await
+    }
+}

--- a/memind-clients/rust/src/resources/mod.rs
+++ b/memind-clients/rust/src/resources/mod.rs
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod memory;
+
+pub use memory::MemoryClient;

--- a/memind-clients/rust/src/retry.rs
+++ b/memind-clients/rust/src/retry.rs
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Duration, SystemTime};
+
+#[derive(Clone, Debug)]
+pub struct RetryPolicy {
+    pub max_retries: u32,
+    pub initial_delay: Duration,
+    pub max_delay: Duration,
+    pub jitter_ratio: f64,
+}
+
+impl RetryPolicy {
+    pub fn new(max_retries: u32) -> Self {
+        Self {
+            max_retries,
+            initial_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(2),
+            jitter_ratio: 0.25,
+        }
+    }
+}
+
+pub fn is_retryable_status(status: u16) -> bool {
+    matches!(status, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+pub fn parse_retry_after(value: &str, now: SystemTime) -> Option<Duration> {
+    if let Ok(seconds) = value.trim().parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let retry_at = httpdate::parse_http_date(value.trim()).ok()?;
+    retry_at.duration_since(now).ok()
+}
+
+pub fn compute_delay(policy: &RetryPolicy, attempt: u32) -> Duration {
+    let multiplier = 2u32.saturating_pow(attempt);
+    let base = policy.initial_delay.saturating_mul(multiplier);
+    base.min(policy.max_delay)
+}
+
+pub(crate) fn apply_jitter(delay: Duration, ratio: f64) -> Duration {
+    if ratio <= 0.0 {
+        return delay;
+    }
+    let millis = delay.as_millis() as f64;
+    let spread = millis * ratio;
+    let low = (millis - spread).max(0.0);
+    let high = millis + spread;
+    let sampled = fastrand::f64() * (high - low) + low;
+    Duration::from_millis(sampled.round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_delay, is_retryable_status, parse_retry_after, RetryPolicy};
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn retryable_statuses_match_spec() {
+        for status in [408, 429, 500, 502, 503, 504] {
+            assert!(is_retryable_status(status), "status {status}");
+        }
+        for status in [400, 401, 403, 404, 409, 422] {
+            assert!(!is_retryable_status(status), "status {status}");
+        }
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds_and_http_date() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let later = httpdate::fmt_http_date(now + Duration::from_secs(5));
+
+        assert_eq!(parse_retry_after("3", now), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after(&later, now), Some(Duration::from_secs(5)));
+        assert_eq!(parse_retry_after("", now), None);
+        assert_eq!(parse_retry_after("not a date", now), None);
+    }
+
+    #[test]
+    fn compute_delay_caps_exponential_backoff() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(2),
+            jitter_ratio: 0.0,
+        };
+
+        assert_eq!(compute_delay(&policy, 0), Duration::from_millis(500));
+        assert_eq!(compute_delay(&policy, 1), Duration::from_secs(1));
+        assert_eq!(compute_delay(&policy, 3), Duration::from_secs(2));
+    }
+}

--- a/memind-clients/rust/tests/client_test.rs
+++ b/memind-clients/rust/tests/client_test.rs
@@ -1,0 +1,509 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use memind::{
+    AddMessageRequest, CommitMemoryRequest, ExtractMemoryRequest, MemindClient, MemindError,
+    RawContent, RequestOptions, RetrieveMemoryRequest,
+};
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[test]
+fn builder_requires_base_url() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    std::env::remove_var("MEMIND_BASE_URL");
+
+    let result = MemindClient::builder().build();
+    assert!(matches!(result, Err(MemindError::Config { .. })));
+}
+
+#[test]
+fn debug_output_does_not_expose_api_token() {
+    let client = MemindClient::builder()
+        .base_url("https://api.example.test")
+        .api_token("secret-token")
+        .build()
+        .unwrap();
+
+    let output = format!("{client:?}");
+    assert!(output.contains("api_token_configured"));
+    assert!(!output.contains("secret-token"));
+}
+
+#[test]
+fn debug_output_does_not_expose_builder_or_request_header_secrets() {
+    let builder = MemindClient::builder()
+        .base_url("https://api.example.test")
+        .api_token("secret-token")
+        .extra_header(
+            HeaderName::from_static("x-client-secret"),
+            HeaderValue::from_static("secret-token"),
+        )
+        .unwrap();
+    let output = format!("{builder:?}");
+    assert!(output.contains("api_token_configured"));
+    assert!(output.contains("extra_header_count"));
+    assert!(!output.contains("secret-token"));
+
+    let options = RequestOptions::new()
+        .header(
+            HeaderName::from_static("x-client-secret"),
+            HeaderValue::from_static("secret-token"),
+        )
+        .unwrap();
+    let output = format!("{options:?}");
+    assert!(output.contains("header_count"));
+    assert!(!output.contains("secret-token"));
+}
+
+#[test]
+fn builder_reads_base_url_and_token_from_environment() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    std::env::set_var("MEMIND_BASE_URL", "https://api.example.test/");
+    std::env::set_var("MEMIND_API_TOKEN", " token-1 ");
+
+    let client = MemindClient::from_env().expect("env client");
+    assert_eq!(client.base_url(), "https://api.example.test");
+
+    std::env::remove_var("MEMIND_BASE_URL");
+    std::env::remove_var("MEMIND_API_TOKEN");
+}
+
+#[test]
+fn builder_rejects_sdk_owned_extra_headers() {
+    let err = MemindClient::builder()
+        .base_url("https://api.example.test")
+        .extra_header(AUTHORIZATION, HeaderValue::from_static("Bearer nope"))
+        .unwrap_err();
+
+    assert!(matches!(err, MemindError::Config { .. }));
+}
+
+#[test]
+fn builder_rejects_zero_timeout_on_build() {
+    let err = MemindClient::builder()
+        .base_url("https://api.example.test")
+        .timeout(Duration::ZERO)
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(err, MemindError::Config { .. }));
+}
+
+#[test]
+fn builder_rejects_base_url_with_query_or_fragment() {
+    for base_url in [
+        "https://api.example.test?region=us",
+        "https://api.example.test#fragment",
+    ] {
+        let err = MemindClient::builder()
+            .base_url(base_url)
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, MemindError::Config { .. }), "{base_url}");
+    }
+}
+
+#[test]
+fn request_options_rejects_sdk_owned_headers() {
+    for header in [AUTHORIZATION, CONTENT_TYPE, USER_AGENT] {
+        let err = RequestOptions::new()
+            .header(header, HeaderValue::from_static("bad"))
+            .unwrap_err();
+        assert!(matches!(err, MemindError::InvalidRequest { .. }));
+    }
+}
+
+#[test]
+fn request_options_accepts_custom_headers_and_overrides() {
+    let options = RequestOptions::new()
+        .timeout(Duration::from_secs(10))
+        .max_retries(0)
+        .header(
+            HeaderName::from_static("x-client-trace"),
+            HeaderValue::from_static("trace-1"),
+        )
+        .expect("custom header");
+
+    let output = format!("{options:?}");
+    assert!(output.contains("timeout"));
+    assert!(output.contains("max_retries"));
+    assert!(output.contains("header_count"));
+}
+
+#[tokio::test]
+async fn health_calls_open_v1_health_and_parses_success_envelope() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .and(header("accept", "application/json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {"status": "ok", "service": "memind"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .api_token(" token-1 ")
+        .build()
+        .unwrap();
+
+    let health = client.health().await.unwrap();
+    assert_eq!(health.status, "ok");
+    assert_eq!(health.service, "memind");
+}
+
+#[tokio::test]
+async fn health_sends_authorization_and_user_agent_headers() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .and(header("authorization", "Bearer token-1"))
+        .and(header("user-agent", "memind-rust/test-suite"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {"status": "ok", "service": "memind"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .api_token(" token-1 ")
+        .user_agent("memind-rust/test-suite")
+        .build()
+        .unwrap();
+
+    client.health().await.unwrap();
+}
+
+#[tokio::test]
+async fn blank_api_token_does_not_send_authorization_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .and(header("authorization", "Bearer "))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {"status": "ok", "service": "memind"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .api_token("   ")
+        .build()
+        .unwrap();
+
+    client.health().await.unwrap();
+}
+
+#[tokio::test]
+async fn base_url_path_prefix_is_preserved() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/gateway/open/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {"status": "ok", "service": "memind"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(format!("{}/gateway", server.uri()))
+        .build()
+        .unwrap();
+
+    client.health().await.unwrap();
+}
+
+#[tokio::test]
+async fn api_error_envelope_preserves_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .append_header("X-Request-Id", "rid-1")
+                .set_body_json(json!({
+                    "error": {
+                        "code": "unauthorized",
+                        "message": "missing token",
+                        "details": {"scope": "open"}
+                    }
+                })),
+        )
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+    match err {
+        MemindError::Api(api) => {
+            assert_eq!(api.status, 401);
+            assert_eq!(api.code, "unauthorized");
+            assert_eq!(api.request_id.as_deref(), Some("rid-1"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn request_options_rejects_zero_timeout_at_send_time() {
+    let client = MemindClient::builder()
+        .base_url("https://api.example.test")
+        .build()
+        .unwrap();
+
+    let err = client
+        .health_with_options(RequestOptions::new().timeout(Duration::ZERO))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, MemindError::InvalidRequest { .. }));
+}
+
+#[tokio::test]
+async fn malformed_json_returns_decode_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{bad-json"))
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+    assert!(matches!(err, MemindError::Decode { .. }));
+}
+
+#[tokio::test]
+async fn non_json_response_returns_decode_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+    assert!(matches!(err, MemindError::Decode { .. }));
+}
+
+#[tokio::test]
+async fn non_json_error_response_returns_http_api_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(
+            ResponseTemplate::new(502)
+                .append_header("X-Request-Id", "rid-502")
+                .set_body_string("bad gateway"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+    match err {
+        MemindError::Api(api) => {
+            assert_eq!(api.status, 502);
+            assert_eq!(api.code, "http_error");
+            assert_eq!(api.request_id.as_deref(), Some("rid-502"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn memory_methods_call_expected_endpoints() {
+    let server = MockServer::start().await;
+    for (endpoint, data) in [
+        ("/open/v1/memory/sync/extract", json!({"status": "SUCCESS"})),
+        (
+            "/open/v1/memory/sync/add-message",
+            json!({"triggered": false}),
+        ),
+        ("/open/v1/memory/sync/commit", json!({"status": "SUCCESS"})),
+        (
+            "/open/v1/memory/retrieve",
+            json!({"items": [], "insights": [], "rawData": [], "evidences": []}),
+        ),
+    ] {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": data })))
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let raw = RawContent::conversation(vec![memind::Message::user("remember")]).unwrap();
+    client
+        .memory()
+        .extract(ExtractMemoryRequest::new("u1", "a1", raw))
+        .await
+        .unwrap();
+    client
+        .memory()
+        .add_message(AddMessageRequest::new(
+            "u1",
+            "a1",
+            memind::Message::user("hello"),
+        ))
+        .await
+        .unwrap();
+    client
+        .memory()
+        .commit(CommitMemoryRequest::new("u1", "a1"))
+        .await
+        .unwrap();
+    client
+        .memory()
+        .retrieve(RetrieveMemoryRequest::new(
+            "u1",
+            "a1",
+            "what",
+            memind::Strategy::Simple,
+        ))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn partial_success_extract_is_successful_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open/v1/memory/sync/extract"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "status": "PARTIAL_SUCCESS",
+                "rawDataIds": ["r1"],
+                "itemIds": [],
+                "insightIds": [],
+                "insightPending": true
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let raw = RawContent::conversation(vec![memind::Message::user("remember")]).unwrap();
+    let response = client
+        .memory()
+        .extract(ExtractMemoryRequest::new("u1", "a1", raw))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status, memind::ExtractStatus::PartialSuccess);
+    assert!(response.insight_pending);
+}
+
+#[tokio::test]
+async fn memory_methods_validate_identity_before_sending() {
+    let server = MockServer::start().await;
+    for endpoint in [
+        "/open/v1/memory/sync/extract",
+        "/open/v1/memory/sync/add-message",
+        "/open/v1/memory/sync/commit",
+        "/open/v1/memory/retrieve",
+    ] {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+    }
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let raw = RawContent::conversation(vec![memind::Message::user("remember")]).unwrap();
+    let extract_err = client
+        .memory()
+        .extract(ExtractMemoryRequest::new(" ", "a1", raw))
+        .await
+        .unwrap_err();
+    assert!(matches!(extract_err, MemindError::InvalidRequest { .. }));
+
+    let add_message_err = client
+        .memory()
+        .add_message(AddMessageRequest::new(
+            "u1",
+            " ",
+            memind::Message::user("hello"),
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        add_message_err,
+        MemindError::InvalidRequest { .. }
+    ));
+
+    let commit_err = client
+        .memory()
+        .commit(CommitMemoryRequest::new("", "a1"))
+        .await
+        .unwrap_err();
+    assert!(matches!(commit_err, MemindError::InvalidRequest { .. }));
+
+    let retrieve_err = client
+        .memory()
+        .retrieve(RetrieveMemoryRequest::new(
+            "u1",
+            "a1",
+            " ",
+            memind::Strategy::Simple,
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(retrieve_err, MemindError::InvalidRequest { .. }));
+}

--- a/memind-clients/rust/tests/errors_test.rs
+++ b/memind-clients/rust/tests/errors_test.rs
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memind::MemindClient;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn api_error_variant_can_be_matched_from_integration_tests() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": {
+                "code": "invalid_request",
+                "message": "user_id must be non-blank"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+
+    match err {
+        memind::MemindError::Api(api_error) => assert_eq!(api_error.status, 400),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/memind-clients/rust/tests/integration_test.rs
+++ b/memind-clients/rust/tests/integration_test.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memind::{
+    ExtractMemoryRequest, MemindClient, Message, RawContent, RetrieveMemoryRequest, Strategy,
+};
+
+fn integration_client() -> Option<MemindClient> {
+    std::env::var("MEMIND_BASE_URL").ok().and_then(|base_url| {
+        MemindClient::builder()
+            .base_url(base_url)
+            .api_token_from_env()
+            .build()
+            .ok()
+    })
+}
+
+#[tokio::test]
+async fn real_server_health_when_configured() {
+    let Some(client) = integration_client() else {
+        eprintln!("skipping integration test because MEMIND_BASE_URL is not set");
+        return;
+    };
+
+    let health = client.health().await.expect("health");
+    assert!(!health.status.is_empty());
+}
+
+#[tokio::test]
+async fn real_server_extract_retrieve_when_enabled() {
+    if std::env::var("MEMIND_FULL_INTEGRATION").ok().as_deref() != Some("1") {
+        eprintln!("skipping full integration test because MEMIND_FULL_INTEGRATION=1 is not set");
+        return;
+    }
+    let Some(client) = integration_client() else {
+        eprintln!("skipping full integration test because MEMIND_BASE_URL is not set");
+        return;
+    };
+
+    let unique = format!(
+        "rust-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let raw = RawContent::conversation(vec![Message::user("I prefer concise answers.")]).unwrap();
+    let extraction = client
+        .memory()
+        .extract(ExtractMemoryRequest::new(&unique, "agent-rust", raw))
+        .await
+        .expect("extract");
+
+    assert!(matches!(
+        extraction.status,
+        memind::ExtractStatus::Success | memind::ExtractStatus::PartialSuccess
+    ));
+
+    let retrieved = client
+        .memory()
+        .retrieve(RetrieveMemoryRequest::new(
+            &unique,
+            "agent-rust",
+            "What does the user prefer?",
+            Strategy::Simple,
+        ))
+        .await
+        .expect("retrieve");
+
+    let _ = retrieved;
+}

--- a/memind-clients/rust/tests/public_api_test.rs
+++ b/memind-clients/rust/tests/public_api_test.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memind::{
+    AddMessageRequest, AddMessageResponse, ClientBuilder, CommitMemoryRequest, ContentBlock,
+    ExtractMemoryRequest, ExtractMemoryResponse, ExtractStatus, HealthResponse, MemindApiError,
+    MemindClient, MemindError, MemoryClient, Message, RawContent, RequestOptions,
+    RetrieveMemoryRequest, RetrieveMemoryResponse, RetrievedItem, Role, Source, Strategy,
+};
+
+#[test]
+fn public_api_exports_expected_names() {
+    fn assert_type<T>() {}
+
+    assert_type::<MemindClient>();
+    assert_type::<ClientBuilder>();
+    assert_type::<MemoryClient>();
+    assert_type::<RequestOptions>();
+    assert_type::<MemindError>();
+    assert_type::<MemindApiError>();
+    assert_type::<Role>();
+    assert_type::<Strategy>();
+    assert_type::<ExtractStatus>();
+    assert_type::<HealthResponse>();
+    assert_type::<Message>();
+    assert_type::<ContentBlock>();
+    assert_type::<Source>();
+    assert_type::<RawContent>();
+    assert_type::<ExtractMemoryRequest>();
+    assert_type::<ExtractMemoryResponse>();
+    assert_type::<AddMessageRequest>();
+    assert_type::<AddMessageResponse>();
+    assert_type::<CommitMemoryRequest>();
+    assert_type::<RetrieveMemoryRequest>();
+    assert_type::<RetrieveMemoryResponse>();
+    assert_type::<RetrievedItem>();
+}

--- a/memind-clients/rust/tests/retry_test.rs
+++ b/memind-clients/rust/tests/retry_test.rs
@@ -1,0 +1,199 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memind::{
+    AddMessageRequest, CommitMemoryRequest, ExtractMemoryRequest, MemindClient, RawContent,
+    RequestOptions, RetrieveMemoryRequest,
+};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn retrieve_retries_on_503_by_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open/v1/memory/retrieve"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .append_header("Retry-After", "0")
+                .set_body_json(json!({
+                    "error": {"code": "unavailable", "message": "try again"}
+                })),
+        )
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client
+        .memory()
+        .retrieve(RetrieveMemoryRequest::new(
+            "u1",
+            "a1",
+            "what",
+            memind::Strategy::Simple,
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, memind::MemindError::Api(_)));
+}
+
+#[tokio::test]
+async fn health_retries_on_503_by_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open/v1/health"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .append_header("Retry-After", "0")
+                .set_body_json(json!({
+                    "error": {"code": "unavailable", "message": "try again"}
+                })),
+        )
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client.health().await.unwrap_err();
+    assert!(matches!(err, memind::MemindError::Api(_)));
+}
+
+#[tokio::test]
+async fn add_message_does_not_retry_by_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open/v1/memory/sync/add-message"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+            "error": {"code": "unavailable", "message": "try again"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client
+        .memory()
+        .add_message(AddMessageRequest::new(
+            "u1",
+            "a1",
+            memind::Message::user("hello"),
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, memind::MemindError::Api(_)));
+}
+
+#[tokio::test]
+async fn extract_and_commit_do_not_retry_by_default() {
+    let server = MockServer::start().await;
+    for endpoint in [
+        "/open/v1/memory/sync/extract",
+        "/open/v1/memory/sync/commit",
+    ] {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+                "error": {"code": "unavailable", "message": "try again"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let raw = RawContent::conversation(vec![memind::Message::user("remember")]).unwrap();
+    let extract_err = client
+        .memory()
+        .extract(ExtractMemoryRequest::new("u1", "a1", raw))
+        .await
+        .unwrap_err();
+    assert!(matches!(extract_err, memind::MemindError::Api(_)));
+
+    let commit_err = client
+        .memory()
+        .commit(CommitMemoryRequest::new("u1", "a1"))
+        .await
+        .unwrap_err();
+    assert!(matches!(commit_err, memind::MemindError::Api(_)));
+}
+
+#[tokio::test]
+async fn mutating_operation_retries_when_per_request_max_retries_is_set() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open/v1/memory/sync/commit"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .append_header("Retry-After", "0")
+                .set_body_json(json!({
+                    "error": {"code": "unavailable", "message": "try again"}
+                })),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client
+        .memory()
+        .commit_with_options(
+            CommitMemoryRequest::new("u1", "a1"),
+            RequestOptions::new().max_retries(1),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, memind::MemindError::Api(_)));
+}
+
+#[tokio::test]
+async fn per_request_max_retries_zero_disables_retrieve_retry() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open/v1/memory/retrieve"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+            "error": {"code": "unavailable", "message": "try again"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = MemindClient::builder()
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+    let err = client
+        .memory()
+        .retrieve_with_options(
+            RetrieveMemoryRequest::new("u1", "a1", "what", memind::Strategy::Simple),
+            RequestOptions::new().max_retries(0),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, memind::MemindError::Api(_)));
+}

--- a/memind-clients/rust/tests/serialization_test.rs
+++ b/memind-clients/rust/tests/serialization_test.rs
@@ -1,0 +1,206 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memind::{
+    AddMessageRequest, CommitMemoryRequest, ContentBlock, ExtractMemoryRequest,
+    ExtractMemoryResponse, ExtractStatus, Message, RawContent, RetrieveMemoryRequest, Role, Source,
+    Strategy,
+};
+use serde_json::json;
+
+#[test]
+fn message_user_matches_wire_json() {
+    let message = Message::user("hello");
+    let value = serde_json::to_value(message).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "role": "USER",
+            "content": [{"type": "text", "text": "hello"}]
+        })
+    );
+}
+
+#[test]
+fn message_assistant_matches_wire_json() {
+    let message = Message::assistant("hi");
+    let value = serde_json::to_value(message).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "role": "ASSISTANT",
+            "content": [{"type": "text", "text": "hi"}]
+        })
+    );
+}
+
+#[test]
+fn content_block_and_source_tags_match_server() {
+    let image = ContentBlock::image(Source::base64("image/png", "abcd"));
+    let value = serde_json::to_value(image).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "abcd"}
+        })
+    );
+}
+
+#[test]
+fn raw_content_conversation_serializes_flat_type_and_messages() {
+    let raw = RawContent::conversation(vec![Message::user("remember this")]).unwrap();
+    let value = serde_json::to_value(raw).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "type": "conversation",
+            "messages": [
+                {"role": "USER", "content": [{"type": "text", "text": "remember this"}]}
+            ]
+        })
+    );
+}
+
+#[test]
+fn raw_content_object_serializes_flat_fields() {
+    let mut fields = serde_json::Map::new();
+    fields.insert("title".to_string(), json!("Runbook"));
+    fields.insert("body".to_string(), json!("steps"));
+
+    let raw = RawContent::object("document", fields).unwrap();
+    let value = serde_json::to_value(raw).unwrap();
+
+    assert_eq!(
+        value,
+        json!({"type": "document", "title": "Runbook", "body": "steps"})
+    );
+}
+
+#[test]
+fn raw_content_object_rejects_invalid_type_inputs() {
+    assert!(RawContent::object(" ", serde_json::Map::new()).is_err());
+    assert!(RawContent::object("conversation", serde_json::Map::new()).is_err());
+
+    let mut fields = serde_json::Map::new();
+    fields.insert("type".to_string(), json!("bad"));
+    assert!(RawContent::object("document", fields).is_err());
+}
+
+#[test]
+fn raw_content_deserializes_unknown_object_without_plugin_type() {
+    let raw: RawContent =
+        serde_json::from_value(json!({"type": "tool-call", "name": "search"})).unwrap();
+
+    match raw {
+        RawContent::Object {
+            content_type,
+            fields,
+        } => {
+            assert_eq!(content_type, "tool-call");
+            assert_eq!(fields.get("name"), Some(&json!("search")));
+        }
+        RawContent::Conversation { .. } => panic!("expected object raw content"),
+    }
+}
+
+#[test]
+fn source_validation_rejects_blank_media_inputs() {
+    let message = Message {
+        role: Role::User,
+        content: vec![ContentBlock::image(Source::url(" "))],
+        timestamp: None,
+        user_name: None,
+        source_client: None,
+    };
+    assert!(RawContent::conversation(vec![message]).is_err());
+
+    let message = Message {
+        role: Role::User,
+        content: vec![ContentBlock::audio(Source::base64(" ", ""))],
+        timestamp: None,
+        user_name: None,
+        source_client: None,
+    };
+    assert!(RawContent::conversation(vec![message]).is_err());
+}
+
+#[test]
+fn extract_status_serializes_known_and_unknown_values() {
+    assert_eq!(
+        serde_json::to_value(ExtractStatus::Success).unwrap(),
+        "SUCCESS"
+    );
+    assert_eq!(
+        serde_json::to_value(ExtractStatus::PartialSuccess).unwrap(),
+        "PARTIAL_SUCCESS"
+    );
+    assert_eq!(
+        serde_json::to_value(ExtractStatus::Unknown("QUEUED".to_string())).unwrap(),
+        "QUEUED"
+    );
+}
+
+#[test]
+fn extract_status_deserializes_unknown_values() {
+    let status: ExtractStatus = serde_json::from_value(json!("QUEUED")).unwrap();
+    assert_eq!(status, ExtractStatus::Unknown("QUEUED".to_string()));
+}
+
+#[test]
+fn extract_response_defaults_missing_arrays_and_flags() {
+    let response: ExtractMemoryResponse =
+        serde_json::from_value(json!({"status": "SUCCESS"})).unwrap();
+
+    assert_eq!(response.status, ExtractStatus::Success);
+    assert!(response.raw_data_ids.is_empty());
+    assert!(response.item_ids.is_empty());
+    assert!(response.insight_ids.is_empty());
+    assert!(!response.insight_pending);
+}
+
+#[test]
+fn request_models_serialize_camel_case() {
+    let raw = RawContent::conversation(vec![Message::user("hello")]).unwrap();
+    let extract = ExtractMemoryRequest::new("u1", "a1", raw).source_client(" rust ");
+    let value = serde_json::to_value(extract).unwrap();
+    assert_eq!(value["userId"], "u1");
+    assert_eq!(value["agentId"], "a1");
+    assert_eq!(value["sourceClient"], "rust");
+
+    let commit = CommitMemoryRequest::new("u1", "a1");
+    let value = serde_json::to_value(commit).unwrap();
+    assert_eq!(value, json!({"userId": "u1", "agentId": "a1"}));
+}
+
+#[test]
+fn retrieve_request_serializes_strategy_and_trace() {
+    let request = RetrieveMemoryRequest::new("u1", "a1", "what", Strategy::Deep).trace(true);
+    let value = serde_json::to_value(request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "userId": "u1",
+            "agentId": "a1",
+            "query": "what",
+            "strategy": "DEEP",
+            "trace": true
+        })
+    );
+}
+
+#[test]
+fn add_message_request_omits_blank_source_client() {
+    let request = AddMessageRequest::new("u1", "a1", Message::user("hi")).source_client("   ");
+    let value = serde_json::to_value(request).unwrap();
+    assert!(value.get("sourceClient").is_none());
+}

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,7 @@
                         <exclude>memind-clients/python/**/__pycache__/**</exclude>
                         <exclude>memind-clients/python/**/*.pyc</exclude>
                         <exclude>memind-clients/typescript/**</exclude>
+                        <exclude>memind-clients/rust/**</exclude>
                         <exclude>.corepack/**</exclude>
                     </excludes>
                 </configuration>
@@ -382,6 +383,7 @@
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <excludes>memind-clients/rust/**</excludes>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary
- Add the official async Rust SDK for Memind Open API, including typed request/response models, structured errors, retries, and safe URL handling.
- Add Rust client CI and a manual crates.io release workflow.
- Document the Rust client in the root README and exclude Rust files from Maven license/checkstyle scanning.

## Test Plan
- cargo fmt --check
- cargo +1.86.0 check --lib --all-features
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo package
- mvn com.mycila:license-maven-plugin:check

## Notes
- The branch is based on the latest origin/main and does not include docs/superpowers changes.
- mvn checkstyle:check currently fails on pre-existing Java client checkstyle violations unrelated to this Rust SDK change.