### PR TITLE
Use official Python client in integrations

### DIFF
--- a/memind-integrations/claude-code/README.md
+++ b/memind-integrations/claude-code/README.md
@@ -10,18 +10,18 @@ does not start the server itself.
 
 The integration is intentionally small:
 
-- No Python third-party packages.
+- Uses the official Memind Python client.
 - No local daemon management.
 - No MCP dependency.
 - No tool-call ingestion in v0.1.
 
 ## What It Does
 
-- **Retrieval**: `UserPromptSubmit` calls Memind `/open/v1/memory/retrieve` and injects relevant memories into
+- **Retrieval**: `UserPromptSubmit` calls `MemindClient.memory.retrieve(...)` and injects relevant memories into
   Claude Code as `<memind_memories>...</memind_memories>` additional context.
 - **Ingestion**: `Stop`, `PreCompact`, and `SessionEnd` read the Claude Code transcript, filter
-  user/assistant messages, and submit a caller-owned conversation payload to Memind
-  `/open/v1/memory/extract/sync`.
+  user/assistant messages, and submit a caller-owned conversation payload through
+  `AsyncMemindClient.memory.extract(...)`.
 - **Retry**: failed ingestion payloads are spooled under `~/.memind/claude-code/retry/` and replayed on later
   `SessionStart` hooks.
 - **Source tagging**: all requests use `sourceClient = "claude-code"` by default, so Memind can distinguish
@@ -30,8 +30,17 @@ The integration is intentionally small:
 ## Requirements
 
 - Claude Code with plugin and hook support.
-- Python 3.9+ available as `python3`.
+- Python 3.10+ available as `python3`.
+- The official `memind` Python package installed in the same `python3` environment used by hooks.
 - A running Memind server, usually at `http://127.0.0.1:8366`.
+
+Install the official client before enabling hooks:
+
+```bash
+python3 -m pip install memind
+```
+
+The official `memind` package installs its runtime dependencies, including `httpx` and `pydantic`.
 
 Check the Memind server before installing:
 
@@ -79,7 +88,7 @@ Claude Code installs the plugin from that directory and loads:
 - `.claude-plugin/plugin.json`: plugin metadata.
 - `hooks/hooks.json`: lifecycle hook commands.
 - `settings.json`: default Memind integration settings.
-- `scripts/`: stdlib-only Python hook runtime.
+- `scripts/`: Python hook runtime using the official Memind Python client.
 
 The plugin does not modify Memind server configuration. User overrides are read from
 `~/.memind/claude-code.json` only when you create that file.
@@ -229,7 +238,8 @@ The ingestion flow:
 3. Strips previously injected `<memind_memories>` blocks to avoid feedback loops.
 4. Skips tool/event payloads, unsupported roles, and Claude Code interruption placeholders.
 5. Computes stable fingerprints and sends only messages that have not already been submitted.
-6. Builds one caller-owned conversation raw-content payload and submits it to `/open/v1/memory/extract/sync`.
+6. Builds one caller-owned conversation raw-content payload and submits it through
+   `AsyncMemindClient.memory.extract(...)`.
 
 The local retry spool stores the full extraction payload plus the covered message fingerprints. Fingerprints are
 marked submitted only after Memind returns `SUCCESS`; `PARTIAL_SUCCESS` and failures keep the payload available
