### PR TITLE
Update Codex hooks feature flag

### DIFF
--- a/memind-integrations/codex/README.md
+++ b/memind-integrations/codex/README.md
@@ -105,7 +105,7 @@ The installer writes only these locations by default:
 
 - `~/.memind/codex/`: installed hook scripts, default settings, plugin metadata, and this README.
 - `~/.codex/hooks.json`: Memind hook entries are merged into the existing hooks file.
-- `~/.codex/config.toml`: `[features] codex_hooks = true` is added only when it is missing.
+- `~/.codex/config.toml`: `[features] hooks = true` is added only when it is missing.
 
 The installer does **not** overwrite unrelated Codex hooks or settings. Re-running the installer is idempotent:
 old Memind-owned hook entries are removed before fresh entries are added.
@@ -272,7 +272,7 @@ curl -fsSL http://127.0.0.1:8366/open/v1/health
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 3. Confirm `~/.codex/hooks.json` contains Memind commands pointing to `~/.memind/codex/scripts/...`.
@@ -333,7 +333,7 @@ Uninstall removes only Memind hook entries from `~/.codex/hooks.json`. It preser
 - `~/.memind/codex.json`
 - `~/.memind/codex/state/`
 - `~/.memind/codex/retry/`
-- `[features] codex_hooks = true`
+- `[features] hooks = true`
 
 The feature flag is preserved because other Codex hooks may depend on it.
 
