### PR TITLE
Add HTTP MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,39 @@ After the images are built and the containers start:
 - Server health check: `http://localhost:8366/open/v1/health`
 - Open API base path: `http://localhost:8366/open/v1`
 - Admin API base path: `http://localhost:8366/admin/v1`
+- HTTP MCP endpoint: `http://localhost:8366/mcp`
 
 The UI container proxies `/open/*` and `/admin/*` to `memind-server`, so the browser can use
 the UI as a same-origin local admin console.
+
+### HTTP MCP server
+
+`memind-server` includes a stateless HTTP MCP server at `/mcp`, enabled by default. It exposes
+Memind memory tools for MCP-compatible agents and uses the same runtime, database, configuration,
+and logs as the REST APIs.
+
+Claude Code can connect to the local server with:
+
+```bash
+claude mcp add --transport http memind http://localhost:8366/mcp
+```
+
+Available MCP tools:
+
+- `memind_retrieve`: retrieve memory for a `userId` and `agentId` with a natural-language `query`;
+  `strategy` can be `SIMPLE` or `DEEP`, and defaults to `SIMPLE`.
+- `memind_extract_text`: immediately extract memory from standalone text, such as pasted notes,
+  document excerpts, or summaries.
+- `memind_add_message`: add one `user` or `assistant` conversation message to Memind's pending
+  conversation buffer.
+- `memind_commit`: commit pending conversation messages for the same `userId` and `agentId`.
+
+Use `memind_extract_text` for one-off text memory. Use `memind_add_message` followed by
+`memind_commit` for conversation-style memory. To disable the MCP endpoint, set
+`MEMIND_MCP_ENABLED=false` before starting `memind-server`.
+
+Do not expose `/mcp` directly to public networks without an authentication gateway or equivalent
+network controls. MCP tools can read and write scoped memory.
 
 ### Common commands
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -174,9 +174,34 @@ docker compose up -d --build
 - 服务健康检查：`http://localhost:8366/open/v1/health`
 - Open API 基础路径：`http://localhost:8366/open/v1`
 - Admin API 基础路径：`http://localhost:8366/admin/v1`
+- HTTP MCP 端点：`http://localhost:8366/mcp`
 
 UI 容器会把 `/open/*` 和 `/admin/*` 代理到 `memind-server`，因此浏览器可以把 UI
 当作同源的本地管理控制台使用。
+
+### HTTP MCP Server
+
+`memind-server` 内置了一个无状态 HTTP MCP server，默认路径为 `/mcp`，默认启用。它会把
+Memind 记忆能力暴露给兼容 MCP 的 Agent，并复用同一套运行时、数据库、配置和日志。
+
+Claude Code 可以这样连接本地服务：
+
+```bash
+claude mcp add --transport http memind http://localhost:8366/mcp
+```
+
+当前暴露的 MCP tools：
+
+- `memind_retrieve`：按 `userId`、`agentId` 和自然语言 `query` 检索记忆；`strategy`
+  可选 `SIMPLE` 或 `DEEP`，默认是 `SIMPLE`。
+- `memind_extract_text`：立即从一段独立文本中提取记忆，适合用户粘贴的笔记、文档片段或总结。
+- `memind_add_message`：向 Memind 的待提交对话缓冲区添加一条 `user` 或 `assistant` 消息。
+- `memind_commit`：提交同一个 `userId` 和 `agentId` 下的待处理对话消息。
+
+`memind_extract_text` 适合一次性的文本记忆；`memind_add_message` 加 `memind_commit` 适合对话流式记忆。
+如果要关闭 MCP 端点，在启动 `memind-server` 前设置 `MEMIND_MCP_ENABLED=false`。
+
+不要在没有鉴权网关或等价网络控制的情况下把 `/mcp` 直接暴露到公网。MCP tools 可以读写对应作用域下的记忆。
 
 ### 常用命令
 