@@ -288,7 +298,8 @@ Then start a new Claude Code session and say something specific:
 Please remember: the Memind Claude Code smoke test topic is blue-lake-42.
 ```
 
-After Claude Code responds, the `Stop` hook should submit the turn to Memind via `/open/v1/memory/extract/sync`.
+After Claude Code responds, the `Stop` hook should submit the turn to Memind through
+`AsyncMemindClient.memory.extract(...)`.
 No manual commit is needed for the default reliable path.
 
 Finally, verify retrieval:
@@ -401,9 +412,9 @@ curl -fsSL http://127.0.0.1:8366/open/v1/health
 
 ### New memories are not immediately retrieved
 
-The default reliable mode submits transcript batches through `/open/v1/memory/extract/sync`, so a `SUCCESS`
-response means extraction finished for that batch. If retrieval still does not surface the expected memory,
-confirm the same `userId` and `agentId` are used for ingestion and retrieval, then inspect
+The default reliable mode submits transcript batches through `AsyncMemindClient.memory.extract(...)`, so a
+`SUCCESS` response means extraction finished for that batch. If retrieval still does not surface the expected
+memory, confirm the same `userId` and `agentId` are used for ingestion and retrieval, then inspect
 `~/.memind/claude-code.log` with `MEMIND_DEBUG=true`.
 
 ### Duplicate messages appear

--- a/memind-integrations/claude-code/scripts/ingest.py
+++ b/memind-integrations/claude-code/scripts/ingest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import asyncio
 import json
 import os
 import sys
@@ -64,9 +65,9 @@ def _spool_extract(retry_spool, identity, source_client, session_id, messages):
     )
 
 
-def ingest_messages(config, hook_input, commit=False, max_messages=None):
+async def ingest_messages_async(config, hook_input, commit=False, max_messages=None):
     identity = resolve_identity(config, hook_input)
-    client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10)
+    client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10, max_retries=0)
     transcript_path = hook_input.get("transcript_path")
     messages = []
     if config.get("autoIngest", True) and transcript_path and Path(transcript_path).exists():
@@ -83,7 +84,7 @@ def ingest_messages(config, hook_input, commit=False, max_messages=None):
         if selected:
             response = None
             try:
-                response = client.extract(
+                response = await client.extract(
                     identity["userId"],
                     identity["agentId"],
                     _extract_payload(selected),
@@ -92,7 +93,7 @@ def ingest_messages(config, hook_input, commit=False, max_messages=None):
             except Exception:
                 _spool_extract(retry_spool, identity, source_client, session_id, selected)
             else:
-                status = ((response or {}).get("data") or {}).get("status")
+                status = getattr(response, "status", None)
                 if status == "SUCCESS":
                     submitted = [message["fingerprint"] for message in selected]
                 else:
@@ -100,6 +101,10 @@ def ingest_messages(config, hook_input, commit=False, max_messages=None):
         state.mark_submitted(submitted)
     committed = False
     return {"submitted": len(submitted), "committed": committed}
+
+
+def ingest_messages(config, hook_input, commit=False, max_messages=None):
+    return asyncio.run(ingest_messages_async(config, hook_input, commit=commit, max_messages=max_messages))
 
 
 def main():

--- a/memind-integrations/claude-code/scripts/lib/client.py
+++ b/memind-integrations/claude-code/scripts/lib/client.py
@@ -12,89 +12,67 @@
 # limitations under the License.
 #
 
-import json
-import urllib.error
-import urllib.request
-from urllib.parse import urljoin
-
-
-class MemindClientError(Exception):
-    pass
-
-
-def is_success_envelope(envelope):
-    return isinstance(envelope, dict) and str(envelope.get("code")) in {"200", "success"}
-
 
 class MemindClient:
-    def __init__(self, base_url, token=None, timeout=10):
-        self.base_url = base_url.rstrip("/") + "/"
+    def __init__(self, base_url, token=None, timeout=10, max_retries=0):
+        self.base_url = base_url
         self.token = token
         self.timeout = timeout
+        self.max_retries = max_retries
 
-    def _headers(self):
-        headers = {"Content-Type": "application/json"}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-        return headers
+    def _async_client(self):
+        from memind import AsyncMemindClient
 
-    def _request(self, method, path, payload=None, require_data=False):
-        url = urljoin(self.base_url, path.lstrip("/"))
-        data = None if payload is None else json.dumps(payload).encode("utf-8")
-        request = urllib.request.Request(url, data=data, method=method, headers=self._headers())
-        try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                body = response.read().decode("utf-8")
-        except (urllib.error.URLError, TimeoutError) as exc:
-            raise MemindClientError(str(exc)) from exc
-        try:
-            envelope = json.loads(body) if body else {}
-        except json.JSONDecodeError as exc:
-            raise MemindClientError("invalid JSON response") from exc
-        if not is_success_envelope(envelope):
-            raise MemindClientError(f"unsuccessful ApiResult code: {envelope.get('code')}")
-        if require_data and envelope.get("data") is None:
-            raise MemindClientError("missing data in ApiResult")
-        return envelope
+        return AsyncMemindClient(
+            base_url=self.base_url,
+            api_token=self.token,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
 
-    def health(self):
-        return self._request("GET", "/open/v1/health", require_data=True)
+    async def health(self):
+        async with self._async_client() as client:
+            return await client.health()
+
+    async def extract(self, user_id, agent_id, raw_content, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.extract(
+                user_id=user_id,
+                agent_id=agent_id,
+                raw_content=raw_content,
+                source_client=source_client,
+            )
+
+    async def add_message(self, user_id, agent_id, message, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.add_message(
+                user_id=user_id,
+                agent_id=agent_id,
+                message=message,
+                source_client=source_client,
+            )
+
+    async def commit(self, user_id, agent_id, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.commit(
+                user_id=user_id,
+                agent_id=agent_id,
+                source_client=source_client,
+            )
 
     def retrieve(self, user_id, agent_id, query, strategy="SIMPLE", trace=False):
-        return self._request(
-            "POST",
-            "/open/v1/memory/retrieve",
-            {"userId": user_id, "agentId": agent_id, "query": query, "strategy": strategy, "trace": trace},
-            require_data=True,
-        )
+        from memind import MemindClient as OfficialMemindClient
 
-    def add_message(self, user_id, agent_id, message, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id, "message": message}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request(
-            "POST",
-            "/open/v1/memory/add-message",
-            payload,
-        )
-
-    def extract(self, user_id, agent_id, raw_content, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id, "rawContent": raw_content}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request(
-            "POST",
-            "/open/v1/memory/extract/sync",
-            payload,
-            require_data=True,
-        )
-
-    def commit(self, user_id, agent_id, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request(
-            "POST",
-            "/open/v1/memory/commit",
-            payload,
-        )
+        with OfficialMemindClient(
+            base_url=self.base_url,
+            api_token=self.token,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        ) as client:
+            return client.memory.retrieve(
+                user_id=user_id,
+                agent_id=agent_id,
+                query=query,
+                strategy=strategy,
+                trace=trace,
+            )

--- a/memind-integrations/claude-code/scripts/retrieve.py
+++ b/memind-integrations/claude-code/scripts/retrieve.py
@@ -74,9 +74,9 @@ def main():
         context_turns = int(config.get("retrieveContextTurns", 0))
         recent_context = read_recent_context(hook_input.get("transcript_path"), context_turns)
         query = prompt if not recent_context else f"{recent_context}\ncurrent: {prompt}"
-        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=12)
-        envelope = client.retrieve(identity["userId"], identity["agentId"], query, config.get("retrieveStrategy", "SIMPLE"), False)
-        context = _format_context(envelope.get("data") or {}, config)
+        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=12, max_retries=0)
+        result = client.retrieve(identity["userId"], identity["agentId"], query, config.get("retrieveStrategy", "SIMPLE"), False)
+        context = _format_context(result.model_dump(by_alias=True), config)
         if not context:
             print(json.dumps({"continue": True}))
             return

--- a/memind-integrations/claude-code/scripts/session_start.py
+++ b/memind-integrations/claude-code/scripts/session_start.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import asyncio
 import json
 import os
 import socket
@@ -37,12 +38,11 @@ def _tcp_check(url, timeout=1):
         return True
 
 
-def main():
-    config = load_config()
+async def _run_session_start_async(config):
     try:
-        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=2)
+        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=2, max_retries=0)
         try:
-            client.health()
+            await client.health()
         except Exception:
             _tcp_check(config["memindApiUrl"], timeout=1)
         claimed = None
@@ -51,15 +51,15 @@ def main():
             claimed = spool.claim_next()
             if claimed:
                 payload = spool.load_claimed(claimed)
-                replay_client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10)
+                replay_client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10, max_retries=0)
                 if payload.get("kind") == "extract":
-                    response = replay_client.extract(
+                    response = await replay_client.extract(
                         payload["userId"],
                         payload["agentId"],
                         payload["rawContent"],
                         payload.get("sourceClient"),
                     )
-                    status = ((response or {}).get("data") or {}).get("status")
+                    status = getattr(response, "status", None)
                     if status != "SUCCESS":
                         raise RuntimeError(f"extract replay did not fully succeed: {status}")
                     if payload.get("sessionId") and payload.get("fingerprints"):
@@ -67,7 +67,7 @@ def main():
                             state.mark_submitted(payload["fingerprints"])
                     spool.complete(claimed)
                 elif payload.get("kind") == "add-message":
-                    replay_client.add_message(
+                    await replay_client.add_message(
                         payload["userId"],
                         payload["agentId"],
                         payload["message"],
@@ -78,7 +78,7 @@ def main():
                             state.mark_submitted([payload["fingerprint"]])
                     spool.complete(claimed)
                 elif payload.get("kind") == "commit":
-                    replay_client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
+                    await replay_client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
                     spool.complete(claimed)
                 else:
                     spool.complete(claimed)
@@ -94,6 +94,18 @@ def main():
             SessionStateStore(state_root()).cleanup(int(config.get("stateMaxAgeDays", 14)))
         except Exception as exc:
             debug_log(config, "state_cleanup_failed", {"error": str(exc)})
+    except Exception as exc:
+        debug_log(config, "session_start_health_failed", {"error": str(exc)})
+
+
+def run_session_start(config):
+    asyncio.run(_run_session_start_async(config))
+
+
+def main():
+    config = load_config()
+    try:
+        run_session_start(config)
     except Exception as exc:
         debug_log(config, "session_start_health_failed", {"error": str(exc)})
     print(json.dumps({"continue": True, "suppressOutput": True}))

--- a/memind-integrations/claude-code/tests/test_client.py
+++ b/memind-integrations/claude-code/tests/test_client.py
@@ -1,131 +1,160 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-import json
-import threading
+import importlib
+import sys
+import types
 import unittest
-from http.server import BaseHTTPRequestHandler, HTTPServer
-
-from scripts.lib.client import MemindClient, MemindClientError, is_success_envelope
-
-
-class Handler(BaseHTTPRequestHandler):
-    responses = []
-    requests = []
-
-    def do_GET(self):
-        self._handle()
-
-    def do_POST(self):
-        self._handle()
-
-    def _handle(self):
-        length = int(self.headers.get("Content-Length", "0"))
-        body = self.rfile.read(length).decode("utf-8") if length else ""
-        Handler.requests.append((self.command, self.path, json.loads(body) if body else None))
-        status, payload = Handler.responses.pop(0)
-        encoded = json.dumps(payload).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(encoded)))
-        self.end_headers()
-        self.wfile.write(encoded)
-
-    def log_message(self, format, *args):
-        return
+from types import SimpleNamespace
+from unittest import mock
 
 
-class ClientTest(unittest.TestCase):
+class _FakeAsyncMemory:
+    def __init__(self):
+        self.calls = []
+
+    async def extract(self, **kwargs):
+        self.calls.append(("extract", kwargs))
+        return SimpleNamespace(status="SUCCESS", raw_data_ids=["rd-1"])
+
+    async def add_message(self, **kwargs):
+        self.calls.append(("add_message", kwargs))
+        return None
+
+    async def commit(self, **kwargs):
+        self.calls.append(("commit", kwargs))
+        return None
+
+
+class _FakeAsyncMemindClient:
+    instances = []
+
+    def __init__(self, *, base_url=None, api_token=None, timeout=None, max_retries=None):
+        self.base_url = base_url
+        self.api_token = api_token
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.memory = _FakeAsyncMemory()
+        self.closed = False
+        _FakeAsyncMemindClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.closed = True
+
+    async def health(self):
+        return SimpleNamespace(status="UP")
+
+
+class _FakeSyncMemory:
+    def __init__(self):
+        self.calls = []
+
+    def retrieve(self, **kwargs):
+        self.calls.append(("retrieve", kwargs))
+        return SimpleNamespace(
+            model_dump=lambda by_alias=True: {
+                "status": "success",
+                "items": [{"id": "1", "text": "remember espresso"}],
+                "insights": [],
+            }
+        )
+
+
+class _FakeSyncMemindClient:
+    instances = []
+
+    def __init__(self, *, base_url=None, api_token=None, timeout=None, max_retries=None):
+        self.base_url = base_url
+        self.api_token = api_token
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.memory = _FakeSyncMemory()
+        self.closed = False
+        _FakeSyncMemindClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+
+
+class _Strategy(str):
+    SIMPLE = "SIMPLE"
+    DEEP = "DEEP"
+
+    def __new__(cls, value):
+        return str.__new__(cls, value)
+
+
+def _fake_memind_module():
+    module = types.ModuleType("memind")
+    module.AsyncMemindClient = _FakeAsyncMemindClient
+    module.MemindClient = _FakeSyncMemindClient
+    module.Strategy = _Strategy
+    return module
+
+
+def _load_client_class():
+    import scripts.lib.client as client_module
+
+    return importlib.reload(client_module).MemindClient
+
+
+class ClientTest(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        Handler.responses = []
-        Handler.requests = []
-        self.server = HTTPServer(("127.0.0.1", 0), Handler)
-        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
-        self.thread.start()
-        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+        _FakeAsyncMemindClient.instances = []
+        _FakeSyncMemindClient.instances = []
 
-    def tearDown(self):
-        self.server.shutdown()
-        self.server.server_close()
-        self.thread.join(timeout=2)
-
-    def test_success_envelope_accepts_200_and_success(self):
-        self.assertTrue(is_success_envelope({"code": "200"}))
-        self.assertTrue(is_success_envelope({"code": "success"}))
-        self.assertFalse(is_success_envelope({"code": "500"}))
-
-    def test_health(self):
-        Handler.responses.append((200, {"code": "success", "data": {"status": "UP"}}))
-        client = MemindClient(self.base_url, timeout=2)
-        self.assertEqual(client.health()["data"]["status"], "UP")
-        self.assertEqual(Handler.requests[0][1], "/open/v1/health")
-
-    def test_add_message_and_commit(self):
-        Handler.responses.append((200, {"code": "200", "data": None}))
-        Handler.responses.append((200, {"code": "200", "data": None}))
-        client = MemindClient(self.base_url, timeout=2)
-        message = {"role": "USER", "content": [{"type": "text", "text": "hello"}], "timestamp": None}
-        client.add_message("u", "a", message, "claude-code")
-        client.commit("u", "a", "claude-code")
-        self.assertEqual(Handler.requests[0][1], "/open/v1/memory/add-message")
-        self.assertEqual(Handler.requests[0][2]["sourceClient"], "claude-code")
-        self.assertEqual(Handler.requests[1][1], "/open/v1/memory/commit")
-        self.assertEqual(Handler.requests[1][2]["sourceClient"], "claude-code")
-
-    def test_extract_sync_sends_raw_content_and_returns_data(self):
-        Handler.responses.append(
-            (
-                200,
-                {
-                    "code": "success",
-                    "data": {
-                        "status": "SUCCESS",
-                        "rawDataIds": ["rd-1"],
-                        "itemIds": [],
-                        "insightIds": [],
-                        "insightPending": False,
-                    },
-                },
+    async def test_async_methods_use_official_client_with_hook_budget(self):
+        with mock.patch.dict(sys.modules, {"memind": _fake_memind_module()}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", "token", timeout=10, max_retries=0)
+            health = await client.health()
+            response = await client.extract(
+                "u",
+                "a",
+                {"type": "conversation", "messages": []},
+                "claude-code",
             )
-        )
-        client = MemindClient(self.base_url, timeout=2)
-        response = client.extract(
-            "u",
-            "a",
-            {
-                "type": "conversation",
-                "messages": [
-                    {"role": "USER", "content": [{"type": "text", "text": "hello"}]}
-                ],
-            },
-            "claude-code",
-        )
-        self.assertEqual(response["data"]["status"], "SUCCESS")
-        self.assertEqual(Handler.requests[0][1], "/open/v1/memory/extract/sync")
-        self.assertEqual(Handler.requests[0][2]["sourceClient"], "claude-code")
+            await client.add_message("u", "a", {"role": "USER", "content": []}, "claude-code")
+            await client.commit("u", "a", "claude-code")
 
-    def test_retrieve_requires_data(self):
-        Handler.responses.append((200, {"code": "success", "data": {"items": [], "insights": []}}))
-        client = MemindClient(self.base_url, timeout=2)
-        response = client.retrieve("u", "a", "query", "SIMPLE", False)
-        self.assertEqual(response["data"]["items"], [])
+        self.assertEqual(health.status, "UP")
+        self.assertEqual(response.status, "SUCCESS")
+        self.assertEqual(len(_FakeAsyncMemindClient.instances), 4)
+        for instance in _FakeAsyncMemindClient.instances:
+            self.assertEqual(instance.base_url, "http://127.0.0.1:8366")
+            self.assertEqual(instance.api_token, "token")
+            self.assertEqual(instance.timeout, 10)
+            self.assertEqual(instance.max_retries, 0)
+            self.assertTrue(instance.closed)
+        extract_call = _FakeAsyncMemindClient.instances[1].memory.calls[0][1]
+        self.assertEqual(extract_call["source_client"], "claude-code")
+        self.assertEqual(extract_call["raw_content"]["type"], "conversation")
 
-    def test_bad_status_raises(self):
-        Handler.responses.append((500, {"code": "500"}))
-        client = MemindClient(self.base_url, timeout=2)
-        with self.assertRaises(MemindClientError):
-            client.health()
+    def test_retrieve_uses_official_sync_client_and_returns_model(self):
+        with mock.patch.dict(sys.modules, {"memind": _fake_memind_module()}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", timeout=12, max_retries=0)
+            result = client.retrieve("u", "a", "query", "SIMPLE", False)
+
+        self.assertEqual(result.model_dump(by_alias=True)["items"][0]["text"], "remember espresso")
+        self.assertEqual(len(_FakeSyncMemindClient.instances), 1)
+        instance = _FakeSyncMemindClient.instances[0]
+        self.assertEqual(instance.timeout, 12)
+        self.assertEqual(instance.max_retries, 0)
+        self.assertTrue(instance.closed)
+        retrieve_call = instance.memory.calls[0][1]
+        self.assertEqual(retrieve_call["strategy"], "SIMPLE")
+        self.assertFalse(retrieve_call["trace"])
+
+    async def test_missing_official_client_import_propagates_to_hook_fail_open_boundary(self):
+        with mock.patch.dict(sys.modules, {"memind": None}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", timeout=10, max_retries=0)
+            with self.assertRaises(ModuleNotFoundError):
+                await client.health()
 
 
 if __name__ == "__main__":

--- a/memind-integrations/claude-code/tests/test_hooks.py
+++ b/memind-integrations/claude-code/tests/test_hooks.py
@@ -16,6 +16,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -142,7 +143,8 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=Path(tmp) / "retry"):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.return_value = {"data": {"status": "SUCCESS"}}
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="SUCCESS"))
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(
                                 config,
                                 {
@@ -154,9 +156,9 @@ class HookTest(unittest.TestCase):
                             )
             self.assertEqual(result["submitted"], 1)
             self.assertFalse(result["committed"])
-            client.extract.assert_called_once()
-            client.commit.assert_not_called()
-            raw_content = client.extract.call_args.args[2]
+            client.extract.assert_awaited_once()
+            client.commit.assert_not_awaited()
+            raw_content = client.extract.await_args.args[2]
             self.assertEqual(raw_content["type"], "conversation")
             self.assertEqual(raw_content["messages"][0]["role"], "USER")
         finally:
@@ -198,12 +200,8 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=retry_dir):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.return_value = {
-                                "data": {
-                                    "status": "PARTIAL_SUCCESS",
-                                    "errorMessage": "partial",
-                                }
-                            }
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="PARTIAL_SUCCESS"))
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(
                                 config,
                                 {
@@ -259,15 +257,17 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(session_start, "state_root", return_value=state_dir):
                         with mock.patch.object(session_start, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.health.return_value = {"data": {"status": "UP"}}
-                            client.extract.return_value = {"data": {"status": "SUCCESS"}}
+                            client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="SUCCESS"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             session_start.main()
             with SessionStateStore(state_dir).locked("s1") as state:
                 self.assertTrue(state.is_submitted("fp1"))
             self.assertEqual(list(retry_dir.glob("*.json")), [])
-            client.extract.assert_called_once()
-            client.add_message.assert_not_called()
-            client.commit.assert_not_called()
+            client.extract.assert_awaited_once()
+            client.add_message.assert_not_awaited()
+            client.commit.assert_not_awaited()
 
     def test_session_start_keeps_extract_payload_when_replay_is_not_success(self):
         sys.path.insert(0, str(ROOT / "scripts"))
@@ -307,13 +307,15 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(session_start, "state_root", return_value=state_dir):
                         with mock.patch.object(session_start, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.health.return_value = {"data": {"status": "UP"}}
-                            client.extract.return_value = {"data": {"status": "PARTIAL_SUCCESS"}}
+                            client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="PARTIAL_SUCCESS"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             session_start.main()
             with SessionStateStore(state_dir).locked("s1") as state:
                 self.assertFalse(state.is_submitted("fp1"))
             self.assertEqual(len(list(retry_dir.glob("*.json"))), 1)
-            client.extract.assert_called_once()
+            client.extract.assert_awaited_once()
 
 
 if __name__ == "__main__":

--- a/memind-integrations/codex/README.md
+++ b/memind-integrations/codex/README.md
@@ -9,17 +9,17 @@ sessions. The plugin connects Codex to an already-running Memind server; it does
 
 The integration is intentionally small:
 
-- No Python third-party packages.
+- Uses the official Memind Python client.
 - No Codex marketplace dependency.
 - No overwrite of existing Codex hooks or config.
 - No tool-call ingestion in v0.1.
 
 ## What It Does
 
-- **Retrieval**: `UserPromptSubmit` calls Memind `/open/v1/memory/retrieve` and injects relevant memories into
+- **Retrieval**: `UserPromptSubmit` calls `MemindClient.memory.retrieve(...)` and injects relevant memories into
   the Codex prompt as `<memind_memories>...</memind_memories>`.
 - **Ingestion**: `Stop` reads the Codex transcript, filters user/assistant messages, and submits a caller-owned
-  conversation payload to Memind `/open/v1/memory/extract/sync`.
+  conversation payload through `AsyncMemindClient.memory.extract(...)`.
 - **Retry**: failed ingestion batches are spooled under `~/.memind/codex/retry/` and replayed on the next
   `SessionStart`.
 - **Source tagging**: all requests use `sourceClient = "codex"` by default, so Memind can distinguish Codex
@@ -28,8 +28,17 @@ The integration is intentionally small:
 ## Requirements
 
 - Codex CLI with hook support.
-- Python 3.9+ available as `python3`.
+- Python 3.10+ available as `python3`.
+- The official `memind` Python package installed in the same `python3` environment used by hooks.
 - A running Memind server, usually at `http://127.0.0.1:8366`.