@@ -346,7 +346,7 @@ The feature flag is preserved because other Codex hooks may depend on it.
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 ```
 
 - Confirm `~/.codex/hooks.json` contains Memind entries pointing to `~/.memind/codex/scripts/...`.

--- a/memind-integrations/codex/install.sh
+++ b/memind-integrations/codex/install.sh
@@ -118,7 +118,7 @@ if [[ "${DRY_RUN}" == true ]]; then
   else
     echo "Would install Memind Codex files to: ${INSTALL_ROOT}"
     echo "Would merge Memind hook entries into: ${HOOKS_PATH}"
-    echo "Would ensure [features] codex_hooks = true in: ${CONFIG_PATH}"
+    echo "Would ensure [features] hooks = true in: ${CONFIG_PATH}"
   fi
   exit 0
 fi

--- a/memind-integrations/codex/scripts/install_codex_hooks.py
+++ b/memind-integrations/codex/scripts/install_codex_hooks.py
@@ -22,7 +22,9 @@ from pathlib import Path
 OWNER_MARKER = "memind-integrations/codex"
 OWNER_MARKERS = (OWNER_MARKER, "memind/codex")
 PLACEHOLDER = "${CODEX_PLUGIN_ROOT}"
-CODEX_HOOKS_RE = re.compile(r"^codex_hooks\s*=\s*true(?:\s*(?:#.*)?)?$")
+HOOKS_ENABLED_RE = re.compile(r"^hooks\s*=\s*true(?:\s*(?:#.*)?)?$")
+HOOKS_KEY_RE = re.compile(r"^hooks\s*=.*$")
+CODEX_HOOKS_KEY_RE = re.compile(r"^codex_hooks\s*=.*$")
 
 
 def _default_hooks_path():
@@ -110,12 +112,12 @@ def _load_template(plugin_root):
 
 def _feature_flag_message(config_path):
     config_path = Path(config_path)
-    if config_path.exists() and _codex_hooks_enabled(config_path.read_text()):
+    if config_path.exists() and _hooks_enabled(config_path.read_text()):
         return ""
-    return f"Reminder: enable Codex hooks by adding `[features]` with `codex_hooks = true` to {config_path}."
+    return f"Reminder: enable Codex hooks by adding `[features]` with `hooks = true` to {config_path}."
 
 
-def _codex_hooks_enabled(config_text):
+def _hooks_enabled(config_text):
     in_features = False
     for raw_line in config_text.splitlines():
         line = raw_line.strip()
@@ -124,29 +126,81 @@ def _codex_hooks_enabled(config_text):
         if line.startswith("[") and line.endswith("]"):
             in_features = line == "[features]"
             continue
-        if in_features and CODEX_HOOKS_RE.match(line):
+        if in_features and HOOKS_ENABLED_RE.match(line):
             return True
     return False
 
 
-def _enable_codex_hooks(config_path):
-    config_path = Path(config_path)
-    config_text = config_path.read_text() if config_path.exists() else ""
-    if _codex_hooks_enabled(config_text):
-        return False
+def _line_ending(raw_line):
+    if raw_line.endswith("\r\n"):
+        return "\r\n"
+    if raw_line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def _ensure_hooks_feature_enabled(config_text):
+    if not config_text:
+        return "[features]\nhooks = true\n", True
 
     lines = config_text.splitlines(keepends=True)
+    features_start = None
+    features_end = len(lines)
     for index, raw_line in enumerate(lines):
-        if raw_line.strip() == "[features]":
-            lines.insert(index + 1, "codex_hooks = true\n")
-            _write_text_atomic(config_path, "".join(lines))
-            return True
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            if line == "[features]" and features_start is None:
+                features_start = index
+            elif features_start is not None:
+                features_end = index
+                break
 
-    if not config_text:
-        _write_text_atomic(config_path, "[features]\ncodex_hooks = true\n")
-        return True
-    suffix = "" if config_text.endswith("\n") else "\n"
-    _write_text_atomic(config_path, f"{config_text}{suffix}\n[features]\ncodex_hooks = true\n")
+    if features_start is None:
+        suffix = "" if config_text.endswith("\n") else "\n"
+        return f"{config_text}{suffix}\n[features]\nhooks = true\n", True
+
+    changed = False
+    hooks_written = False
+    body = []
+    for raw_line in lines[features_start + 1 : features_end]:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            body.append(raw_line)
+            continue
+        if CODEX_HOOKS_KEY_RE.match(line):
+            changed = True
+            continue
+        if HOOKS_KEY_RE.match(line):
+            if hooks_written:
+                changed = True
+                continue
+            hooks_written = True
+            if HOOKS_ENABLED_RE.match(line):
+                body.append(raw_line)
+            else:
+                indent = raw_line[: len(raw_line) - len(raw_line.lstrip())]
+                body.append(f"{indent}hooks = true{_line_ending(raw_line)}")
+                changed = True
+            continue
+        body.append(raw_line)
+
+    if not hooks_written:
+        body.insert(0, "hooks = true\n")
+        changed = True
+
+    if not changed:
+        return config_text, False
+
+    return "".join(lines[: features_start + 1] + body + lines[features_end:]), True
+
+
+def _enable_hooks_feature(config_path):
+    config_path = Path(config_path)
+    config_text = config_path.read_text() if config_path.exists() else ""
+    updated, changed = _ensure_hooks_feature_enabled(config_text)
+    if not changed:
+        return False
+    _write_text_atomic(config_path, updated)
     return True
 
 
@@ -159,7 +213,7 @@ def install_hooks(plugin_root, hooks_path=None, codex_config_path=None, enable_f
         existing["hooks"].setdefault(event, []).extend(groups)
     _write_json_atomic(hooks_path, existing)
     message = f"Installed Memind Codex hooks into {hooks_path}."
-    if enable_feature_flag and _enable_codex_hooks(codex_config_path):
+    if enable_feature_flag and _enable_hooks_feature(codex_config_path):
         return f"{message}\nEnabled Codex hooks feature flag in {codex_config_path}."
     if not enable_feature_flag:
         reminder = _feature_flag_message(codex_config_path)

--- a/memind-integrations/codex/tests/test_installer.py
+++ b/memind-integrations/codex/tests/test_installer.py
@@ -109,7 +109,8 @@ class InstallerTest(unittest.TestCase):
             config_text = config_path.read_text()
         self.assertIn("Enabled Codex hooks feature flag", output)
         self.assertIn("[features]", config_text)
-        self.assertIn("codex_hooks = true", config_text)
+        self.assertIn("hooks = true", config_text)
+        self.assertNotIn("codex_hooks", config_text)
 
     def test_install_preserves_existing_config_when_enabling_feature_flag(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -120,18 +121,60 @@ class InstallerTest(unittest.TestCase):
             config_text = config_path.read_text()
         self.assertIn("Enabled Codex hooks feature flag", output)
         self.assertIn('model = "gpt-5.5"', config_text)
-        self.assertIn("[features]\ncodex_hooks = true\nfoo = true", config_text)
+        self.assertIn("[features]\nhooks = true\nfoo = true", config_text)
         self.assertIn('[projects."/tmp/example"]', config_text)
 
     def test_no_feature_flag_change_when_enabled_under_features(self):
         with tempfile.TemporaryDirectory() as tmp:
             hooks_path = Path(tmp) / "hooks.json"
             config_path = Path(tmp) / "config.toml"
-            config_path.write_text("[features]\n  codex_hooks   =   true\n")
+            config_path.write_text("[features]\n  hooks   =   true\n")
             output = install_hooks(ROOT, hooks_path, codex_config_path=config_path)
             config_text = config_path.read_text()
         self.assertNotIn("Enabled Codex hooks feature flag", output)
-        self.assertEqual(config_text, "[features]\n  codex_hooks   =   true\n")
+        self.assertEqual(config_text, "[features]\n  hooks   =   true\n")
+
+    def test_install_migrates_deprecated_feature_flag_under_features(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_path = Path(tmp) / "hooks.json"
+            config_path = Path(tmp) / "config.toml"
+            config_path.write_text("[features]\n  codex_hooks   =   true\nfoo = true\n")
+            output = install_hooks(ROOT, hooks_path, codex_config_path=config_path)
+            config_text = config_path.read_text()
+        self.assertIn("Enabled Codex hooks feature flag", output)
+        self.assertIn("hooks = true", config_text)
+        self.assertIn("foo = true", config_text)
+        self.assertNotIn("codex_hooks", config_text)
+
+    def test_install_removes_deprecated_feature_flag_when_hooks_already_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_path = Path(tmp) / "hooks.json"
+            config_path = Path(tmp) / "config.toml"
+            config_path.write_text("[features]\nhooks = true\ncodex_hooks = false\n")
+            output = install_hooks(ROOT, hooks_path, codex_config_path=config_path)
+            config_text = config_path.read_text()
+        self.assertIn("Enabled Codex hooks feature flag", output)
+        self.assertIn("[features]\nhooks = true\n", config_text)
+        self.assertNotIn("codex_hooks", config_text)
+
+    def test_install_enables_hooks_when_existing_value_is_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_path = Path(tmp) / "hooks.json"
+            config_path = Path(tmp) / "config.toml"
+            config_path.write_text("[features]\nhooks = false\n")
+            output = install_hooks(ROOT, hooks_path, codex_config_path=config_path)
+            config_text = config_path.read_text()
+        self.assertIn("Enabled Codex hooks feature flag", output)
+        self.assertEqual(config_text, "[features]\nhooks = true\n")
+
+    def test_install_without_feature_flag_change_prints_current_reminder(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_path = Path(tmp) / "hooks.json"
+            config_path = Path(tmp) / "config.toml"
+            output = install_hooks(ROOT, hooks_path, codex_config_path=config_path, enable_feature_flag=False)
+        self.assertIn("hooks = true", output)
+        self.assertNotIn("codex_hooks", output)
+        self.assertFalse(config_path.exists())
 
     def test_shell_installer_installs_to_overridden_paths_without_home_writes(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -165,7 +208,8 @@ class InstallerTest(unittest.TestCase):
             self.assertTrue((install_root / "install.sh").exists())
             self.assertTrue((install_root / "scripts" / "retrieve.py").exists())
             self.assertIn("UserPromptSubmit", hooks["hooks"])
-            self.assertIn("codex_hooks = true", config_text)
+            self.assertIn("hooks = true", config_text)
+            self.assertNotIn("codex_hooks", config_text)
 
     def test_shell_installer_reinstall_and_uninstall_are_owned_entry_safe(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -245,6 +289,8 @@ class InstallerTest(unittest.TestCase):
                 timeout=10,
             )
             self.assertIn("Dry run", result.stdout)
+            self.assertIn("[features] hooks = true", result.stdout)
+            self.assertNotIn("codex_hooks", result.stdout)
             self.assertFalse(install_root.exists())
             self.assertFalse(hooks_path.exists())
             self.assertFalse(config_path.exists())


### PR DESCRIPTION
## Summary
- Update the Codex installer to use the current [features].hooks flag instead of the deprecated codex_hooks flag.
- Migrate existing codex_hooks entries under [features], remove deprecated keys, and enable hooks when the current flag is false.
- Refresh installer tests and Codex integration documentation for the new flag.

## Test Plan
- [x] PYTHONPATH=memind-integrations/codex /opt/homebrew/bin/python3.12 -m unittest discover -s memind-integrations/codex/tests -v
- [x] mvn test