--- a/memind-server/pom.xml
+++ b/memind-server/pom.xml
@@ -78,6 +78,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.xerial</groupId>

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandler.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandler.java
@@ -38,6 +38,8 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
@@ -111,9 +113,13 @@ public class ApiExceptionHandler {
                 exception);
     }
 
-    @ExceptionHandler(NoSuchElementException.class)
+    @ExceptionHandler({
+        NoSuchElementException.class,
+        NoHandlerFoundException.class,
+        NoResourceFoundException.class
+    })
     public ResponseEntity<ErrorResult<Void>> handleNotFound(
-            NoSuchElementException exception, HttpServletRequest request) {
+            Exception exception, HttpServletRequest request) {
         return response(
                 HttpStatus.NOT_FOUND,
                 ApiErrorCode.NOT_FOUND,

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import java.util.List;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBean(MemindMcpToolService.class)
+@ConditionalOnProperty(prefix = "spring.ai.mcp.server", name = "enabled", havingValue = "true")
+@ConditionalOnProperty(
+        prefix = "spring.ai.mcp.server",
+        name = "type",
+        havingValue = "SYNC",
+        matchIfMissing = true)
+@ConditionalOnProperty(
+        prefix = "spring.ai.mcp.server",
+        name = "protocol",
+        havingValue = "STATELESS")
+class MemindMcpToolConfiguration {
+
+    @Bean
+    List<McpStatelessServerFeatures.SyncToolSpecification> memindMcpToolSpecifications(
+            MemindMcpToolService toolService) {
+        return SyncMcpAnnotationProviders.statelessToolSpecifications(List.of(toolService));
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolService.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import com.openmemind.ai.memory.server.domain.memory.response.AddMessageResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.ExtractMemoryResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.mcp.request.MemindAddMessageToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindCommitToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindExtractTextToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindRetrieveToolRequest;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryApplicationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemindMcpToolService {
+
+    private static final Logger log = LoggerFactory.getLogger(MemindMcpToolService.class);
+
+    private final OpenMemoryApplicationService memoryService;
+
+    public MemindMcpToolService(OpenMemoryApplicationService memoryService) {
+        this.memoryService = memoryService;
+    }
+
+    @McpTool(
+            name = "memind_retrieve",
+            title = "Retrieve Memind memory",
+            description =
+                    "Retrieve memory for a userId and agentId using a natural-language query. "
+                            + "Use strategy SIMPLE for low-latency retrieval or DEEP for "
+                            + "LLM-assisted retrieval.")
+    public RetrieveMemoryResponse retrieve(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Natural-language retrieval query.") String query,
+            @McpToolParam(
+                            required = false,
+                            description = "Retrieval strategy: SIMPLE or DEEP. Defaults to SIMPLE.")
+                    String strategy,
+            @McpToolParam(
+                            required = false,
+                            description = "Whether to include retrieval trace when supported.")
+                    Boolean trace) {
+        var request = new MemindRetrieveToolRequest(userId, agentId, query, strategy, trace);
+        log.debug(
+                "MCP tool memind_retrieve invoked for userId={} agentId={}",
+                request.userId(),
+                request.agentId());
+        return memoryService.retrieve(request.toApplicationRequest());
+    }
+
+    @McpTool(
+            name = "memind_extract_text",
+            title = "Extract standalone text into Memind memory",
+            description =
+                    "Extract memory immediately from one standalone text payload, such as pasted "
+                            + "notes, document excerpts, or summaries. For ongoing chat turns, "
+                            + "use memind_add_message and memind_commit instead.")
+    public ExtractMemoryResponse extractText(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Standalone text to extract into memory.") String text,
+            @McpToolParam(
+                            required = false,
+                            description =
+                                    "Source marker stored with the extraction request. Defaults "
+                                            + "to mcp.")
+                    String sourceClient) {
+        var request = new MemindExtractTextToolRequest(userId, agentId, text, sourceClient);
+        log.debug(
+                "MCP tool memind_extract_text invoked for userId={} agentId={}",
+                request.userId(),
+                request.agentId());
+        return memoryService.extract(request.toApplicationRequest());
+    }
+
+    @McpTool(
+            name = "memind_add_message",
+            title = "Add a conversation message to Memind memory",
+            description =
+                    "Add one user or assistant conversation message to Memind's buffered "
+                            + "conversation flow. Use this for conversation-style memory, then "
+                            + "call memind_commit to flush pending messages.")
+    public AddMessageResponse addMessage(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Message role: user or assistant.") String role,
+            @McpToolParam(description = "Plain text message body.") String content,
+            @McpToolParam(
+                            required = false,
+                            description = "Source marker attached to the message. Defaults to mcp.")
+                    String sourceClient) {
+        var request = new MemindAddMessageToolRequest(userId, agentId, role, content, sourceClient);
+        log.debug(
+                "MCP tool memind_add_message invoked for userId={} agentId={}",
+                request.userId(),
+                request.agentId());
+        return memoryService.addMessage(request.toApplicationRequest());
+    }
+
+    @McpTool(
+            name = "memind_commit",
+            title = "Commit pending Memind conversation memory",
+            description =
+                    "Flush pending conversation messages for a userId and agentId. Use this after "
+                            + "memind_add_message when conversation turns should be committed to "
+                            + "memory.")
+    public ExtractMemoryResponse commit(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(
+                            required = false,
+                            description =
+                                    "Source marker for the commit operation. Defaults to mcp.")
+                    String sourceClient) {
+        var request = new MemindCommitToolRequest(userId, agentId, sourceClient);
+        log.debug(
+                "MCP tool memind_commit invoked for userId={} agentId={}",
+                request.userId(),
+                request.agentId());
+        return memoryService.commit(request.toApplicationRequest());
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindAddMessageToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindAddMessageToolRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
+import com.openmemind.ai.memory.server.domain.memory.request.AddMessageRequest;
+
+public record MemindAddMessageToolRequest(
+        String userId, String agentId, String role, String content, String sourceClient) {
+
+    public AddMessageRequest toApplicationRequest() {
+        String normalizedSourceClient = normalizeSourceClient(sourceClient);
+        Message message =
+                messageFor(role, requireText(content, "content"))
+                        .withSourceClient(normalizedSourceClient);
+        return new AddMessageRequest(
+                requireText(userId, "userId"),
+                requireText(agentId, "agentId"),
+                message,
+                normalizedSourceClient);
+    }
+
+    private static Message messageFor(String role, String content) {
+        if (role == null || role.isBlank()) {
+            throw new IllegalArgumentException("role must be one of user, assistant");
+        }
+        return switch (role.trim().toLowerCase()) {
+            case "user" -> Message.user(content);
+            case "assistant" -> Message.assistant(content);
+            default -> throw new IllegalArgumentException("role must be one of user, assistant");
+        };
+    }
+
+    private static String normalizeSourceClient(String value) {
+        if (value == null || value.isBlank()) {
+            return "mcp";
+        }
+        return value.trim();
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindCommitToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindCommitToolRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.domain.memory.request.CommitMemoryRequest;
+
+public record MemindCommitToolRequest(String userId, String agentId, String sourceClient) {
+
+    public CommitMemoryRequest toApplicationRequest() {
+        return new CommitMemoryRequest(
+                requireText(userId, "userId"),
+                requireText(agentId, "agentId"),
+                normalizeSourceClient(sourceClient));
+    }
+
+    private static String normalizeSourceClient(String value) {
+        if (value == null || value.isBlank()) {
+            return "mcp";
+        }
+        return value.trim();
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindExtractTextToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindExtractTextToolRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.core.extraction.rawdata.content.ConversationContent;
+import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
+import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
+import java.util.List;
+
+public record MemindExtractTextToolRequest(
+        String userId, String agentId, String text, String sourceClient) {
+
+    public ExtractMemoryRequest toApplicationRequest() {
+        return new ExtractMemoryRequest(
+                requireText(userId, "userId"),
+                requireText(agentId, "agentId"),
+                new ConversationContent(List.of(Message.user(requireText(text, "text")))),
+                normalizeSourceClient(sourceClient));
+    }
+
+    private static String normalizeSourceClient(String value) {
+        if (value == null || value.isBlank()) {
+            return "mcp";
+        }
+        return value.trim();
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindRetrieveToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindRetrieveToolRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.server.domain.memory.request.RetrieveMemoryRequest;
+
+public record MemindRetrieveToolRequest(
+        String userId, String agentId, String query, String strategy, Boolean trace) {
+
+    public RetrieveMemoryRequest toApplicationRequest() {
+        return new RetrieveMemoryRequest(
+                requireText(userId, "userId"),
+                requireText(agentId, "agentId"),
+                requireText(query, "query"),
+                parseStrategy(strategy),
+                trace);
+    }
+
+    private static RetrievalConfig.Strategy parseStrategy(String value) {
+        if (value == null || value.isBlank()) {
+            return RetrievalConfig.Strategy.SIMPLE;
+        }
+        try {
+            return RetrievalConfig.Strategy.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("strategy must be one of SIMPLE, DEEP", exception);
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/memind-server/src/main/resources/application.yml
+++ b/memind-server/src/main/resources/application.yml
@@ -38,6 +38,23 @@ spring:
     # Switch this to qdrant in the commented example below when enabling Qdrant.
     vectorstore:
       type: simple
+    mcp:
+      server:
+        enabled: ${MEMIND_MCP_ENABLED:true}
+        name: memind-mcp-server
+        version: ${MEMIND_MCP_SERVER_VERSION:0.2.0-SNAPSHOT}
+        type: SYNC
+        protocol: STATELESS
+        request-timeout: ${MEMIND_MCP_REQUEST_TIMEOUT:30s}
+        instructions: "Memind memory tools for AI agents."
+        tool-callback-converter: false
+        annotation-scanner:
+          enabled: true
+        capabilities:
+          tool: true
+          resource: false
+          prompt: false
+          completion: false
     openai:
       base-url: ${OPENAI_BASE_URL:https://openrouter.ai/api}
       api-key: ${OPENAI_API_KEY:}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandlerTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandlerTest.java
@@ -130,6 +130,15 @@ class ApiExceptionHandlerTest {
     }
 
     @Test
+    void missingMvcResourcesReturnNotFoundError() throws Exception {
+        mockMvc.perform(post("/missing-resource").contentType(APPLICATION_JSON).content("{}"))
+                .andExpect(status().isNotFound())
+                .andExpect(header().exists("X-Request-Id"))
+                .andExpect(jsonPath("$.error.code").value("not_found"))
+                .andExpect(jsonPath("$.traceId").doesNotExist());
+    }
+
+    @Test
     void internalErrorsReturnInternalErrorEnvelope(CapturedOutput output) throws Exception {
         mockMvc.perform(get("/boom/internal").header("X-Request-Id", "rid-2"))
                 .andExpect(status().isInternalServerError())

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.server.MemindServerApplication;
+import com.openmemind.ai.memory.server.support.NoopRuntimeTestConfiguration;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+class MemindMcpApplicationTest {
+
+    @Nested
+    @SpringBootTest(classes = {MemindServerApplication.class, NoopRuntimeTestConfiguration.class})
+    class Enabled {
+
+        private static final Path DB_PATH =
+                Path.of("target", "memind-mcp-enabled-" + UUID.randomUUID() + ".db")
+                        .toAbsolutePath();
+
+        @Autowired private ApplicationContext applicationContext;
+
+        @Autowired
+        private ObjectProvider<List<McpStatelessServerFeatures.SyncToolSpecification>>
+                syncToolSpecifications;
+
+        @DynamicPropertySource
+        static void registerProperties(DynamicPropertyRegistry registry) {
+            prepareDatabasePath(DB_PATH);
+            registry.add("spring.main.web-application-type", () -> "servlet");
+            registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + DB_PATH);
+            registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+            registry.add("memind.store.init-schema", () -> "true");
+            registry.add("spring.ai.mcp.server.enabled", () -> "true");
+            registry.add(
+                    "spring.autoconfigure.exclude",
+                    () -> NoopRuntimeTestConfiguration.SPRING_AI_AUTOCONFIG_EXCLUDES);
+        }
+
+        @Test
+        void contextRegistersOnlyMemindMcpTools() {
+            assertThat(applicationContext.getBeanNamesForType(MemindMcpToolService.class))
+                    .hasSize(1);
+            assertThat(applicationContext.getBeanNamesForType(McpStatelessSyncServer.class))
+                    .hasSize(1);
+
+            assertThat(toolNames())
+                    .containsExactly(
+                            "memind_add_message",
+                            "memind_commit",
+                            "memind_extract_text",
+                            "memind_retrieve");
+        }
+
+        @Test
+        void toolsExposeFlatInputSchemas() {
+            Map<String, List<String>> requiredFieldsByTool =
+                    Map.of(
+                            "memind_retrieve", List.of("userId", "agentId", "query"),
+                            "memind_extract_text", List.of("userId", "agentId", "text"),
+                            "memind_add_message", List.of("userId", "agentId", "role", "content"),
+                            "memind_commit", List.of("userId", "agentId"));
+            Map<String, List<String>> optionalFieldsByTool =
+                    Map.of(
+                            "memind_retrieve", List.of("strategy", "trace"),
+                            "memind_extract_text", List.of("sourceClient"),
+                            "memind_add_message", List.of("sourceClient"),
+                            "memind_commit", List.of("sourceClient"));
+
+            toolSpecifications()
+                    .forEach(
+                            spec -> {
+                                var inputSchema = spec.tool().inputSchema();
+                                var toolName = spec.tool().name();
+
+                                assertThat(requiredFieldsByTool).containsKey(toolName);
+                                var expectedRequiredFields = requiredFieldsByTool.get(toolName);
+                                var expectedOptionalFields = optionalFieldsByTool.get(toolName);
+
+                                assertThat(inputSchema.properties())
+                                        .containsKeys(
+                                                expectedRequiredFields.toArray(String[]::new));
+                                assertThat(inputSchema.properties())
+                                        .containsKeys(
+                                                expectedOptionalFields.toArray(String[]::new));
+                                assertThat(inputSchema.properties()).doesNotContainKey("request");
+                                assertThat(inputSchema.required())
+                                        .containsExactlyInAnyOrderElementsOf(
+                                                expectedRequiredFields);
+                                assertThat(inputSchema.required())
+                                        .doesNotContainAnyElementsOf(expectedOptionalFields);
+                            });
+        }
+
+        private List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications() {
+            return syncToolSpecifications.stream().flatMap(List::stream).toList();
+        }
+
+        private List<String> toolNames() {
+            return toolSpecifications().stream().map(spec -> spec.tool().name()).sorted().toList();
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = {MemindServerApplication.class, NoopRuntimeTestConfiguration.class})
+    class Disabled {
+
+        private static final Path DB_PATH =
+                Path.of("target", "memind-mcp-disabled-" + UUID.randomUUID() + ".db")
+                        .toAbsolutePath();
+
+        @Autowired private ApplicationContext applicationContext;
+
+        @Autowired
+        private ObjectProvider<List<McpStatelessServerFeatures.SyncToolSpecification>>
+                syncToolSpecifications;
+
+        @DynamicPropertySource
+        static void registerProperties(DynamicPropertyRegistry registry) {
+            prepareDatabasePath(DB_PATH);
+            registry.add("spring.main.web-application-type", () -> "servlet");
+            registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + DB_PATH);
+            registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+            registry.add("memind.store.init-schema", () -> "true");
+            registry.add("spring.ai.mcp.server.enabled", () -> "false");
+            registry.add(
+                    "spring.autoconfigure.exclude",
+                    () -> NoopRuntimeTestConfiguration.SPRING_AI_AUTOCONFIG_EXCLUDES);
+        }
+
+        @Test
+        void disabledConfigurationDoesNotPublishMcpServerOrToolSpecifications() {
+            assertThat(applicationContext.getBeanNamesForType(MemindMcpToolService.class))
+                    .hasSize(1);
+            assertThat(applicationContext.getBeanProvider(McpStatelessSyncServer.class).stream())
+                    .isEmpty();
+            assertThat(syncToolSpecifications.stream()).isEmpty();
+        }
+    }
+
+    private static void prepareDatabasePath(Path dbPath) {
+        try {
+            Files.createDirectories(dbPath.getParent());
+            Files.deleteIfExists(dbPath);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to prepare test database path", exception);
+        }
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
@@ -14,6 +14,12 @@
 package com.openmemind.ai.memory.server.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.openmemind.ai.memory.server.MemindServerApplication;
 import com.openmemind.ai.memory.server.support.NoopRuntimeTestConfiguration;
@@ -33,6 +39,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 class MemindMcpApplicationTest {
 
@@ -45,6 +54,7 @@ class MemindMcpApplicationTest {
                         .toAbsolutePath();
 
         @Autowired private ApplicationContext applicationContext;
+        @Autowired private WebApplicationContext webApplicationContext;
 
         @Autowired
         private ObjectProvider<List<McpStatelessServerFeatures.SyncToolSpecification>>
@@ -118,6 +128,38 @@ class MemindMcpApplicationTest {
                             });
         }
 
+        @Test
+        void mcpEndpointListsToolsWhenEnabled() throws Exception {
+            mcpClient()
+                    .perform(
+                            post("/mcp")
+                                    .contentType(APPLICATION_JSON)
+                                    .accept(APPLICATION_JSON, TEXT_EVENT_STREAM)
+                                    .content(
+                                            """
+                                            {
+                                              "jsonrpc": "2.0",
+                                              "id": 1,
+                                              "method": "tools/list",
+                                              "params": {}
+                                            }
+                                            """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.error").doesNotExist())
+                    .andExpect(
+                            jsonPath("$.result.tools[*].name")
+                                    .value(
+                                            containsInAnyOrder(
+                                                    "memind_add_message",
+                                                    "memind_commit",
+                                                    "memind_extract_text",
+                                                    "memind_retrieve")));
+        }
+
+        private MockMvc mcpClient() {
+            return MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        }
+
         private List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications() {
             return syncToolSpecifications.stream().flatMap(List::stream).toList();
         }
@@ -136,6 +178,7 @@ class MemindMcpApplicationTest {
                         .toAbsolutePath();
 
         @Autowired private ApplicationContext applicationContext;
+        @Autowired private WebApplicationContext webApplicationContext;
 
         @Autowired
         private ObjectProvider<List<McpStatelessServerFeatures.SyncToolSpecification>>
@@ -161,6 +204,26 @@ class MemindMcpApplicationTest {
             assertThat(applicationContext.getBeanProvider(McpStatelessSyncServer.class).stream())
                     .isEmpty();
             assertThat(syncToolSpecifications.stream()).isEmpty();
+        }
+
+        @Test
+        void mcpEndpointIsUnavailableWhenDisabled() throws Exception {
+            MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                    .build()
+                    .perform(
+                            post("/mcp")
+                                    .contentType(APPLICATION_JSON)
+                                    .accept(APPLICATION_JSON, TEXT_EVENT_STREAM)
+                                    .content(
+                                            """
+                                            {
+                                              "jsonrpc": "2.0",
+                                              "id": 1,
+                                              "method": "tools/list",
+                                              "params": {}
+                                            }
+                                            """))
+                    .andExpect(status().is4xxClientError());
         }
     }
 

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolServiceTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.openmemind.ai.memory.core.extraction.rawdata.content.ConversationContent;
+import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.server.domain.memory.request.AddMessageRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.CommitMemoryRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.RetrieveMemoryRequest;
+import com.openmemind.ai.memory.server.domain.memory.response.AddMessageResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.ExtractMemoryResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryApplicationService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MemindMcpToolServiceTest {
+
+    private final RecordingOpenMemoryApplicationService applicationService =
+            new RecordingOpenMemoryApplicationService();
+    private final MemindMcpToolService toolService = new MemindMcpToolService(applicationService);
+
+    @Test
+    void retrieveDefaultsToSimpleStrategy() {
+        applicationService.retrieveResponse =
+                new RetrieveMemoryResponse(
+                        "success", List.of(), List.of(), List.of(), List.of(), "SIMPLE", "coffee");
+
+        var response = toolService.retrieve(" user-1 ", "agent-1", " coffee ", null, null);
+
+        assertThat(response.strategy()).isEqualTo("SIMPLE");
+        assertThat(applicationService.lastRetrieveRequest.userId()).isEqualTo("user-1");
+        assertThat(applicationService.lastRetrieveRequest.agentId()).isEqualTo("agent-1");
+        assertThat(applicationService.lastRetrieveRequest.query()).isEqualTo("coffee");
+        assertThat(applicationService.lastRetrieveRequest.strategy())
+                .isEqualTo(RetrievalConfig.Strategy.SIMPLE);
+    }
+
+    @Test
+    void retrievePassesDeepStrategyAndTrace() {
+        applicationService.retrieveResponse =
+                new RetrieveMemoryResponse(
+                        "success", List.of(), List.of(), List.of(), List.of(), "DEEP", "coffee");
+
+        toolService.retrieve("user-1", "agent-1", "coffee", "deep", true);
+
+        assertThat(applicationService.lastRetrieveRequest.strategy())
+                .isEqualTo(RetrievalConfig.Strategy.DEEP);
+        assertThat(applicationService.lastRetrieveRequest.trace()).isTrue();
+    }
+
+    @Test
+    void retrieveRejectsInvalidStrategy() {
+        assertThatThrownBy(() -> toolService.retrieve("user-1", "agent-1", "coffee", "wide", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("strategy must be one of SIMPLE, DEEP");
+    }
+
+    @Test
+    void extractTextCreatesConversationContentAndDefaultsSourceClient() {
+        applicationService.extractResponse =
+                new ExtractMemoryResponse(
+                        "SUCCESS", List.of("rd-1"), List.of(), List.of(), false, 1L, null);
+
+        var response = toolService.extractText("user-1", "agent-1", " remember this ", null);
+
+        assertThat(response.rawDataIds()).containsExactly("rd-1");
+        ExtractMemoryRequest request = applicationService.lastExtractRequest;
+        assertThat(request.sourceClient()).isEqualTo("mcp");
+        assertThat(request.rawContent()).isInstanceOf(ConversationContent.class);
+        var content = (ConversationContent) request.rawContent();
+        assertThat(content.getMessages())
+                .singleElement()
+                .satisfies(
+                        message -> {
+                            assertThat(message.role()).isEqualTo(Message.Role.USER);
+                            assertThat(message.textContent()).isEqualTo("remember this");
+                        });
+    }
+
+    @Test
+    void addMessageMapsUserRoleAndSourceClient() {
+        applicationService.addMessageResponse = new AddMessageResponse(false, null);
+
+        toolService.addMessage("user-1", "agent-1", "user", " hello ", null);
+
+        AddMessageRequest request = applicationService.lastAddMessageRequest;
+        assertThat(request.sourceClient()).isEqualTo("mcp");
+        assertThat(request.message().role()).isEqualTo(Message.Role.USER);
+        assertThat(request.message().textContent()).isEqualTo("hello");
+        assertThat(request.message().sourceClient()).isEqualTo("mcp");
+    }
+
+    @Test
+    void addMessageMapsAssistantRole() {
+        toolService.addMessage("user-1", "agent-1", "assistant", " response ", "claude-code");
+
+        AddMessageRequest request = applicationService.lastAddMessageRequest;
+        assertThat(request.sourceClient()).isEqualTo("claude-code");
+        assertThat(request.message().role()).isEqualTo(Message.Role.ASSISTANT);
+        assertThat(request.message().textContent()).isEqualTo("response");
+        assertThat(request.message().sourceClient()).isEqualTo("claude-code");
+    }
+
+    @Test
+    void addMessageRejectsSystemRole() {
+        assertThatThrownBy(
+                        () -> toolService.addMessage("user-1", "agent-1", "system", "policy", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("role must be one of user, assistant");
+    }
+
+    @Test
+    void commitDefaultsSourceClient() {
+        applicationService.commitResponse =
+                new ExtractMemoryResponse(
+                        "SUCCESS", List.of("rd-1"), List.of(), List.of(), false, 1L, null);
+
+        var response = toolService.commit("user-1", "agent-1", null);
+
+        assertThat(response.rawDataIds()).containsExactly("rd-1");
+        CommitMemoryRequest request = applicationService.lastCommitRequest;
+        assertThat(request.sourceClient()).isEqualTo("mcp");
+    }
+
+    @Test
+    void blankRequiredFieldsFailBeforeServiceInvocation() {
+        assertThatThrownBy(() -> toolService.commit(" ", "agent-1", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("userId must not be blank");
+
+        assertThat(applicationService.lastCommitRequest).isNull();
+    }
+
+    private static final class RecordingOpenMemoryApplicationService
+            extends OpenMemoryApplicationService {
+
+        private RetrieveMemoryRequest lastRetrieveRequest;
+        private ExtractMemoryRequest lastExtractRequest;
+        private AddMessageRequest lastAddMessageRequest;
+        private CommitMemoryRequest lastCommitRequest;
+        private RetrieveMemoryResponse retrieveResponse =
+                new RetrieveMemoryResponse(
+                        "success", List.of(), List.of(), List.of(), List.of(), "SIMPLE", "query");
+        private ExtractMemoryResponse extractResponse =
+                new ExtractMemoryResponse(
+                        "SUCCESS", List.of(), List.of(), List.of(), false, 1L, null);
+        private AddMessageResponse addMessageResponse = new AddMessageResponse(false, null);
+        private ExtractMemoryResponse commitResponse =
+                new ExtractMemoryResponse(
+                        "SUCCESS", List.of(), List.of(), List.of(), false, 1L, null);
+
+        private RecordingOpenMemoryApplicationService() {
+            super(null);
+        }
+
+        @Override
+        public RetrieveMemoryResponse retrieve(RetrieveMemoryRequest request) {
+            this.lastRetrieveRequest = request;
+            return retrieveResponse;
+        }
+
+        @Override
+        public ExtractMemoryResponse extract(ExtractMemoryRequest request) {
+            this.lastExtractRequest = request;
+            return extractResponse;
+        }
+
+        @Override
+        public AddMessageResponse addMessage(AddMessageRequest request) {
+            this.lastAddMessageRequest = request;
+            return addMessageResponse;
+        }
+
+        @Override
+        public ExtractMemoryResponse commit(CommitMemoryRequest request) {
+            this.lastCommitRequest = request;
+            return commitResponse;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an embedded stateless HTTP MCP server to memind-server at /mcp using Spring AI MCP WebMVC.
- Expose explicit Memind memory tools for retrieve, one-off text extraction, conversation message buffering, and commit, backed by OpenMemoryApplicationService.
- Add tests for tool mapping, tool registration, endpoint availability, disabled endpoint behavior, and document setup plus production exposure guidance.

## Test Plan
- [x] mvn -q -pl memind-server -am test