+
+Install the official client before running `install.sh`:
+
+```bash
+python3 -m pip install memind
+```
+
+The official `memind` package installs its runtime dependencies, including `httpx` and `pydantic`.
 
 Check the Memind server before installing:
 
@@ -46,6 +55,9 @@ curl -fsSL http://127.0.0.1:8366/open/v1/health
 ```bash
 bash memind-integrations/codex/install.sh
 ```
+
+The installer validates that `python3` can import the official `memind` package and that the package exposes the
+client APIs used by the hooks. Install or upgrade `memind` before running the installer if validation fails.
 
 Published installs use the same script directly from the repository:
 
@@ -236,7 +248,8 @@ The Stop hook:
 3. Strips previously injected `<memind_memories>` blocks to avoid feedback loops.
 4. Skips tool/event payloads and Codex control context blocks.
 5. Computes stable fingerprints and sends only messages that have not already been submitted.
-6. Builds one caller-owned conversation raw-content payload and submits it to `/open/v1/memory/extract/sync`.
+6. Builds one caller-owned conversation raw-content payload and submits it through
+   `AsyncMemindClient.memory.extract(...)`.
 
 The local retry spool stores the full extraction payload plus the covered message fingerprints. Fingerprints are
 marked submitted only after Memind returns `SUCCESS`; `PARTIAL_SUCCESS` and failures keep the payload available

--- a/memind-integrations/codex/install.sh
+++ b/memind-integrations/codex/install.sh
@@ -68,6 +68,35 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
+check_python_runtime() {
+  python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 10):
+    raise SystemExit("error: Python 3.10+ is required for Memind Codex hooks")
+
+try:
+    import memind
+except Exception as exc:
+    raise SystemExit(f"error: Memind Python client is required: {exc}")
+
+required = [
+    "AsyncMemindClient",
+    "MemindClient",
+    "ConversationContent",
+    "Message",
+    "Strategy",
+]
+missing = [name for name in required if not hasattr(memind, name)]
+if missing:
+    joined = ", ".join(missing)
+    raise SystemExit(
+        "error: Memind Python client is missing required public APIs: "
+        f"{joined}. Install or upgrade the official memind package."
+    )
+PY
+}
+
 if [[ "${DRY_RUN}" == true ]]; then
   echo "Dry run: no files will be written."
   if [[ "${UNINSTALL}" == true ]]; then
@@ -179,6 +208,10 @@ if [[ "${UNINSTALL}" == true ]]; then
   run_hook_installer --uninstall
   echo "Uninstall complete. Memind state and user config under ~/.memind are preserved."
   exit 0
+fi
+
+if [[ "${UNINSTALL}" != true ]]; then
+  check_python_runtime
 fi
 
 install_files

--- a/memind-integrations/codex/scripts/ingest.py
+++ b/memind-integrations/codex/scripts/ingest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import asyncio
 import json
 import os
 import sys
@@ -51,9 +52,9 @@ def _spool_extract(retry_spool, identity, source_client, session_key, messages):
     )
 
 
-def ingest_messages(config, hook_input):
+async def ingest_messages_async(config, hook_input):
     identity = resolve_identity(config, hook_input)
-    client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10)
+    client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10, max_retries=0)
     transcript_path = hook_input.get("transcript_path")
     messages = []
     if config.get("autoIngest", True) and transcript_path and Path(transcript_path).exists():
@@ -71,7 +72,7 @@ def ingest_messages(config, hook_input):
     submitted = []
     if selected:
         try:
-            response = client.extract(
+            response = await client.extract(
                 identity["userId"],
                 identity["agentId"],
                 _extract_payload(selected),
@@ -80,7 +81,7 @@ def ingest_messages(config, hook_input):
         except Exception:
             _spool_extract(retry_spool, identity, source_client, session_key, selected)
         else:
-            status = ((response or {}).get("data") or {}).get("status")
+            status = getattr(response, "status", None)
             if status == "SUCCESS":
                 submitted = [message["fingerprint"] for message in selected]
                 store.mark_submitted(session_key, submitted)
@@ -88,6 +89,10 @@ def ingest_messages(config, hook_input):
                 _spool_extract(retry_spool, identity, source_client, session_key, selected)
 
     return {"submitted": len(submitted), "committed": False}
+
+
+def ingest_messages(config, hook_input):
+    return asyncio.run(ingest_messages_async(config, hook_input))
 
 
 def main():

--- a/memind-integrations/codex/scripts/lib/client.py
+++ b/memind-integrations/codex/scripts/lib/client.py
@@ -1,73 +1,63 @@
-import json
-import urllib.error
-import urllib.request
-from urllib.parse import urljoin
-
-
-class MemindClientError(Exception):
-    pass
-
-
-def is_success_envelope(envelope):
-    return isinstance(envelope, dict) and str(envelope.get("code")) in {"200", "success"}
-
-
 class MemindClient:
-    def __init__(self, base_url, token=None, timeout=10):
-        self.base_url = base_url.rstrip("/") + "/"
+    def __init__(self, base_url, token=None, timeout=10, max_retries=0):
+        self.base_url = base_url
         self.token = token
         self.timeout = timeout
+        self.max_retries = max_retries
 
-    def _headers(self):
-        headers = {"Content-Type": "application/json"}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-        return headers
+    def _async_client(self):
+        from memind import AsyncMemindClient
 
-    def _request(self, method, path, payload=None, require_data=False):
-        url = urljoin(self.base_url, path.lstrip("/"))
-        data = None if payload is None else json.dumps(payload).encode("utf-8")
-        request = urllib.request.Request(url, data=data, method=method, headers=self._headers())
-        try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                body = response.read().decode("utf-8")
-        except (urllib.error.URLError, TimeoutError) as exc:
-            raise MemindClientError(str(exc)) from exc
-        try:
-            envelope = json.loads(body) if body else {}
-        except json.JSONDecodeError as exc:
-            raise MemindClientError("invalid JSON response") from exc
-        if not is_success_envelope(envelope):
-            raise MemindClientError(f"unsuccessful ApiResult code: {envelope.get('code')}")
-        if require_data and envelope.get("data") is None:
-            raise MemindClientError("missing data in ApiResult")
-        return envelope
-
-    def health(self):
-        return self._request("GET", "/open/v1/health", require_data=True)
-
-    def retrieve(self, user_id, agent_id, query, strategy="SIMPLE", trace=False):
-        return self._request(
-            "POST",
-            "/open/v1/memory/retrieve",
-            {"userId": user_id, "agentId": agent_id, "query": query, "strategy": strategy, "trace": trace},
-            require_data=True,
+        return AsyncMemindClient(
+            base_url=self.base_url,
+            api_token=self.token,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
         )
 
-    def add_message(self, user_id, agent_id, message, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id, "message": message}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request("POST", "/open/v1/memory/add-message", payload)
+    async def health(self):
+        async with self._async_client() as client:
+            return await client.health()
 
-    def extract(self, user_id, agent_id, raw_content, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id, "rawContent": raw_content}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request("POST", "/open/v1/memory/extract/sync", payload, require_data=True)
+    async def extract(self, user_id, agent_id, raw_content, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.extract(
+                user_id=user_id,
+                agent_id=agent_id,
+                raw_content=raw_content,
+                source_client=source_client,
+            )
 
-    def commit(self, user_id, agent_id, source_client=None):
-        payload = {"userId": user_id, "agentId": agent_id}
-        if source_client:
-            payload["sourceClient"] = source_client
-        return self._request("POST", "/open/v1/memory/commit", payload)
+    async def add_message(self, user_id, agent_id, message, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.add_message(
+                user_id=user_id,
+                agent_id=agent_id,
+                message=message,
+                source_client=source_client,
+            )
+
+    async def commit(self, user_id, agent_id, source_client=None):
+        async with self._async_client() as client:
+            return await client.memory.commit(
+                user_id=user_id,
+                agent_id=agent_id,
+                source_client=source_client,
+            )
+
+    def retrieve(self, user_id, agent_id, query, strategy="SIMPLE", trace=False):
+        from memind import MemindClient as OfficialMemindClient
+
+        with OfficialMemindClient(
+            base_url=self.base_url,
+            api_token=self.token,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        ) as client:
+            return client.memory.retrieve(
+                user_id=user_id,
+                agent_id=agent_id,
+                query=query,
+                strategy=strategy,
+                trace=trace,
+            )

--- a/memind-integrations/codex/scripts/retrieve.py
+++ b/memind-integrations/codex/scripts/retrieve.py
@@ -61,9 +61,9 @@ def main():
         context_turns = int(config.get("retrieveContextTurns", 0))
         recent_context = read_recent_context(hook_input.get("transcript_path"), context_turns)
         query = prompt if not recent_context else f"{recent_context}\ncurrent: {prompt}"
-        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=12)
-        envelope = client.retrieve(identity["userId"], identity["agentId"], query, config.get("retrieveStrategy", "SIMPLE"), False)
-        context = _format_context(envelope.get("data") or {}, config)
+        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=12, max_retries=0)
+        result = client.retrieve(identity["userId"], identity["agentId"], query, config.get("retrieveStrategy", "SIMPLE"), False)
+        context = _format_context(result.model_dump(by_alias=True), config)
         if not context:
             print(json.dumps({"continue": True}))
             return

--- a/memind-integrations/codex/scripts/session_start.py
+++ b/memind-integrations/codex/scripts/session_start.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import asyncio
 import json
 import os
 import socket
@@ -24,7 +25,7 @@ def _tcp_check(url, timeout=1):
         return True
 
 
-def _replay_ingestion_batch(client, payload):
+async def _replay_ingestion_batch(client, payload):
     session_key = payload.get("sessionKey")
     fingerprints = payload.get("fingerprints") or []
     operations = payload.get("operations") or []
@@ -38,7 +39,7 @@ def _replay_ingestion_batch(client, payload):
             with store.locked(session_key) as state:
                 if state.is_submitted(fingerprint):
                     continue
-        client.add_message(
+        await client.add_message(
             operation["userId"],
             operation["agentId"],
             operation["message"],
@@ -47,21 +48,21 @@ def _replay_ingestion_batch(client, payload):
         appended += 1
         if fingerprint and session_key:
             store.mark_submitted(session_key, [fingerprint])
-    if payload.get("commitOnSuccess"):
-        client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
+    if appended and payload.get("commitOnSuccess"):
+        await client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
     return appended
 
 
-def _replay_payload(client, payload):
+async def _replay_payload(client, payload):
     kind = payload.get("kind")
     if kind == "extract":
-        response = client.extract(
+        response = await client.extract(
             payload["userId"],
             payload["agentId"],
             payload["rawContent"],
             payload.get("sourceClient"),
         )
-        status = ((response or {}).get("data") or {}).get("status")
+        status = getattr(response, "status", None)
         if status != "SUCCESS":
             raise RuntimeError(f"extract replay did not fully succeed: {status}")
         session_key = payload.get("sessionKey")
@@ -70,18 +71,18 @@ def _replay_payload(client, payload):
             SessionStateStore(state_root()).mark_submitted(session_key, fingerprints)
         return len(fingerprints)
     if kind == "ingestion-batch":
-        return _replay_ingestion_batch(client, payload)
+        return await _replay_ingestion_batch(client, payload)
     if kind == "commit":
-        client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
+        await client.commit(payload["userId"], payload["agentId"], payload.get("sourceClient"))
         return 0
     return 0
 
 
-def run_session_start(config):
+async def run_session_start_async(config):
     try:
-        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=2)
+        client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=2, max_retries=0)
         try:
-            client.health()
+            await client.health()
         except Exception:
             _tcp_check(config["memindApiUrl"], timeout=1)
     except Exception as exc:
@@ -94,8 +95,8 @@ def run_session_start(config):
         claimed = spool.claim_next()
         if claimed:
             payload = spool.load_claimed(claimed)
-            replay_client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10)
-            _replay_payload(replay_client, payload)
+            replay_client = MemindClient(config["memindApiUrl"], config.get("memindApiToken"), timeout=10, max_retries=0)
+            await _replay_payload(replay_client, payload)
             spool.complete(claimed)
         spool.cleanup(int(config.get("ingestRetryMaxFiles", 20)), int(config.get("ingestRetryMaxAgeDays", 7)))
     except Exception as exc:
@@ -110,6 +111,10 @@ def run_session_start(config):
         SessionStateStore(state_root()).cleanup(int(config.get("stateMaxAgeDays", 14)))
     except Exception as exc:
         debug_log(config, "state_cleanup_failed", {"error": str(exc)})
+
+
+def run_session_start(config):
+    asyncio.run(run_session_start_async(config))
 
 
 def main():

--- a/memind-integrations/codex/tests/test_client.py
+++ b/memind-integrations/codex/tests/test_client.py
@@ -1,83 +1,152 @@
-import json
+import importlib
+import sys
+import types
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
-from scripts.lib.client import MemindClient, MemindClientError, is_success_envelope
+
+class _FakeAsyncMemory:
+    def __init__(self):
+        self.calls = []
+
+    async def extract(self, **kwargs):
+        self.calls.append(("extract", kwargs))
+        return SimpleNamespace(status="SUCCESS", raw_data_ids=["rd-1"])
+
+    async def add_message(self, **kwargs):
+        self.calls.append(("add_message", kwargs))
+        return None
+
+    async def commit(self, **kwargs):
+        self.calls.append(("commit", kwargs))
+        return None
 
 
-class _FakeResponse:
-    def __init__(self, body):
-        self.body = body
+class _FakeAsyncMemindClient:
+    instances = []
+
+    def __init__(self, *, base_url=None, api_token=None, timeout=None, max_retries=None):
+        self.base_url = base_url
+        self.api_token = api_token
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.memory = _FakeAsyncMemory()
+        self.closed = False
+        _FakeAsyncMemindClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.closed = True
+
+    async def health(self):
+        return SimpleNamespace(status="UP")
+
+
+class _FakeSyncMemory:
+    def __init__(self):
+        self.calls = []
+
+    def retrieve(self, **kwargs):
+        self.calls.append(("retrieve", kwargs))
+        return SimpleNamespace(
+            model_dump=lambda by_alias=True: {
+                "status": "success",
+                "items": [{"id": "1", "text": "remember espresso"}],
+                "insights": [],
+            }
+        )
+
+
+class _FakeSyncMemindClient:
+    instances = []
+
+    def __init__(self, *, base_url=None, api_token=None, timeout=None, max_retries=None):
+        self.base_url = base_url
+        self.api_token = api_token
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.memory = _FakeSyncMemory()
+        self.closed = False
+        _FakeSyncMemindClient.instances.append(self)
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def read(self):
-        return self.body.encode("utf-8")
+        self.closed = True
 
 
-class ClientTest(unittest.TestCase):
-    def test_success_codes_match_api_result_variants(self):
-        self.assertTrue(is_success_envelope({"code": "200"}))
-        self.assertTrue(is_success_envelope({"code": "success"}))
-        self.assertFalse(is_success_envelope({"code": "500"}))
+class _Strategy(str):
+    SIMPLE = "SIMPLE"
+    DEEP = "DEEP"
 
-    @mock.patch("urllib.request.urlopen")
-    def test_add_message_sends_source_client(self, urlopen):
-        urlopen.return_value = _FakeResponse(json.dumps({"code": "200"}))
-        client = MemindClient("http://127.0.0.1:8366")
-        client.add_message("u", "a", {"role": "USER", "content": []}, "codex")
-        payload = json.loads(urlopen.call_args.args[0].data.decode("utf-8"))
-        self.assertEqual(payload["sourceClient"], "codex")
-        self.assertEqual(payload["message"]["role"], "USER")
+    def __new__(cls, value):
+        return str.__new__(cls, value)
 
-    @mock.patch("urllib.request.urlopen")
-    def test_commit_sends_source_client(self, urlopen):
-        urlopen.return_value = _FakeResponse(json.dumps({"code": "200"}))
-        client = MemindClient("http://127.0.0.1:8366")
-        client.commit("u", "a", "codex")
-        payload = json.loads(urlopen.call_args.args[0].data.decode("utf-8"))
-        self.assertEqual(payload, {"userId": "u", "agentId": "a", "sourceClient": "codex"})
 
-    @mock.patch("urllib.request.urlopen")
-    def test_extract_sync_sends_source_client_and_raw_content(self, urlopen):
-        urlopen.return_value = _FakeResponse(
-            json.dumps(
-                {
-                    "code": "success",
-                    "data": {
-                        "status": "SUCCESS",
-                        "rawDataIds": ["rd-1"],
-                        "itemIds": [],
-                        "insightIds": [],
-                        "insightPending": False,
-                    },
-                }
+def _fake_memind_module():
+    module = types.ModuleType("memind")
+    module.AsyncMemindClient = _FakeAsyncMemindClient
+    module.MemindClient = _FakeSyncMemindClient
+    module.Strategy = _Strategy
+    return module
+
+
+def _load_client_class():
+    import scripts.lib.client as client_module
+
+    return importlib.reload(client_module).MemindClient
+
+
+class ClientTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        _FakeAsyncMemindClient.instances = []
+        _FakeSyncMemindClient.instances = []
+
+    async def test_async_methods_use_official_client_with_codex_source(self):
+        with mock.patch.dict(sys.modules, {"memind": _fake_memind_module()}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", "token", timeout=10, max_retries=0)
+            health = await client.health()
+            response = await client.extract(
+                "u",
+                "a",
+                {"type": "conversation", "messages": []},
+                "codex",
             )
-        )
-        client = MemindClient("http://127.0.0.1:8366")
-        response = client.extract(
-            "u",
-            "a",
-            {"type": "conversation", "messages": [{"role": "USER", "content": []}]},
-            "codex",
-        )
-        request = urlopen.call_args.args[0]
-        payload = json.loads(request.data.decode("utf-8"))
-        self.assertTrue(request.full_url.endswith("/open/v1/memory/extract/sync"))
-        self.assertEqual(response["data"]["status"], "SUCCESS")
-        self.assertEqual(payload["sourceClient"], "codex")
-        self.assertEqual(payload["rawContent"]["type"], "conversation")
+            await client.add_message("u", "a", {"role": "USER", "content": []}, "codex")
+            await client.commit("u", "a", "codex")
 
-    @mock.patch("urllib.request.urlopen")
-    def test_retrieve_requires_data(self, urlopen):
-        urlopen.return_value = _FakeResponse(json.dumps({"code": "success"}))
-        client = MemindClient("http://127.0.0.1:8366")
-        with self.assertRaises(MemindClientError):
-            client.retrieve("u", "a", "q")
+        self.assertEqual(health.status, "UP")
+        self.assertEqual(response.status, "SUCCESS")
+        self.assertEqual(len(_FakeAsyncMemindClient.instances), 4)
+        for instance in _FakeAsyncMemindClient.instances:
+            self.assertEqual(instance.base_url, "http://127.0.0.1:8366")
+            self.assertEqual(instance.api_token, "token")
+            self.assertEqual(instance.timeout, 10)
+            self.assertEqual(instance.max_retries, 0)
+            self.assertTrue(instance.closed)
+        extract_call = _FakeAsyncMemindClient.instances[1].memory.calls[0][1]
+        self.assertEqual(extract_call["source_client"], "codex")
+
+    def test_retrieve_uses_official_sync_client(self):
+        with mock.patch.dict(sys.modules, {"memind": _fake_memind_module()}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", timeout=12, max_retries=0)
+            result = client.retrieve("u", "a", "query", "SIMPLE", False)
+
+        self.assertEqual(result.model_dump(by_alias=True)["items"][0]["text"], "remember espresso")
+        self.assertTrue(_FakeSyncMemindClient.instances[0].closed)
+
+    async def test_missing_official_client_import_propagates_to_hook_fail_open_boundary(self):
+        with mock.patch.dict(sys.modules, {"memind": None}):
+            MemindClient = _load_client_class()
+            client = MemindClient("http://127.0.0.1:8366", timeout=10, max_retries=0)
+            with self.assertRaises(ModuleNotFoundError):
+                await client.extract("u", "a", {"type": "conversation", "messages": []}, "codex")
 
 
 if __name__ == "__main__":

--- a/memind-integrations/codex/tests/test_hooks.py
+++ b/memind-integrations/codex/tests/test_hooks.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -99,13 +100,15 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=Path(tmp) / "retry"):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.return_value = {"data": {"status": "SUCCESS"}}
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="SUCCESS"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(config, {"session_id": "s1", "transcript_path": str(transcript), "cwd": tmp})
             self.assertEqual(result["submitted"], 1)
             self.assertFalse(result["committed"])
-            client.extract.assert_called_once()
-            client.add_message.assert_not_called()
-            client.commit.assert_not_called()
+            client.extract.assert_awaited_once()
+            client.add_message.assert_not_awaited()
+            client.commit.assert_not_awaited()
         finally:
             transcript.unlink()
 
@@ -138,7 +141,9 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=Path(tmp) / "retry"):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.side_effect = RuntimeError("down")
+                            client.extract = mock.AsyncMock(side_effect=RuntimeError("down"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(config, {"session_id": "s1", "transcript_path": str(transcript), "cwd": tmp})
                 messages = extract_messages(transcript, ["user", "assistant"])
                 with SessionStateStore(Path(tmp) / "state").locked("s1") as state:
@@ -146,9 +151,9 @@ class HookTest(unittest.TestCase):
                     self.assertFalse(state.is_submitted(messages[1]["fingerprint"]))
             self.assertEqual(result["submitted"], 0)
             self.assertFalse(result["committed"])
-            client.extract.assert_called_once()
-            client.add_message.assert_not_called()
-            client.commit.assert_not_called()
+            client.extract.assert_awaited_once()
+            client.add_message.assert_not_awaited()
+            client.commit.assert_not_awaited()
         finally:
             transcript.unlink()
 
@@ -180,7 +185,9 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=retry_dir):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.side_effect = RuntimeError("down")
+                            client.extract = mock.AsyncMock(side_effect=RuntimeError("down"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(config, {"session_id": "s1", "transcript_path": str(transcript), "cwd": tmp})
                 payload_files = list(retry_dir.glob("*.json"))
                 self.assertEqual(len(payload_files), 1)
@@ -192,9 +199,9 @@ class HookTest(unittest.TestCase):
             self.assertEqual(len(payload["rawContent"]["messages"]), 2)
             self.assertEqual(len(payload["fingerprints"]), 2)
             self.assertNotIn("commitOnSuccess", payload)
-            client.extract.assert_called_once()
-            client.add_message.assert_not_called()
-            client.commit.assert_not_called()
+            client.extract.assert_awaited_once()
+            client.add_message.assert_not_awaited()
+            client.commit.assert_not_awaited()
         finally:
             transcript.unlink()
 
@@ -225,7 +232,9 @@ class HookTest(unittest.TestCase):
                     with mock.patch.object(ingest, "retry_root", return_value=retry_dir):
                         with mock.patch.object(ingest, "MemindClient") as client_cls:
                             client = client_cls.return_value
-                            client.extract.return_value = {"data": {"status": "PARTIAL_SUCCESS"}}
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="PARTIAL_SUCCESS"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
                             result = ingest.ingest_messages(config, {"session_id": "s1", "transcript_path": str(transcript), "cwd": tmp})
                 payload = json.loads(next(retry_dir.glob("*.json")).read_text())
             self.assertEqual(result["submitted"], 0)
@@ -285,9 +294,19 @@ class HookTest(unittest.TestCase):
                 with mock.patch.object(session_start, "state_root", return_value=state_root):
                     with mock.patch.object(session_start, "MemindClient") as client_cls:
                         client = client_cls.return_value
+                        events = []
+
+                        async def add_message_side_effect(*args, **kwargs):
+                            events.append("add_message")
+
+                        async def commit_side_effect(*args, **kwargs):
+                            events.append("commit")
+
+                        client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                        client.add_message = mock.AsyncMock(side_effect=add_message_side_effect)
+                        client.commit = mock.AsyncMock(side_effect=commit_side_effect)
                         session_start.run_session_start(config)
-        method_names = [call[0] for call in client.method_calls]
-        self.assertLess(method_names.index("add_message"), method_names.index("commit"))
+        self.assertEqual(events, ["add_message", "commit"])
 
     def test_session_start_replays_extract_payload_and_marks_fingerprints(self):
         sys.path.insert(0, str(ROOT / "scripts"))
@@ -326,15 +345,17 @@ class HookTest(unittest.TestCase):
                 with mock.patch.object(session_start, "state_root", return_value=state_root):
                     with mock.patch.object(session_start, "MemindClient") as client_cls:
                         client = client_cls.return_value
-                        client.health.return_value = {"data": {"status": "UP"}}
-                        client.extract.return_value = {"data": {"status": "SUCCESS"}}
+                        client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                        client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="SUCCESS"))
+                        client.add_message = mock.AsyncMock(return_value=None)
+                        client.commit = mock.AsyncMock(return_value=None)
                         session_start.run_session_start(config)
             with SessionStateStore(state_root).locked("s1") as state:
                 self.assertTrue(state.is_submitted("fp1"))
             self.assertEqual(list(retry_root.glob("*.json")), [])
-            client.extract.assert_called_once()
-            client.add_message.assert_not_called()
-            client.commit.assert_not_called()
+            client.extract.assert_awaited_once()
+            client.add_message.assert_not_awaited()
+            client.commit.assert_not_awaited()
 
     def test_session_start_keeps_extract_payload_when_replay_is_not_success(self):
         sys.path.insert(0, str(ROOT / "scripts"))
@@ -373,13 +394,15 @@ class HookTest(unittest.TestCase):
                 with mock.patch.object(session_start, "state_root", return_value=state_root):
                     with mock.patch.object(session_start, "MemindClient") as client_cls:
                         client = client_cls.return_value
-                        client.health.return_value = {"data": {"status": "UP"}}
-                        client.extract.return_value = {"data": {"status": "PARTIAL_SUCCESS"}}
+                        client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                        client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="PARTIAL_SUCCESS"))
+                        client.add_message = mock.AsyncMock(return_value=None)
+                        client.commit = mock.AsyncMock(return_value=None)
                         session_start.run_session_start(config)
             with SessionStateStore(state_root).locked("s1") as state:
                 self.assertFalse(state.is_submitted("fp1"))
             self.assertEqual(len(list(retry_root.glob("*.json"))), 1)
-            client.extract.assert_called_once()
+            client.extract.assert_awaited_once()
 
     def test_session_start_skips_replayed_message_already_submitted_by_later_stop(self):
         sys.path.insert(0, str(ROOT / "scripts"))
@@ -423,8 +446,12 @@ class HookTest(unittest.TestCase):
                 with mock.patch.object(session_start, "state_root", return_value=state_root):
                     with mock.patch.object(session_start, "MemindClient") as client_cls:
                         client = client_cls.return_value
+                        client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                        client.add_message = mock.AsyncMock(return_value=None)
+                        client.commit = mock.AsyncMock(return_value=None)
                         session_start.run_session_start(config)
-        client.add_message.assert_not_called()
+        client.add_message.assert_not_awaited()
+        client.commit.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/memind-integrations/codex/tests/test_installer.py
+++ b/memind-integrations/codex/tests/test_installer.py
@@ -1,5 +1,7 @@
 import json
+import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,6 +9,55 @@ from pathlib import Path
 from scripts.install_codex_hooks import install_hooks, uninstall_hooks
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _repo_root():
+    return ROOT.parents[1]
+
+
+def _installer_env(extra_pythonpath=None, python_bin_dir=None):
+    env = dict(os.environ)
+    paths = []
+    if extra_pythonpath:
+        paths.append(str(extra_pythonpath))
+    paths.append(str(_repo_root() / "memind-clients" / "python" / "src"))
+    existing = env.get("PYTHONPATH")
+    if existing:
+        paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    python_dir = str(python_bin_dir or Path(sys.executable).resolve().parent)
+    env["PATH"] = f"{python_dir}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+def _write_python3_shim(root):
+    python_bin = Path(root) / "python-bin"
+    python_bin.mkdir()
+    fake_python = python_bin / "python3"
+    fake_python.write_text(f"#!/usr/bin/env sh\nexec {sys.executable!r} \"$@\"\n")
+    fake_python.chmod(0o755)
+    return python_bin
+
+
+def _write_memind_package(root, names):
+    fake_package_root = Path(root) / "fake-python"
+    fake_memind = fake_package_root / "memind"
+    fake_memind.mkdir(parents=True)
+    fake_memind.joinpath("__init__.py").write_text("\n".join(f"{name} = object" for name in names) + "\n")
+    return fake_package_root
+
+
+def _valid_memind_package(root):
+    return _write_memind_package(
+        root,
+        [
+            "AsyncMemindClient",
+            "MemindClient",
+            "ConversationContent",
+            "Message",
+            "Strategy",
+        ],
+    )
 
 
 class InstallerTest(unittest.TestCase):
@@ -70,6 +121,8 @@ class InstallerTest(unittest.TestCase):
 
     def test_shell_installer_installs_to_overridden_paths_without_home_writes(self):
         with tempfile.TemporaryDirectory() as tmp:
+            python_bin = _write_python3_shim(tmp)
+            fake_package_root = _valid_memind_package(tmp)
             install_root = Path(tmp) / "memind" / "codex"
             hooks_path = Path(tmp) / "codex" / "hooks.json"
             config_path = Path(tmp) / "codex" / "config.toml"
@@ -88,6 +141,7 @@ class InstallerTest(unittest.TestCase):
                 ],
                 capture_output=True,
                 check=True,
+                env=_installer_env(fake_package_root, python_bin_dir=python_bin),
                 text=True,
                 timeout=10,
             )
@@ -101,6 +155,8 @@ class InstallerTest(unittest.TestCase):
 
     def test_shell_installer_reinstall_and_uninstall_are_owned_entry_safe(self):
         with tempfile.TemporaryDirectory() as tmp:
+            python_bin = _write_python3_shim(tmp)
+            fake_package_root = _valid_memind_package(tmp)
             install_root = Path(tmp) / "memind" / "codex"
             hooks_path = Path(tmp) / "codex" / "hooks.json"
             config_path = Path(tmp) / "codex" / "config.toml"
@@ -116,12 +172,12 @@ class InstallerTest(unittest.TestCase):
                 "--config-path",
                 str(config_path),
             ]
-            subprocess.run(base_command, check=True, capture_output=True, text=True, timeout=10)
+            subprocess.run(base_command, check=True, capture_output=True, text=True, timeout=10, env=_installer_env(fake_package_root, python_bin_dir=python_bin))
             hooks = json.loads(hooks_path.read_text())
             hooks["hooks"].setdefault("Stop", []).append({"hooks": [{"type": "command", "command": "echo keep"}]})
             hooks_path.write_text(json.dumps(hooks))
 
-            subprocess.run(base_command, check=True, capture_output=True, text=True, timeout=10)
+            subprocess.run(base_command, check=True, capture_output=True, text=True, timeout=10, env=_installer_env(fake_package_root, python_bin_dir=python_bin))
             reinstalled = json.loads(hooks_path.read_text())["hooks"]
             stop_commands = [hook["command"] for group in reinstalled["Stop"] for hook in group["hooks"]]
             memind_stop_commands = [command for command in stop_commands if "ingest.py" in command]
@@ -142,6 +198,7 @@ class InstallerTest(unittest.TestCase):
                 ],
                 check=True,
                 capture_output=True,
+                env=_installer_env(fake_package_root, python_bin_dir=python_bin),
                 text=True,
                 timeout=10,
             )
@@ -177,6 +234,74 @@ class InstallerTest(unittest.TestCase):
             self.assertFalse(install_root.exists())
             self.assertFalse(hooks_path.exists())
             self.assertFalse(config_path.exists())
+
+    def test_shell_installer_fails_when_python_is_too_old(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_bin = Path(tmp) / "bin"
+            fake_bin.mkdir()
+            fake_python = fake_bin / "python3"
+            fake_python.write_text(
+                "#!/usr/bin/env sh\n"
+                "echo 'error: Python 3.10+ is required for Memind Codex hooks' >&2\n"
+                "exit 1\n"
+            )
+            fake_python.chmod(0o755)
+            install_root = Path(tmp) / "memind" / "codex"
+            hooks_path = Path(tmp) / "codex" / "hooks.json"
+            config_path = Path(tmp) / "codex" / "config.toml"
+            env = _installer_env()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "install.sh"),
+                    "--source-root",
+                    str(ROOT),
+                    "--install-root",
+                    str(install_root),
+                    "--hooks-path",
+                    str(hooks_path),
+                    "--config-path",
+                    str(config_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Python 3.10+", result.stderr)
+        self.assertFalse(hooks_path.exists())
+
+    def test_shell_installer_fails_when_memind_package_lacks_required_api(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            python_bin = _write_python3_shim(tmp)
+            fake_package_root = _write_memind_package(tmp, ["MemindClient"])
+            install_root = Path(tmp) / "memind" / "codex"
+            hooks_path = Path(tmp) / "codex" / "hooks.json"
+            config_path = Path(tmp) / "codex" / "config.toml"
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "install.sh"),
+                    "--source-root",
+                    str(ROOT),
+                    "--install-root",
+                    str(install_root),
+                    "--hooks-path",
+                    str(hooks_path),
+                    "--config-path",
+                    str(config_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=_installer_env(fake_package_root, python_bin_dir=python_bin),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Memind Python client", result.stderr)
+        self.assertIn("AsyncMemindClient", result.stderr)
+        self.assertFalse(hooks_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace hand-rolled Memind HTTP API calls in the Claude Code and Codex integrations with adapters around the official Python client.
- Keep memory retrieval synchronous so retrieved memories can still be injected into context, while using the Python client async APIs for extraction, replay, and message ingestion paths.
- Update integration documentation, installer validation, and tests to align with the Python client dependency and supported Python version.

## Test Plan
- `PATH=/opt/homebrew/bin:$PATH PYTHONPATH=memind-integrations/claude-code:memind-clients/python/src /opt/homebrew/bin/python3.12 -m unittest discover -s memind-integrations/claude-code/tests -v`
- `PATH=/opt/homebrew/bin:$PATH PYTHONPATH=memind-integrations/codex:memind-clients/python/src /opt/homebrew/bin/python3.12 -m unittest discover -s memind-integrations/codex/tests -v`