### PR TITLE
Add Memind OpenClaw integration

### DIFF
--- a/.github/workflows/openclaw-integration.yml
+++ b/.github/workflows/openclaw-integration.yml
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: OpenClaw Integration CI
+
+on:
+  push:
+    paths:
+      - 'memind-integrations/openclaw/**'
+      - '.github/workflows/openclaw-integration.yml'
+      - '.github/workflows/release-openclaw-integration.yml'
+  pull_request:
+    paths:
+      - 'memind-integrations/openclaw/**'
+      - '.github/workflows/openclaw-integration.yml'
+      - '.github/workflows/release-openclaw-integration.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: memind-integrations/openclaw/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: memind-integrations/openclaw
+        run: pnpm install --frozen-lockfile
+
+      - name: Format check
+        working-directory: memind-integrations/openclaw
+        run: pnpm format:check
+
+      - name: Lint
+        working-directory: memind-integrations/openclaw
+        run: pnpm lint
+
+      - name: Type check
+        working-directory: memind-integrations/openclaw
+        run: pnpm typecheck
+
+      - name: Test with coverage
+        working-directory: memind-integrations/openclaw
+        run: pnpm test:coverage
+
+      - name: Build
+        working-directory: memind-integrations/openclaw
+        run: pnpm build
+
+      - name: Pack check
+        working-directory: memind-integrations/openclaw
+        run: pnpm pack --json --pack-destination .pack-check

--- a/.github/workflows/release-openclaw-integration.yml
+++ b/.github/workflows/release-openclaw-integration.yml
@@ -1,0 +1,94 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release OpenClaw Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (must match package.json)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Build and publish OpenClaw integration
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: memind-integrations/openclaw/pnpm-lock.yaml
+
+      - name: Validate version input
+        working-directory: memind-integrations/openclaw
+        shell: bash
+        run: |
+          if [ -z "${{ inputs.version }}" ]; then
+            echo "Error: version input is required"
+            exit 1
+          fi
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ inputs.version }}" ]; then
+            echo "Error: input version (${{ inputs.version }}) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: release version must be a stable semver version like 0.1.0"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: memind-integrations/openclaw
+        run: pnpm install --frozen-lockfile
+
+      - name: Format check
+        working-directory: memind-integrations/openclaw
+        run: pnpm format:check
+
+      - name: Lint
+        working-directory: memind-integrations/openclaw
+        run: pnpm lint
+
+      - name: Type check
+        working-directory: memind-integrations/openclaw
+        run: pnpm typecheck
+
+      - name: Test
+        working-directory: memind-integrations/openclaw
+        run: pnpm test:coverage
+
+      - name: Build
+        working-directory: memind-integrations/openclaw
+        run: pnpm build
+
+      - name: Pack check
+        working-directory: memind-integrations/openclaw
+        run: pnpm pack --json --pack-destination .pack-check
+
+      - name: Publish
+        working-directory: memind-integrations/openclaw
+        run: npm publish --access public --provenance

--- a/memind-integrations/openclaw/.gitignore
+++ b/memind-integrations/openclaw/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+.pack-check/
+*.tsbuildinfo
+*.tgz

--- a/memind-integrations/openclaw/.prettierignore
+++ b/memind-integrations/openclaw/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+.pack-check/
+*.tgz
+pnpm-lock.yaml

--- a/memind-integrations/openclaw/.prettierrc
+++ b/memind-integrations/openclaw/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/memind-integrations/openclaw/LICENSE
+++ b/memind-integrations/openclaw/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 OpenMemind
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/memind-integrations/openclaw/README.md
+++ b/memind-integrations/openclaw/README.md
@@ -1,0 +1,214 @@
+# @openmemind/memind-openclaw
+
+Memind memory backend for OpenClaw.
+
+The plugin retrieves relevant Memind memories before each prompt and submits successful
+user/assistant OpenClaw conversation text to Memind extraction after each agent turn. It connects
+to an already-running Memind server and does not start the server.
+
+Use this plugin when you want OpenClaw to remember project facts, preferences, implementation
+decisions, and previous discussions across sessions.
+
+The integration is intentionally small:
+
+- Uses the official `@openmemind/memind` TypeScript client.
+- Activates only when selected as OpenClaw's memory slot.
+- Does not manage a local Memind daemon.
+- Does not ingest tool calls or media in v0.1.
+
+## Requirements
+
+- OpenClaw with plugin and memory slot support.
+- Node.js 20+.
+- A running Memind server, usually at `http://127.0.0.1:8366`.
+
+Check the Memind server before enabling the plugin:
+
+```bash
+curl -fsSL http://127.0.0.1:8366/open/v1/health
+```
+
+## Quick Start
+
+Install the plugin:
+
+```bash
+openclaw plugins install @openmemind/memind-openclaw
+```
+
+Install alone does not activate the plugin. Select it as the OpenClaw memory backend:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "memind-openclaw"
+    },
+    "entries": {
+      "memind-openclaw": {
+        "enabled": true,
+        "config": {
+          "memindApiUrl": "http://127.0.0.1:8366",
+          "memindApiToken": {
+            "source": "env",
+            "id": "MEMIND_API_TOKEN"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the OpenClaw gateway or session after changing plugin configuration.
+
+## What It Does
+
+- **Retrieval**: `before_prompt_build` calls `MemindClient.memory.retrieve(...)` and injects
+  relevant memories into OpenClaw as `<memind_memories>...</memind_memories>`.
+- **Ingestion**: `agent_end` filters successful user/assistant messages and submits a caller-owned
+  conversation payload through `MemindClient.memory.extract(...)`.
+- **Retry**: failed extraction payloads are spooled under OpenClaw's plugin state directory and
+  replayed on later `agent_end` hooks.
+- **Source tagging**: all requests use `sourceClient = "openclaw"` by default, so Memind can
+  distinguish OpenClaw memory from Claude Code, Codex, API calls, or future clients.
+
+The plugin is fail-open: Memind retrieval or extraction failures are logged but do not block the
+agent turn.
+
+## Configuration
+
+The default configuration works with a local Memind server at `http://127.0.0.1:8366`.
+
+### Common Settings
+
+| Setting                       | Default                 | Description                                                                             |
+| ----------------------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| `memindApiUrl`                | `http://127.0.0.1:8366` | Memind server URL.                                                                      |
+| `memindApiToken`              | unset                   | Optional bearer token. Use a string token or an env SecretRef.                          |
+| `userId`                      | `local__<system-user>`  | Memind user identity.                                                                   |
+| `agentId`                     | `openclaw`              | Base agent identity.                                                                    |
+| `agentIdMode`                 | `project`               | `project`, `fixed`, or `session`.                                                       |
+| `sourceClient`                | `openclaw`              | Source marker stored with Memind data.                                                  |
+| `autoRetrieve`                | `true`                  | Enables prompt-time memory retrieval.                                                   |
+| `autoIngest`                  | `true`                  | Enables post-turn conversation extraction.                                              |
+| `retrieveStrategy`            | `SIMPLE`                | Memind retrieval strategy.                                                              |
+| `retrieveMaxEntries`          | `8`                     | Maximum formatted memory entries injected into OpenClaw.                                |
+| `retrieveMaxChars`            | `6000`                  | Maximum injected memory body characters, excluding the fixed XML envelope and preamble. |
+| `retrieveContextTurns`        | `1`                     | Number of recent turns included in the retrieval query.                                 |
+| `retrievePromptPreamble`      | built in                | Text placed at the start of the injected memory block.                                  |
+| `recallInjectionPosition`     | `context`               | `context`, `system-prepend`, or `system-append`.                                        |
+| `ingestionRoles`              | `["user", "assistant"]` | Conversation roles eligible for ingestion.                                              |
+| `ingestionMaxMessagesPerHook` | `20`                    | Maximum new messages sent during one capture hook.                                      |
+| `ingestRetrySpool`            | `true`                  | Enables file-backed retry for failed extraction payloads.                               |
+| `stateMaxAgeDays`             | `14`                    | Retention window for submitted-message fingerprints.                                    |
+| `ingestRetryMaxFiles`         | `20`                    | Maximum retry payload files to keep.                                                    |
+| `ingestRetryMaxAgeDays`       | `7`                     | Retention window for retry payloads.                                                    |
+| `captureToolCalls`            | `false`                 | Reserved for a future release; v0.1 rejects `true`.                                     |
+| `captureMedia`                | `false`                 | Reserved for a future release; v0.1 rejects `true`.                                     |
+| `skipNonInteractiveTriggers`  | `true`                  | Skips cron, heartbeat, automation, and schedule sessions.                               |
+| `captureSubagents`            | `false`                 | Captures subagent sessions when enabled.                                                |
+| `debug`                       | `false`                 | Enables debug logs through the OpenClaw plugin logger.                                  |
+
+### Token SecretRef
+
+The plugin resolves this SecretRef form from environment variables:
+
+```json
+{
+  "memindApiToken": {
+    "source": "env",
+    "id": "MEMIND_API_TOKEN"
+  }
+}
+```
+
+A plain string token is also accepted:
+
+```json
+{
+  "memindApiToken": "memind-token"
+}
+```
+
+## Identity Model
+
+By default, Memind stores OpenClaw memory under:
+
+- `userId`: `local__<system-user>`
+- `agentId`: `openclaw__<project-name>-<stable-hash>`
+
+The project hash is based on the OpenClaw workspace directory. This keeps different repositories
+separated while allowing memory to survive across OpenClaw sessions in the same project.
+
+To use one shared OpenClaw memory across all projects:
+
+```json
+{
+  "agentId": "openclaw",
+  "agentIdMode": "fixed"
+}
+```
+
+To isolate memory by OpenClaw session:
+
+```json
+{
+  "agentId": "openclaw",
+  "agentIdMode": "session"
+}
+```
+
+## Retrieval Behavior
+
+Retrieval runs before each user prompt when `autoRetrieve = true` and the plugin is selected through
+`plugins.slots.memory = "memind-openclaw"`.
+
+The injected context format is:
+
+```text
+<memind_memories>
+Relevant memories from Memind. Use only when directly helpful:
+## Insights
+- [insight:42] ...
+
+## Memory Items
+- [item:101] ...
+</memind_memories>
+```
+
+Insights are formatted before memory items. Higher-level insights (`ROOT`, then `BRANCH`) are
+preferred; `LEAF` insights are omitted by default unless no higher-level insights are available.
+
+`retrieveContextTurns` defaults to `1`, so retrieval can use the current prompt plus the most recent
+conversation turn. Set it to `0` if you want retrieval queries to use only the current prompt.
+
+## Ingestion Behavior
+
+Ingestion runs after successful OpenClaw agent turns when `autoIngest = true`.
+
+The capture hook:
+
+1. Reads messages from the OpenClaw hook payload.
+2. Extracts text from user and assistant messages.
+3. Strips previously injected `<memind_memories>` blocks to avoid feedback loops.
+4. Skips tool calls, media, unsupported roles, non-interactive triggers, and subagent sessions by
+   default.
+5. Keeps the final user turn and following assistant messages.
+6. Computes stable fingerprints and sends only messages that have not already been submitted.
+7. Builds one caller-owned conversation raw-content payload and submits it through
+   `MemindClient.memory.extract(...)`.
+
+The local retry spool stores the full extraction payload plus the covered message fingerprints.
+Fingerprints are marked submitted only after Memind returns `SUCCESS`; `PARTIAL_SUCCESS` and
+failures keep the payload available for later replay.
+
+## Troubleshooting
+
+- If no memories are injected, confirm `plugins.slots.memory` is set to `memind-openclaw`.
+- If capture does not run, confirm the turn completed successfully and is not a cron, heartbeat,
+  automation, schedule, or subagent session.
+- If authenticated Memind requests fail, confirm `MEMIND_API_TOKEN` is present in the OpenClaw
+  process environment or configure `memindApiToken` as a plain string.
+- If Memind is unavailable, OpenClaw continues normally and extraction retries later when retry
+  spooling is enabled.

--- a/memind-integrations/openclaw/eslint.config.js
+++ b/memind-integrations/openclaw/eslint.config.js
@@ -1,0 +1,30 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', 'coverage/', '.pack-check/'],
+  },
+)

--- a/memind-integrations/openclaw/openclaw-plugin-sdk.d.ts
+++ b/memind-integrations/openclaw/openclaw-plugin-sdk.d.ts
@@ -1,0 +1,56 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+declare module 'openclaw/plugin-sdk' {
+  export type OpenClawHookHandler = (event: unknown, ctx?: unknown) => unknown | Promise<unknown>
+
+  export interface OpenClawPluginApi {
+    pluginConfig?: Record<string, unknown>
+    config?: {
+      plugins?: {
+        slots?: Record<string, string>
+        memoryPluginId?: string
+        entries?: Record<string, { enabled?: boolean; config?: Record<string, unknown> }>
+      }
+    }
+    logger: {
+      debug(message: string): void
+      info(message: string): void
+      warn(message: string): void
+      error(message: string): void
+    }
+    on(event: string, handler: OpenClawHookHandler): void
+    registerService(service: {
+      id: string
+      start: (context?: { stateDir?: string; [key: string]: unknown }) => void
+      stop: () => void
+    }): void
+    resolvePath?(path: string): string
+    registerMemoryCapability?(config: Record<string, unknown>): void
+    [key: string]: unknown
+  }
+}
+
+declare module 'openclaw/plugin-sdk/plugin-entry' {
+  import type { OpenClawPluginApi } from 'openclaw/plugin-sdk'
+
+  export interface PluginEntry {
+    id: string
+    name: string
+    description?: string
+    register(api: OpenClawPluginApi): void
+  }
+
+  export function definePluginEntry<T extends PluginEntry>(entry: T): T
+}

--- a/memind-integrations/openclaw/openclaw.plugin.json
+++ b/memind-integrations/openclaw/openclaw.plugin.json
@@ -1,0 +1,137 @@
+{
+  "id": "memind-openclaw",
+  "name": "Memind Memory",
+  "description": "Memind memory backend for OpenClaw. Retrieves relevant memories before prompts and extracts durable text-only conversation memory after successful turns.",
+  "version": "0.1.0",
+  "kind": "memory",
+  "configContracts": {
+    "secretInputs": {
+      "paths": [
+        {
+          "path": "memindApiToken",
+          "expected": "string"
+        }
+      ]
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "memindApiUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:8366"
+      },
+      "memindApiToken": {
+        "type": ["string", "object"],
+        "sensitive": true
+      },
+      "userId": {
+        "type": ["string", "null"]
+      },
+      "agentId": {
+        "type": "string",
+        "default": "openclaw"
+      },
+      "agentIdMode": {
+        "type": "string",
+        "enum": ["project", "fixed", "session"],
+        "default": "project"
+      },
+      "sourceClient": {
+        "type": "string",
+        "default": "openclaw"
+      },
+      "autoRetrieve": {
+        "type": "boolean",
+        "default": true
+      },
+      "autoIngest": {
+        "type": "boolean",
+        "default": true
+      },
+      "retrieveStrategy": {
+        "type": "string",
+        "enum": ["SIMPLE"],
+        "default": "SIMPLE"
+      },
+      "retrieveMaxEntries": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 8
+      },
+      "retrieveMaxChars": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 6000
+      },
+      "retrieveContextTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 1
+      },
+      "retrievePromptPreamble": {
+        "type": "string"
+      },
+      "recallInjectionPosition": {
+        "type": "string",
+        "enum": ["context", "system-prepend", "system-append"],
+        "default": "context"
+      },
+      "ingestionRoles": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["user", "assistant"]
+        },
+        "default": ["user", "assistant"]
+      },
+      "ingestionMaxMessagesPerHook": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 20
+      },
+      "ingestRetrySpool": {
+        "type": "boolean",
+        "default": true
+      },
+      "stateMaxAgeDays": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 14
+      },
+      "ingestRetryMaxFiles": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 20
+      },
+      "ingestRetryMaxAgeDays": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 7
+      },
+      "captureToolCalls": {
+        "type": "boolean",
+        "const": false,
+        "default": false
+      },
+      "captureMedia": {
+        "type": "boolean",
+        "const": false,
+        "default": false
+      },
+      "skipNonInteractiveTriggers": {
+        "type": "boolean",
+        "default": true
+      },
+      "captureSubagents": {
+        "type": "boolean",
+        "default": false
+      },
+      "debug": {
+        "type": "boolean",
+        "default": false
+      }
+    }
+  }
+}

--- a/memind-integrations/openclaw/package.json
+++ b/memind-integrations/openclaw/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@openmemind/memind-openclaw",
+  "version": "0.1.0",
+  "description": "Memind memory backend for OpenClaw",
+  "license": "Apache-2.0",
+  "type": "module",
+  "packageManager": "pnpm@10.15.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "LICENSE",
+    "README.md"
+  ],
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "memory",
+    "memind",
+    "long-term-memory"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openmemind/memind.git",
+    "directory": "memind-integrations/openclaw"
+  },
+  "bugs": {
+    "url": "https://github.com/openmemind/memind/issues"
+  },
+  "homepage": "https://github.com/openmemind/memind#readme",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint .",
+    "format:check": "prettier --check .",
+    "format": "prettier --write .",
+    "pack:check": "pnpm pack --json --pack-destination .pack-check"
+  },
+  "dependencies": {
+    "@openmemind/memind": "^0.2.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.4.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.0.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ],
+    "install": {
+      "npmSpec": "@openmemind/memind-openclaw"
+    }
+  }
+}

--- a/memind-integrations/openclaw/pnpm-lock.yaml
+++ b/memind-integrations/openclaw/pnpm-lock.yaml
@@ -1,0 +1,2535 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@openmemind/memind':
+        specifier: ^0.2.0
+        version: 0.2.0
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.41))
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
+      prettier:
+        specifier: ^3.4.0
+        version: 3.8.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.19.41)
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@openmemind/memind@0.2.0':
+    resolution: {integrity: sha512-Jh6l5NwcTrrIMjrYgAdAbyMl6oMc7njKs3dAVKkrZezaxrd565uvu1QUy26LFv8ZxGeOmQ6xqSRjqYYSoLYrUw==}
+    engines: {node: '>=20'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@typescript-eslint/eslint-plugin@8.59.3':
+    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.3
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.3':
+    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.3':
+    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.3':
+    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.3':
+    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.3':
+    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.3':
+    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.3':
+    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.3':
+    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.59.3:
+    resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@openmemind/memind@0.2.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.3(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.3': {}
+
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.41))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@20.19.41)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@20.19.41))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@20.19.41)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  callsites@3.1.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.3
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
+
+  object-assign@4.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.14):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.14
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
+
+  punycode@2.3.1: {}
+
+  readdirp@4.1.2: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.14)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.14)
+      resolve-from: 5.0.0
+      rollup: 4.60.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.14
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.59.3(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite-node@3.2.4(@types/node@20.19.41):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.3(@types/node@20.19.41)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.3(@types/node@20.19.41):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.41
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@20.19.41):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@20.19.41))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.3(@types/node@20.19.41)
+      vite-node: 3.2.4(@types/node@20.19.41)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  yocto-queue@0.1.0: {}

--- a/memind-integrations/openclaw/src/capture.ts
+++ b/memind-integrations/openclaw/src/capture.ts
@@ -1,0 +1,132 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { RawContent, type RawContentValue } from '@openmemind/memind'
+
+import { extractMessages } from './content.js'
+import { isNonInteractiveTrigger, isSubagentSession } from './identity.js'
+import type { Identity, MemindMemoryClient, MemindOpenClawConfig, OpenClawMessage } from './types.js'
+
+export type CaptureInput = {
+  cfg: MemindOpenClawConfig
+  client: MemindMemoryClient
+  identity: Identity
+  event: Record<string, unknown>
+  ctx?: Record<string, unknown>
+  state: {
+    filterUnsubmitted(sessionKey: string, fingerprints: string[]): Promise<string[]>
+    markSubmitted(sessionKey: string, fingerprints: string[]): Promise<void>
+  }
+  retry?: {
+    enqueue(entry: {
+      kind: 'extract'
+      userId: string
+      agentId: string
+      sourceClient: string
+      sessionKey: string
+      fingerprints: string[]
+      rawContent: RawContentValue
+    }): Promise<void>
+  }
+  logger?: { warn(message: string): void; debug(message: string): void }
+}
+
+export async function handleCapture(input: CaptureInput): Promise<{ submitted: number }> {
+  const { cfg, client, identity, event, ctx, state, retry, logger } = input
+  if (!cfg.autoIngest || event.success === false) return { submitted: 0 }
+  const trigger = typeof ctx?.trigger === 'string' ? ctx.trigger : undefined
+  const sessionKey =
+    typeof ctx?.sessionKey === 'string'
+      ? ctx.sessionKey
+      : typeof identity.sessionKey === 'string'
+        ? identity.sessionKey
+        : 'default'
+  if (cfg.skipNonInteractiveTriggers && isNonInteractiveTrigger(trigger, sessionKey)) {
+    return { submitted: 0 }
+  }
+  if (!cfg.captureSubagents && isSubagentSession(sessionKey)) return { submitted: 0 }
+
+  const rawMessages = selectMessages(event)
+  const messages = selectFinalTurn(extractMessages(rawMessages, cfg))
+  if (messages.length === 0) return { submitted: 0 }
+  const byFingerprint = new Map(messages.map((message) => [message.fingerprint, message]))
+  const selectedFingerprints = (
+    await state.filterUnsubmitted(sessionKey, [...byFingerprint.keys()])
+  ).slice(0, cfg.ingestionMaxMessagesPerHook)
+  if (selectedFingerprints.length === 0) return { submitted: 0 }
+  const selectedMessages = selectedFingerprints
+    .map((fingerprint) => byFingerprint.get(fingerprint))
+    .filter((message): message is NonNullable<typeof message> => Boolean(message))
+  if (selectedMessages.length === 0) return { submitted: 0 }
+  const rawContent = RawContent.conversation(
+    selectedMessages.map(({ fingerprint: _fingerprint, ...message }) => message),
+  )
+
+  try {
+    const response = await client.extract(
+      {
+        userId: identity.userId,
+        agentId: identity.agentId,
+        rawContent,
+        sourceClient: identity.sourceClient,
+      },
+      { timeoutMs: 15_000, maxRetries: 0 },
+    )
+    if (response.status === 'SUCCESS') {
+      await state.markSubmitted(sessionKey, selectedFingerprints)
+      return { submitted: selectedFingerprints.length }
+    }
+    await retry?.enqueue({
+      kind: 'extract',
+      userId: identity.userId,
+      agentId: identity.agentId,
+      sourceClient: identity.sourceClient,
+      sessionKey,
+      fingerprints: selectedFingerprints,
+      rawContent,
+    })
+    return { submitted: 0 }
+  } catch (error: unknown) {
+    logger?.warn(`memind-openclaw: capture failed: ${String(error)}`)
+    await retry?.enqueue({
+      kind: 'extract',
+      userId: identity.userId,
+      agentId: identity.agentId,
+      sourceClient: identity.sourceClient,
+      sessionKey,
+      fingerprints: selectedFingerprints,
+      rawContent,
+    })
+    return { submitted: 0 }
+  }
+}
+
+function selectMessages(event: Record<string, unknown>): OpenClawMessage[] {
+  const context = event.context as { sessionEntry?: { messages?: unknown } } | undefined
+  const fromContext = context?.sessionEntry?.messages
+  if (Array.isArray(fromContext)) return fromContext as OpenClawMessage[]
+  return Array.isArray(event.messages) ? (event.messages as OpenClawMessage[]) : []
+}
+
+function selectFinalTurn<T extends { role: 'USER' | 'ASSISTANT' }>(messages: T[]): T[] {
+  let lastUserIndex = -1
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === 'USER') {
+      lastUserIndex = index
+      break
+    }
+  }
+  if (lastUserIndex < 0) return messages
+  return messages.slice(lastUserIndex)
+}

--- a/memind-integrations/openclaw/src/capture.ts
+++ b/memind-integrations/openclaw/src/capture.ts
@@ -16,7 +16,12 @@ import { RawContent, type RawContentValue } from '@openmemind/memind'
 
 import { extractMessages } from './content.js'
 import { isNonInteractiveTrigger, isSubagentSession } from './identity.js'
-import type { Identity, MemindMemoryClient, MemindOpenClawConfig, OpenClawMessage } from './types.js'
+import type {
+  Identity,
+  MemindMemoryClient,
+  MemindOpenClawConfig,
+  OpenClawMessage,
+} from './types.js'
 
 export type CaptureInput = {
   cfg: MemindOpenClawConfig

--- a/memind-integrations/openclaw/src/client.ts
+++ b/memind-integrations/openclaw/src/client.ts
@@ -1,0 +1,37 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { MemindClient } from '@openmemind/memind'
+
+import type { MemindMemoryClient, MemindOpenClawConfig, SecretRef } from './types.js'
+
+export function createMemindMemoryClient(cfg: MemindOpenClawConfig): MemindMemoryClient {
+  const client = new MemindClient({
+    baseUrl: cfg.memindApiUrl,
+    apiToken: resolveToken(cfg.memindApiToken),
+    timeoutMs: 15_000,
+    maxRetries: 0,
+  })
+  return client.memory
+}
+
+export function resolveToken(
+  token: string | SecretRef | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  if (!token) return undefined
+  if (typeof token === 'string') return token.trim() || undefined
+  if (token.source === 'env') return env[token.id]?.trim() || undefined
+  return undefined
+}

--- a/memind-integrations/openclaw/src/config.ts
+++ b/memind-integrations/openclaw/src/config.ts
@@ -1,0 +1,244 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type {
+  AgentIdMode,
+  IngestionRole,
+  MemindOpenClawConfig,
+  RecallInjectionPosition,
+  SecretRef,
+  SlotConfigLike,
+} from './types.js'
+
+export const PLUGIN_ID = 'memind-openclaw'
+
+export const DEFAULT_CONFIG: MemindOpenClawConfig = {
+  memindApiUrl: 'http://127.0.0.1:8366',
+  agentId: 'openclaw',
+  agentIdMode: 'project',
+  sourceClient: 'openclaw',
+  autoRetrieve: true,
+  autoIngest: true,
+  retrieveStrategy: 'SIMPLE',
+  retrieveMaxEntries: 8,
+  retrieveMaxChars: 6000,
+  retrieveContextTurns: 1,
+  retrievePromptPreamble: 'Relevant memories from Memind. Use only when directly helpful:',
+  recallInjectionPosition: 'context',
+  ingestionRoles: ['user', 'assistant'],
+  ingestionMaxMessagesPerHook: 20,
+  ingestRetrySpool: true,
+  stateMaxAgeDays: 14,
+  ingestRetryMaxFiles: 20,
+  ingestRetryMaxAgeDays: 7,
+  captureToolCalls: false,
+  captureMedia: false,
+  skipNonInteractiveTriggers: true,
+  captureSubagents: false,
+  debug: false,
+}
+
+const ALLOWED_KEYS = new Set(Object.keys(DEFAULT_CONFIG).concat(['memindApiToken', 'userId']))
+const AGENT_ID_MODES = new Set<AgentIdMode>(['project', 'fixed', 'session'])
+const INJECTION_POSITIONS = new Set<RecallInjectionPosition>([
+  'context',
+  'system-prepend',
+  'system-append',
+])
+const RETRIEVE_STRATEGIES = new Set<MemindOpenClawConfig['retrieveStrategy']>(['SIMPLE'])
+const INGESTION_ROLES = new Set<IngestionRole>(['user', 'assistant'])
+
+export function parseConfig(value: unknown): MemindOpenClawConfig {
+  const raw = objectValue(value, 'config')
+  const unknown = Object.keys(raw).filter((key) => !ALLOWED_KEYS.has(key))
+  if (unknown.length > 0) {
+    throw new Error(`memind-openclaw config has unknown keys: ${unknown.join(', ')}`)
+  }
+
+  const cfg: MemindOpenClawConfig = { ...DEFAULT_CONFIG }
+
+  cfg.memindApiUrl = stringValue(raw.memindApiUrl, cfg.memindApiUrl, 'memindApiUrl').replace(
+    /\/+$/,
+    '',
+  )
+  cfg.memindApiToken = tokenValue(raw.memindApiToken)
+  cfg.userId = optionalString(raw.userId, 'userId')
+  cfg.agentId = stringValue(raw.agentId, cfg.agentId, 'agentId')
+  cfg.agentIdMode = enumValue(raw.agentIdMode, cfg.agentIdMode, AGENT_ID_MODES, 'agentIdMode')
+  cfg.sourceClient = stringValue(raw.sourceClient, cfg.sourceClient, 'sourceClient')
+  cfg.autoRetrieve = booleanValue(raw.autoRetrieve, cfg.autoRetrieve, 'autoRetrieve')
+  cfg.autoIngest = booleanValue(raw.autoIngest, cfg.autoIngest, 'autoIngest')
+  cfg.retrieveStrategy = enumValue(
+    raw.retrieveStrategy,
+    cfg.retrieveStrategy,
+    RETRIEVE_STRATEGIES,
+    'retrieveStrategy',
+  )
+  cfg.retrieveMaxEntries = positiveInteger(
+    raw.retrieveMaxEntries,
+    cfg.retrieveMaxEntries,
+    'retrieveMaxEntries',
+  )
+  cfg.retrieveMaxChars = positiveInteger(
+    raw.retrieveMaxChars,
+    cfg.retrieveMaxChars,
+    'retrieveMaxChars',
+  )
+  cfg.retrieveContextTurns = nonNegativeInteger(
+    raw.retrieveContextTurns,
+    cfg.retrieveContextTurns,
+    'retrieveContextTurns',
+  )
+  cfg.retrievePromptPreamble = stringValue(
+    raw.retrievePromptPreamble,
+    cfg.retrievePromptPreamble,
+    'retrievePromptPreamble',
+  )
+  cfg.recallInjectionPosition = enumValue(
+    raw.recallInjectionPosition,
+    cfg.recallInjectionPosition,
+    INJECTION_POSITIONS,
+    'recallInjectionPosition',
+  )
+  cfg.ingestionRoles = ingestionRoles(raw.ingestionRoles, cfg.ingestionRoles)
+  cfg.ingestionMaxMessagesPerHook = positiveInteger(
+    raw.ingestionMaxMessagesPerHook,
+    cfg.ingestionMaxMessagesPerHook,
+    'ingestionMaxMessagesPerHook',
+  )
+  cfg.ingestRetrySpool = booleanValue(
+    raw.ingestRetrySpool,
+    cfg.ingestRetrySpool,
+    'ingestRetrySpool',
+  )
+  cfg.stateMaxAgeDays = positiveInteger(raw.stateMaxAgeDays, cfg.stateMaxAgeDays, 'stateMaxAgeDays')
+  cfg.ingestRetryMaxFiles = nonNegativeInteger(
+    raw.ingestRetryMaxFiles,
+    cfg.ingestRetryMaxFiles,
+    'ingestRetryMaxFiles',
+  )
+  cfg.ingestRetryMaxAgeDays = positiveInteger(
+    raw.ingestRetryMaxAgeDays,
+    cfg.ingestRetryMaxAgeDays,
+    'ingestRetryMaxAgeDays',
+  )
+  cfg.captureToolCalls = reservedFalseBoolean(raw.captureToolCalls, 'captureToolCalls')
+  cfg.captureMedia = reservedFalseBoolean(raw.captureMedia, 'captureMedia')
+  cfg.skipNonInteractiveTriggers = booleanValue(
+    raw.skipNonInteractiveTriggers,
+    cfg.skipNonInteractiveTriggers,
+    'skipNonInteractiveTriggers',
+  )
+  cfg.captureSubagents = booleanValue(raw.captureSubagents, cfg.captureSubagents, 'captureSubagents')
+  cfg.debug = booleanValue(raw.debug, cfg.debug, 'debug')
+
+  return cfg
+}
+
+export function shouldRunAutomaticHooks(
+  pluginId: string,
+  config: SlotConfigLike | undefined,
+): boolean {
+  return config?.slots?.memory === pluginId || config?.memoryPluginId === pluginId
+}
+
+function objectValue(value: unknown, label: string): Record<string, unknown> {
+  if (value === undefined || value === null) return {}
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function stringValue(value: unknown, fallback: string, label: string): string {
+  if (value === undefined) return fallback
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${label} must be a non-blank string`)
+  }
+  return value.trim()
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null) return undefined
+  return stringValue(value, '', label)
+}
+
+function tokenValue(value: unknown): string | SecretRef | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'string') return value.trim() || undefined
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const ref = value as Record<string, unknown>
+    if (typeof ref.source === 'string' && typeof ref.id === 'string') {
+      return value as SecretRef
+    }
+  }
+  throw new Error('memindApiToken must be a string or SecretRef object')
+}
+
+function booleanValue(value: unknown, fallback: boolean, label: string): boolean {
+  if (value === undefined) return fallback
+  if (typeof value !== 'boolean') throw new Error(`${label} must be a boolean`)
+  return value
+}
+
+function reservedFalseBoolean(value: unknown, label: string): boolean {
+  if (value === undefined || value === false) return false
+  if (typeof value !== 'boolean') throw new Error(`${label} must be a boolean`)
+  throw new Error(`${label} is reserved for a future release and must remain false in v0.1`)
+}
+
+function positiveInteger(value: unknown, fallback: number, label: string): number {
+  const parsed = integerValue(value, fallback, label)
+  if (parsed <= 0) throw new Error(`${label} must be a positive integer`)
+  return parsed
+}
+
+function nonNegativeInteger(value: unknown, fallback: number, label: string): number {
+  const parsed = integerValue(value, fallback, label)
+  if (parsed < 0) throw new Error(`${label} must be a non-negative integer`)
+  return parsed
+}
+
+function integerValue(value: unknown, fallback: number, label: string): number {
+  if (value === undefined) return fallback
+  if (!Number.isInteger(value)) throw new Error(`${label} must be an integer`)
+  return value as number
+}
+
+function enumValue<T extends string>(
+  value: unknown,
+  fallback: T,
+  allowed: Set<T>,
+  label: string,
+): T {
+  if (value === undefined) return fallback
+  if (typeof value !== 'string' || !allowed.has(value as T)) {
+    throw new Error(`${label} has unsupported value: ${String(value)}`)
+  }
+  return value as T
+}
+
+function ingestionRoles(value: unknown, fallback: IngestionRole[]): IngestionRole[] {
+  if (value === undefined) return fallback
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('ingestionRoles must be a non-empty array')
+  }
+  const roles = value.map((role) => {
+    if (typeof role !== 'string' || !INGESTION_ROLES.has(role as IngestionRole)) {
+      throw new Error(`ingestionRoles has unsupported role: ${String(role)}`)
+    }
+    return role as IngestionRole
+  })
+  return [...new Set(roles)]
+}

--- a/memind-integrations/openclaw/src/config.ts
+++ b/memind-integrations/openclaw/src/config.ts
@@ -140,7 +140,11 @@ export function parseConfig(value: unknown): MemindOpenClawConfig {
     cfg.skipNonInteractiveTriggers,
     'skipNonInteractiveTriggers',
   )
-  cfg.captureSubagents = booleanValue(raw.captureSubagents, cfg.captureSubagents, 'captureSubagents')
+  cfg.captureSubagents = booleanValue(
+    raw.captureSubagents,
+    cfg.captureSubagents,
+    'captureSubagents',
+  )
   cfg.debug = booleanValue(raw.debug, cfg.debug, 'debug')
 
   return cfg

--- a/memind-integrations/openclaw/src/content.ts
+++ b/memind-integrations/openclaw/src/content.ts
@@ -1,0 +1,136 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { createHash } from 'node:crypto'
+
+import type { MemindOpenClawConfig, NormalizedMessage, OpenClawMessage } from './types.js'
+
+const MEMIND_BLOCK_RE = /<memind_memories>[\s\S]*?<\/memind_memories>/g
+const SENDER_METADATA_RE = /Sender\s*\(untrusted metadata\):\s*```json[\s\S]*?```\s*/gi
+const CONVERSATION_METADATA_RE =
+  /Conversation info\s*\(untrusted metadata\):\s*```json[\s\S]*?```\s*/gi
+const INTERRUPTION_RE = /^\[(?:Request|Response) interrupted by user\]$/i
+
+export function stripInjectedContext(text: string): string {
+  return text
+    .replace(MEMIND_BLOCK_RE, '')
+    .replace(SENDER_METADATA_RE, '')
+    .replace(CONVERSATION_METADATA_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return cleanText(content)
+  if (!Array.isArray(content)) return ''
+  const texts: string[] = []
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const record = block as Record<string, unknown>
+    if (record.type === 'text' && typeof record.text === 'string') {
+      const text = cleanText(record.text)
+      if (text) texts.push(text)
+    }
+  }
+  return cleanText(texts.join('\n\n'))
+}
+
+export function containsUnsupportedBlocks(content: unknown): boolean {
+  if (!Array.isArray(content)) return false
+  return content.some((block) => {
+    if (!block || typeof block !== 'object') return false
+    const type = String((block as Record<string, unknown>).type ?? '').toLowerCase()
+    return Boolean(type && type !== 'text')
+  })
+}
+
+export function extractMessages(
+  messages: OpenClawMessage[],
+  cfg: MemindOpenClawConfig,
+): NormalizedMessage[] {
+  const allowed = new Set(cfg.ingestionRoles)
+  const out: NormalizedMessage[] = []
+  messages.forEach((message, index) => {
+    const role = typeof message.role === 'string' ? message.role.toLowerCase() : ''
+    if (!allowed.has(role as 'user' | 'assistant')) return
+    if (containsUnsupportedBlocks(message.content)) return
+    const text = textFromContent(message.content)
+    if (isNoiseText(text)) return
+    const normalizedRole = role === 'user' ? 'USER' : 'ASSISTANT'
+    out.push({
+      fingerprint: fingerprintMessage(message, normalizedRole, text, index),
+      role: normalizedRole,
+      content: [{ type: 'text', text }],
+      timestamp: normalizeTimestamp(message.timestamp),
+      userName: stringOrUndefined(message.userName ?? message.user_name),
+    })
+  })
+  return out
+}
+
+export function readRecentContext(messages: OpenClawMessage[], cfg: MemindOpenClawConfig): string {
+  if (cfg.retrieveContextTurns <= 0) return ''
+  const pairs: Array<{ role: string; text: string }> = []
+  for (const message of messages) {
+    const role = typeof message.role === 'string' ? message.role.toLowerCase() : ''
+    if (role !== 'user' && role !== 'assistant') continue
+    const text = textFromContent(message.content)
+    if (isNoiseText(text)) continue
+    pairs.push({ role, text })
+  }
+  return pairs
+    .slice(Math.max(0, pairs.length - cfg.retrieveContextTurns * 2))
+    .map((entry) => `${entry.role}: ${entry.text}`)
+    .join('\n')
+}
+
+function cleanText(text: string): string {
+  return stripInjectedContext(text).trim()
+}
+
+function isNoiseText(text: string): boolean {
+  const trimmed = text.trim()
+  return !trimmed || INTERRUPTION_RE.test(trimmed)
+}
+
+function fingerprintMessage(
+  message: OpenClawMessage,
+  role: 'USER' | 'ASSISTANT',
+  text: string,
+  index: number,
+): string {
+  const source = {
+    id: message.id ?? message.uuid,
+    timestamp: message.timestamp,
+    role,
+    text,
+    index,
+  }
+  return createHash('sha1').update(JSON.stringify(source)).digest('hex')
+}
+
+function normalizeTimestamp(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+  }
+  return undefined
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}

--- a/memind-integrations/openclaw/src/format.ts
+++ b/memind-integrations/openclaw/src/format.ts
@@ -1,0 +1,62 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type { RetrieveMemoryResponse } from '@openmemind/memind'
+
+import type { MemindOpenClawConfig } from './types.js'
+
+const TIER_RANK: Record<string, number> = { ROOT: 0, BRANCH: 1, LEAF: 2 }
+
+export function formatMemindContext(
+  data: RetrieveMemoryResponse,
+  cfg: MemindOpenClawConfig,
+): string {
+  const insights = [...(data.insights ?? [])]
+    .filter((insight) => insight.text)
+    .sort((a, b) => (TIER_RANK[a.tier ?? 'LEAF'] ?? 2) - (TIER_RANK[b.tier ?? 'LEAF'] ?? 2))
+  const highLevel = insights.filter((insight) =>
+    ['ROOT', 'BRANCH'].includes((insight.tier ?? '').toUpperCase()),
+  )
+  const selectedInsights = (highLevel.length ? highLevel : insights).slice(
+    0,
+    Math.min(3, cfg.retrieveMaxEntries),
+  )
+  const remaining = cfg.retrieveMaxEntries - selectedInsights.length
+  const selectedItems = [...(data.items ?? [])]
+    .filter((item) => item.text)
+    .sort((a, b) => (b.finalScore ?? b.vectorScore ?? 0) - (a.finalScore ?? a.vectorScore ?? 0))
+    .slice(0, Math.max(0, remaining))
+
+  const sections: string[] = []
+  if (selectedInsights.length > 0) {
+    sections.push('## Insights')
+    sections.push(...selectedInsights.map((insight) => `- [insight:${insight.id}] ${insight.text}`))
+  }
+  if (selectedItems.length > 0) {
+    if (sections.length > 0) sections.push('')
+    sections.push('## Memory Items')
+    sections.push(...selectedItems.map((item) => `- [item:${item.id}] ${item.text}`))
+  }
+  if (sections.length === 0 && data.status !== 'degraded') return ''
+
+  let body = sections.join('\n')
+  if (data.status === 'degraded') {
+    body += '\n[Note: Memory retrieval encountered an error. Results may be incomplete.]'
+  }
+  if (body.length > cfg.retrieveMaxChars) {
+    const suffix = '\n[truncated]'
+    body = `${body.slice(0, Math.max(0, cfg.retrieveMaxChars - suffix.length)).trimEnd()}${suffix}`
+  }
+  return `<memind_memories>\n${cfg.retrievePromptPreamble}\n${body}\n</memind_memories>`
+}

--- a/memind-integrations/openclaw/src/identity.ts
+++ b/memind-integrations/openclaw/src/identity.ts
@@ -51,7 +51,13 @@ export function isSubagentSession(sessionKey: string | undefined): boolean {
 }
 
 export function sanitizeIdentityPart(value: string): string {
-  const base = value.trim().replace(/\.git$/i, '').split(/[\\/]/).filter(Boolean).pop() ?? ''
+  const base =
+    value
+      .trim()
+      .replace(/\.git$/i, '')
+      .split(/[\\/]/)
+      .filter(Boolean)
+      .pop() ?? ''
   const normalized = base
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, '-')

--- a/memind-integrations/openclaw/src/identity.ts
+++ b/memind-integrations/openclaw/src/identity.ts
@@ -1,0 +1,82 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { createHash } from 'node:crypto'
+import { userInfo } from 'node:os'
+import path from 'node:path'
+
+import type { Identity, MemindOpenClawConfig } from './types.js'
+
+const NON_INTERACTIVE_TRIGGERS = new Set(['cron', 'heartbeat', 'automation', 'schedule'])
+
+export type IdentityContext = {
+  cwd?: string
+  gitRemoteUrl?: string
+  sessionKey?: string
+  systemUser?: string
+}
+
+export function resolveIdentity(cfg: MemindOpenClawConfig, ctx: IdentityContext = {}): Identity {
+  const userId = cfg.userId ?? `local__${sanitizeIdentityPart(ctx.systemUser ?? currentUser())}`
+  return {
+    userId,
+    agentId: resolveAgentId(cfg, ctx),
+    sourceClient: cfg.sourceClient,
+    sessionKey: ctx.sessionKey,
+  }
+}
+
+export function isNonInteractiveTrigger(
+  trigger: string | undefined,
+  sessionKey: string | undefined,
+): boolean {
+  if (trigger && NON_INTERACTIVE_TRIGGERS.has(trigger.toLowerCase())) return true
+  if (!sessionKey) return false
+  return /:(cron|heartbeat|automation|schedule)(:|$)/i.test(sessionKey)
+}
+
+export function isSubagentSession(sessionKey: string | undefined): boolean {
+  return Boolean(sessionKey && /:subagent:/i.test(sessionKey))
+}
+
+export function sanitizeIdentityPart(value: string): string {
+  const base = value.trim().replace(/\.git$/i, '').split(/[\\/]/).filter(Boolean).pop() ?? ''
+  const normalized = base
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return normalized || 'default'
+}
+
+function resolveAgentId(cfg: MemindOpenClawConfig, ctx: IdentityContext): string {
+  if (cfg.agentIdMode === 'fixed') return cfg.agentId
+  const source =
+    cfg.agentIdMode === 'session'
+      ? (ctx.sessionKey ?? ctx.cwd ?? 'default-session')
+      : (ctx.gitRemoteUrl ?? ctx.cwd ?? process.cwd())
+  const label = cfg.agentIdMode === 'session' ? 'session' : sanitizeIdentityPart(source)
+  return `${cfg.agentId}__${label}-${stableHash(source)}`
+}
+
+function stableHash(value: string): string {
+  return createHash('sha1').update(value).digest('hex').slice(0, 10)
+}
+
+function currentUser(): string {
+  try {
+    return userInfo().username || 'default'
+  } catch {
+    return path.basename(process.cwd()) || 'default'
+  }
+}

--- a/memind-integrations/openclaw/src/index.ts
+++ b/memind-integrations/openclaw/src/index.ts
@@ -12,14 +12,125 @@
 // limitations under the License.
 //
 
+import { homedir } from 'node:os'
+import path from 'node:path'
+
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk'
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry'
 
+import { handleCapture } from './capture.js'
+import { createMemindMemoryClient } from './client.js'
+import { parseConfig, PLUGIN_ID, shouldRunAutomaticHooks } from './config.js'
+import { resolveIdentity } from './identity.js'
+import { handleRecall } from './recall.js'
+import { createRuntimeStores, resolveWorkspaceDir } from './runtime.js'
+
 const plugin = definePluginEntry({
-  id: 'memind-openclaw',
+  id: PLUGIN_ID,
   name: 'Memind Memory',
   description: 'Memind memory backend for OpenClaw',
-  register(_api: OpenClawPluginApi) {},
+
+  register(api: OpenClawPluginApi) {
+    const cfg = parseConfig(readPluginConfig(api))
+    let stateDir = path.join(homedir(), '.memind', 'openclaw')
+    const selected = shouldRunAutomaticHooks(PLUGIN_ID, {
+      slots: api.config?.plugins?.slots,
+      memoryPluginId:
+        typeof api.config?.plugins?.memoryPluginId === 'string'
+          ? api.config.plugins.memoryPluginId
+          : undefined,
+    })
+
+    api.registerService({
+      id: PLUGIN_ID,
+      start: (context?: { stateDir?: string }) => {
+        const provided = context?.stateDir
+        if (typeof provided === 'string' && provided.trim()) stateDir = provided
+        api.logger.info(`memind-openclaw: service initialized (stateDir: ${stateDir})`)
+      },
+      stop: () => {
+        api.logger.info('memind-openclaw: stopped')
+      },
+    })
+
+    if (!selected) {
+      api.logger.warn(
+        'memind-openclaw: plugin is enabled but not selected in plugins.slots.memory; automatic hooks are disabled',
+      )
+      return
+    }
+
+    api.registerMemoryCapability?.({
+      runtime: {
+        provider: 'memind',
+        pluginId: PLUGIN_ID,
+      },
+    })
+
+    const client = createMemindMemoryClient(cfg)
+    const stores = createRuntimeStores(cfg, () => stateDir)
+
+    if (cfg.autoRetrieve) {
+      api.on('before_prompt_build', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const cwd = resolveWorkspaceDir(hookEvent, hookCtx, process.cwd())
+        debug(api, cfg.debug, `memind-openclaw: resolved workspaceDir=${cwd} stateDir=${stateDir}`)
+        const identity = resolveIdentity(cfg, {
+          cwd,
+          sessionKey: stringValue(hookCtx.sessionKey),
+        })
+        return handleRecall({ cfg, client, identity, event: hookEvent, ctx: hookCtx, logger: api.logger })
+      })
+    }
+
+    if (cfg.autoIngest) {
+      api.on('agent_end', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const runtime = stores.current()
+        const cwd = resolveWorkspaceDir(hookEvent, hookCtx, process.cwd())
+        debug(api, cfg.debug, `memind-openclaw: resolved workspaceDir=${cwd} stateDir=${stateDir}`)
+        const identity = resolveIdentity(cfg, {
+          cwd,
+          sessionKey: stringValue(hookCtx.sessionKey),
+        })
+        if (runtime.retry) {
+          runtime.retry.flush(client).catch((error: unknown) => {
+            api.logger.warn(`memind-openclaw: retry flush failed: ${String(error)}`)
+          })
+        }
+        return handleCapture({
+          cfg,
+          client,
+          identity,
+          event: hookEvent,
+          ctx: hookCtx,
+          state: runtime.state,
+          retry: runtime.retry,
+          logger: api.logger,
+        })
+      })
+    }
+  },
 })
+
+function readPluginConfig(api: OpenClawPluginApi): Record<string, unknown> {
+  return api.pluginConfig ?? api.config?.plugins?.entries?.[PLUGIN_ID]?.config ?? {}
+}
+
+function debug(api: OpenClawPluginApi, enabled: boolean, message: string): void {
+  if (enabled) api.logger.debug(message)
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
 
 export default plugin

--- a/memind-integrations/openclaw/src/index.ts
+++ b/memind-integrations/openclaw/src/index.ts
@@ -80,7 +80,14 @@ const plugin = definePluginEntry({
           cwd,
           sessionKey: stringValue(hookCtx.sessionKey),
         })
-        return handleRecall({ cfg, client, identity, event: hookEvent, ctx: hookCtx, logger: api.logger })
+        return handleRecall({
+          cfg,
+          client,
+          identity,
+          event: hookEvent,
+          ctx: hookCtx,
+          logger: api.logger,
+        })
       })
     }
 

--- a/memind-integrations/openclaw/src/index.ts
+++ b/memind-integrations/openclaw/src/index.ts
@@ -1,0 +1,25 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk'
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry'
+
+const plugin = definePluginEntry({
+  id: 'memind-openclaw',
+  name: 'Memind Memory',
+  description: 'Memind memory backend for OpenClaw',
+  register(_api: OpenClawPluginApi) {},
+})
+
+export default plugin

--- a/memind-integrations/openclaw/src/recall.ts
+++ b/memind-integrations/openclaw/src/recall.ts
@@ -15,7 +15,12 @@
 import { readRecentContext, stripInjectedContext } from './content.js'
 import { formatMemindContext } from './format.js'
 import { isNonInteractiveTrigger } from './identity.js'
-import type { Identity, MemindMemoryClient, MemindOpenClawConfig, OpenClawMessage } from './types.js'
+import type {
+  Identity,
+  MemindMemoryClient,
+  MemindOpenClawConfig,
+  OpenClawMessage,
+} from './types.js'
 
 export type RecallInput = {
   cfg: MemindOpenClawConfig
@@ -26,12 +31,15 @@ export type RecallInput = {
   logger?: { warn(message: string): void; debug(message: string): void }
 }
 
-export async function handleRecall(input: RecallInput): Promise<Record<string, string> | undefined> {
+export async function handleRecall(
+  input: RecallInput,
+): Promise<Record<string, string> | undefined> {
   const { cfg, client, identity, event, ctx, logger } = input
   if (!cfg.autoRetrieve) return undefined
   const trigger = typeof ctx?.trigger === 'string' ? ctx.trigger : undefined
   const sessionKey = typeof ctx?.sessionKey === 'string' ? ctx.sessionKey : undefined
-  if (cfg.skipNonInteractiveTriggers && isNonInteractiveTrigger(trigger, sessionKey)) return undefined
+  if (cfg.skipNonInteractiveTriggers && isNonInteractiveTrigger(trigger, sessionKey))
+    return undefined
 
   const prompt = extractPrompt(event)
   if (!prompt || prompt.length < 5 || isBootstrapPrompt(prompt)) return undefined

--- a/memind-integrations/openclaw/src/recall.ts
+++ b/memind-integrations/openclaw/src/recall.ts
@@ -1,0 +1,82 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { readRecentContext, stripInjectedContext } from './content.js'
+import { formatMemindContext } from './format.js'
+import { isNonInteractiveTrigger } from './identity.js'
+import type { Identity, MemindMemoryClient, MemindOpenClawConfig, OpenClawMessage } from './types.js'
+
+export type RecallInput = {
+  cfg: MemindOpenClawConfig
+  client: MemindMemoryClient
+  identity: Identity
+  event: Record<string, unknown>
+  ctx?: Record<string, unknown>
+  logger?: { warn(message: string): void; debug(message: string): void }
+}
+
+export async function handleRecall(input: RecallInput): Promise<Record<string, string> | undefined> {
+  const { cfg, client, identity, event, ctx, logger } = input
+  if (!cfg.autoRetrieve) return undefined
+  const trigger = typeof ctx?.trigger === 'string' ? ctx.trigger : undefined
+  const sessionKey = typeof ctx?.sessionKey === 'string' ? ctx.sessionKey : undefined
+  if (cfg.skipNonInteractiveTriggers && isNonInteractiveTrigger(trigger, sessionKey)) return undefined
+
+  const prompt = extractPrompt(event)
+  if (!prompt || prompt.length < 5 || isBootstrapPrompt(prompt)) return undefined
+  const recent = Array.isArray(event.messages)
+    ? readRecentContext(event.messages as OpenClawMessage[], cfg)
+    : ''
+  const query = recent ? `${recent}\ncurrent: ${prompt}` : prompt
+
+  try {
+    const result = await client.retrieve(
+      {
+        userId: identity.userId,
+        agentId: identity.agentId,
+        query,
+        strategy: cfg.retrieveStrategy,
+        trace: false,
+      },
+      { timeoutMs: 12_000, maxRetries: 0 },
+    )
+    const context = formatMemindContext(result, cfg)
+    if (!context) return undefined
+    if (cfg.recallInjectionPosition === 'system-prepend') return { prependSystemContext: context }
+    if (cfg.recallInjectionPosition === 'system-append') return { appendSystemContext: context }
+    return { prependContext: context }
+  } catch (error: unknown) {
+    logger?.warn(`memind-openclaw: recall failed: ${String(error)}`)
+    return undefined
+  }
+}
+
+function extractPrompt(event: Record<string, unknown>): string {
+  const raw =
+    typeof event.rawMessage === 'string'
+      ? event.rawMessage
+      : typeof event.prompt === 'string'
+        ? event.prompt
+        : ''
+  return stripInjectedContext(raw)
+}
+
+function isBootstrapPrompt(prompt: string): boolean {
+  const lower = prompt.toLowerCase()
+  return (
+    lower.includes('a new session was started') ||
+    lower.includes('session startup sequence') ||
+    lower.includes('/new or /reset')
+  )
+}

--- a/memind-integrations/openclaw/src/retry.ts
+++ b/memind-integrations/openclaw/src/retry.ts
@@ -1,0 +1,135 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+
+import type { RawContentValue } from '@openmemind/memind'
+
+export type RetryEntry = {
+  version?: 1
+  kind: 'extract'
+  userId: string
+  agentId: string
+  sourceClient: string
+  sessionKey: string
+  fingerprints: string[]
+  rawContent: RawContentValue
+  createdAt?: string
+}
+
+export type RetryOptions = {
+  maxFiles: number
+  maxAgeDays: number
+}
+
+export class RetrySpool {
+  constructor(
+    private readonly root: string,
+    private readonly options: RetryOptions,
+  ) {}
+
+  async enqueue(entry: RetryEntry): Promise<void> {
+    if (this.options.maxFiles <= 0) return
+    await mkdir(this.root, { recursive: true })
+    await this.prune()
+    const enriched: RetryEntry = {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      ...entry,
+    }
+    await writeFile(
+      path.join(this.root, `${Date.now()}-${randomUUID()}.json`),
+      JSON.stringify(enriched, null, 2),
+      'utf8',
+    )
+    await this.prune()
+  }
+
+  async flush(client: {
+    extract(request: {
+      userId: string
+      agentId: string
+      rawContent: RawContentValue
+      sourceClient?: string
+    }): Promise<{ status: string }>
+  }): Promise<number> {
+    await mkdir(this.root, { recursive: true })
+    await this.prune()
+    let flushed = 0
+    for (const file of await this.files()) {
+      const full = path.join(this.root, file)
+      try {
+        const entry = JSON.parse(await readFile(full, 'utf8')) as RetryEntry
+        const result = await client.extract({
+          userId: entry.userId,
+          agentId: entry.agentId,
+          rawContent: entry.rawContent,
+          sourceClient: entry.sourceClient,
+        })
+        if (result.status === 'SUCCESS') {
+          await rm(full, { force: true })
+          flushed += 1
+        }
+      } catch (error: unknown) {
+        if (error instanceof SyntaxError) {
+          await this.quarantine(full, file)
+        }
+      }
+    }
+    return flushed
+  }
+
+  async size(): Promise<number> {
+    return (await this.files()).length
+  }
+
+  private async prune(): Promise<void> {
+    const files = await this.files()
+    const now = Date.now()
+    for (const file of files) {
+      const full = path.join(this.root, file)
+      const info = await stat(full)
+      const ageDays = (now - info.mtimeMs) / 86_400_000
+      if (ageDays > this.options.maxAgeDays) await rm(full, { force: true })
+    }
+    const remaining = await this.files()
+    const overflow = remaining.length - this.options.maxFiles
+    if (overflow > 0) {
+      for (const file of remaining.slice(0, overflow)) {
+        await rm(path.join(this.root, file), { force: true })
+      }
+    }
+  }
+
+  private async files(): Promise<string[]> {
+    try {
+      return (await readdir(this.root)).filter((file) => file.endsWith('.json')).sort()
+    } catch {
+      return []
+    }
+  }
+
+  private async quarantine(fullPath: string, file: string): Promise<void> {
+    const quarantineDir = path.join(this.root, 'quarantine')
+    await mkdir(quarantineDir, { recursive: true })
+    await writeFile(
+      path.join(quarantineDir, `${Date.now()}-${file}`),
+      await readFile(fullPath, 'utf8').catch(() => ''),
+      'utf8',
+    )
+    await rm(fullPath, { force: true })
+  }
+}

--- a/memind-integrations/openclaw/src/runtime.ts
+++ b/memind-integrations/openclaw/src/runtime.ts
@@ -1,0 +1,73 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import path from 'node:path'
+
+import { RetrySpool } from './retry.js'
+import { SubmittedStateStore } from './state.js'
+import type { MemindOpenClawConfig } from './types.js'
+
+export type RuntimeStores = {
+  stateRoot: string
+  retryRoot?: string
+  state: SubmittedStateStore
+  retry?: RetrySpool
+}
+
+export function resolveWorkspaceDir(
+  event: Record<string, unknown> | undefined,
+  ctx: Record<string, unknown> | undefined,
+  fallback: string,
+): string {
+  return (
+    stringValue(ctx?.workspaceDir) ??
+    stringValue(ctx?.cwd) ??
+    stringValue(event?.workspaceDir) ??
+    stringValue(event?.cwd) ??
+    fallback
+  )
+}
+
+export function createRuntimeStores(
+  cfg: MemindOpenClawConfig,
+  getStateDir: () => string,
+): { current(): RuntimeStores } {
+  let cachedDir: string | undefined
+  let cached: RuntimeStores | undefined
+  return {
+    current(): RuntimeStores {
+      const stateDir = getStateDir()
+      if (cached && cachedDir === stateDir) return cached
+      const stateRoot = path.join(stateDir, 'state')
+      const retryRoot = path.join(stateDir, 'retry')
+      cachedDir = stateDir
+      cached = {
+        stateRoot,
+        retryRoot: cfg.ingestRetrySpool ? retryRoot : undefined,
+        state: new SubmittedStateStore(stateRoot, { maxAgeDays: cfg.stateMaxAgeDays }),
+        retry: cfg.ingestRetrySpool
+          ? new RetrySpool(retryRoot, {
+              maxFiles: cfg.ingestRetryMaxFiles,
+              maxAgeDays: cfg.ingestRetryMaxAgeDays,
+            })
+          : undefined,
+      }
+      return cached
+    },
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}

--- a/memind-integrations/openclaw/src/state.ts
+++ b/memind-integrations/openclaw/src/state.ts
@@ -1,0 +1,69 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+type StateFile = {
+  version: 1
+  submitted: string[]
+}
+
+export class SubmittedStateStore {
+  constructor(
+    private readonly root: string,
+    private readonly options: { maxAgeDays: number },
+  ) {}
+
+  async filterUnsubmitted(sessionKey: string, fingerprints: string[]): Promise<string[]> {
+    const state = await this.read(sessionKey)
+    const submitted = new Set(state.submitted)
+    return fingerprints.filter((fingerprint) => !submitted.has(fingerprint))
+  }
+
+  async markSubmitted(sessionKey: string, fingerprints: string[]): Promise<void> {
+    const state = await this.read(sessionKey)
+    const next = new Set(state.submitted)
+    fingerprints.forEach((fingerprint) => next.add(fingerprint))
+    await this.write(sessionKey, { version: 1, submitted: [...next].sort() })
+  }
+
+  private async read(sessionKey: string): Promise<StateFile> {
+    try {
+      const statePath = this.pathFor(sessionKey)
+      const info = await stat(statePath)
+      const ageDays = (Date.now() - info.mtimeMs) / 86_400_000
+      if (ageDays > this.options.maxAgeDays) return { version: 1, submitted: [] }
+      const raw = await readFile(statePath, 'utf8')
+      const parsed = JSON.parse(raw) as StateFile
+      if (parsed.version === 1 && Array.isArray(parsed.submitted)) return parsed
+    } catch {
+      return { version: 1, submitted: [] }
+    }
+    return { version: 1, submitted: [] }
+  }
+
+  private async write(sessionKey: string, state: StateFile): Promise<void> {
+    await mkdir(this.root, { recursive: true })
+    await writeFile(this.pathFor(sessionKey), JSON.stringify(state, null, 2), 'utf8')
+  }
+
+  private pathFor(sessionKey: string): string {
+    return path.join(this.root, `${safeKey(sessionKey)}.json`)
+  }
+}
+
+export function safeKey(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]+/g, '_') || 'default'
+}

--- a/memind-integrations/openclaw/src/types.ts
+++ b/memind-integrations/openclaw/src/types.ts
@@ -1,0 +1,107 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type {
+  ExtractMemoryResponse,
+  MessageValue,
+  RawContentValue,
+  RetrieveMemoryResponse,
+} from '@openmemind/memind'
+
+export type SecretRef = {
+  source: string
+  provider?: string
+  id: string
+}
+
+export type AgentIdMode = 'project' | 'fixed' | 'session'
+export type RecallInjectionPosition = 'context' | 'system-prepend' | 'system-append'
+export type IngestionRole = 'user' | 'assistant'
+export type SlotConfigLike = {
+  slots?: Record<string, string>
+  memoryPluginId?: string
+}
+
+export type MemindOpenClawConfig = {
+  memindApiUrl: string
+  memindApiToken?: string | SecretRef
+  userId?: string
+  agentId: string
+  agentIdMode: AgentIdMode
+  sourceClient: string
+  autoRetrieve: boolean
+  autoIngest: boolean
+  retrieveStrategy: 'SIMPLE'
+  retrieveMaxEntries: number
+  retrieveMaxChars: number
+  retrieveContextTurns: number
+  retrievePromptPreamble: string
+  recallInjectionPosition: RecallInjectionPosition
+  ingestionRoles: IngestionRole[]
+  ingestionMaxMessagesPerHook: number
+  ingestRetrySpool: boolean
+  stateMaxAgeDays: number
+  ingestRetryMaxFiles: number
+  ingestRetryMaxAgeDays: number
+  captureToolCalls: boolean
+  captureMedia: boolean
+  skipNonInteractiveTriggers: boolean
+  captureSubagents: boolean
+  debug: boolean
+}
+
+export type OpenClawMessage = {
+  role?: string
+  content?: unknown
+  timestamp?: string | number
+  userName?: string
+  user_name?: string
+  id?: string
+  uuid?: string
+  toolCallId?: string
+  [key: string]: unknown
+}
+
+export type NormalizedMessage = MessageValue & {
+  fingerprint: string
+}
+
+export type Identity = {
+  userId: string
+  agentId: string
+  sourceClient: string
+  sessionKey?: string
+}
+
+export type MemindMemoryClient = {
+  retrieve(
+    request: {
+      userId: string
+      agentId: string
+      query: string
+      strategy: 'SIMPLE'
+      trace?: boolean
+    },
+    options?: { timeoutMs?: number; maxRetries?: number; signal?: AbortSignal },
+  ): Promise<RetrieveMemoryResponse>
+  extract(
+    request: {
+      userId: string
+      agentId: string
+      rawContent: RawContentValue
+      sourceClient?: string
+    },
+    options?: { timeoutMs?: number; maxRetries?: number; signal?: AbortSignal },
+  ): Promise<ExtractMemoryResponse>
+}

--- a/memind-integrations/openclaw/test-shims/plugin-entry.ts
+++ b/memind-integrations/openclaw/test-shims/plugin-entry.ts
@@ -1,0 +1,17 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+export function definePluginEntry<T>(entry: T): T {
+  return entry
+}

--- a/memind-integrations/openclaw/test-shims/plugin-sdk.ts
+++ b/memind-integrations/openclaw/test-shims/plugin-sdk.ts
@@ -1,0 +1,15 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+export {}

--- a/memind-integrations/openclaw/tests/capture.test.ts
+++ b/memind-integrations/openclaw/tests/capture.test.ts
@@ -19,7 +19,12 @@ import { parseConfig } from '../src/config.js'
 import { handleCapture } from '../src/capture.js'
 import type { Identity, MemindMemoryClient } from '../src/types.js'
 
-const identity: Identity = { userId: 'u1', agentId: 'a1', sourceClient: 'openclaw', sessionKey: 's1' }
+const identity: Identity = {
+  userId: 'u1',
+  agentId: 'a1',
+  sourceClient: 'openclaw',
+  sessionKey: 's1',
+}
 
 function successfulExtractResponse(): ExtractMemoryResponse {
   return {
@@ -97,7 +102,10 @@ describe('handleCapture', () => {
         rawContent: expect.objectContaining({
           type: 'conversation',
           messages: [
-            expect.objectContaining({ role: 'USER', content: [{ type: 'text', text: 'new question' }] }),
+            expect.objectContaining({
+              role: 'USER',
+              content: [{ type: 'text', text: 'new question' }],
+            }),
             expect.objectContaining({
               role: 'ASSISTANT',
               content: [{ type: 'text', text: 'new answer' }],

--- a/memind-integrations/openclaw/tests/capture.test.ts
+++ b/memind-integrations/openclaw/tests/capture.test.ts
@@ -1,0 +1,184 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type { ExtractMemoryResponse } from '@openmemind/memind'
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import { handleCapture } from '../src/capture.js'
+import type { Identity, MemindMemoryClient } from '../src/types.js'
+
+const identity: Identity = { userId: 'u1', agentId: 'a1', sourceClient: 'openclaw', sessionKey: 's1' }
+
+function successfulExtractResponse(): ExtractMemoryResponse {
+  return {
+    status: 'SUCCESS',
+    rawDataIds: [],
+    itemIds: [],
+    insightIds: [],
+    insightPending: false,
+  }
+}
+
+describe('handleCapture', () => {
+  it('extracts successful turns and marks submitted fingerprints', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn(),
+      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
+    }
+    const state = {
+      filterUnsubmitted: vi
+        .fn()
+        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
+      markSubmitted: vi.fn().mockResolvedValue(undefined),
+    }
+    const result = await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: { success: true, messages: [{ role: 'user', content: 'remember me', id: 'f1' }] },
+      ctx: { sessionKey: 's1' },
+      state,
+    })
+    expect(result.submitted).toBe(1)
+    expect(client.extract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'u1',
+        agentId: 'a1',
+        sourceClient: 'openclaw',
+      }),
+      expect.objectContaining({ maxRetries: 0 }),
+    )
+    expect(state.markSubmitted).toHaveBeenCalledWith('s1', expect.any(Array))
+  })
+
+  it('keeps only the final turn by default', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn(),
+      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
+    }
+    const state = {
+      filterUnsubmitted: vi
+        .fn()
+        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
+      markSubmitted: vi.fn().mockResolvedValue(undefined),
+    }
+    await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: {
+        success: true,
+        messages: [
+          { role: 'user', content: 'old question', id: 'old-u' },
+          { role: 'assistant', content: 'old answer', id: 'old-a' },
+          { role: 'user', content: 'new question', id: 'new-u' },
+          { role: 'assistant', content: 'new answer', id: 'new-a' },
+        ],
+      },
+      ctx: { sessionKey: 's1' },
+      state,
+    })
+    expect(client.extract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawContent: expect.objectContaining({
+          type: 'conversation',
+          messages: [
+            expect.objectContaining({ role: 'USER', content: [{ type: 'text', text: 'new question' }] }),
+            expect.objectContaining({
+              role: 'ASSISTANT',
+              content: [{ type: 'text', text: 'new answer' }],
+            }),
+          ],
+        }),
+      }),
+      expect.any(Object),
+    )
+  })
+
+  it('respects ingestionMaxMessagesPerHook after final-turn selection', async () => {
+    const cfg = parseConfig({ ingestionMaxMessagesPerHook: 1 })
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn(),
+      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
+    }
+    const state = {
+      filterUnsubmitted: vi
+        .fn()
+        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
+      markSubmitted: vi.fn().mockResolvedValue(undefined),
+    }
+    const result = await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: {
+        success: true,
+        messages: [
+          { role: 'user', content: 'new question', id: 'new-u' },
+          { role: 'assistant', content: 'new answer', id: 'new-a' },
+        ],
+      },
+      ctx: { sessionKey: 's1' },
+      state,
+    })
+    expect(result.submitted).toBe(1)
+    expect(state.markSubmitted).toHaveBeenCalledWith(
+      's1',
+      expect.arrayContaining([expect.any(String)]),
+    )
+  })
+
+  it('skips failed turns', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = { retrieve: vi.fn(), extract: vi.fn() }
+    const result = await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: { success: false, messages: [{ role: 'user', content: 'no' }] },
+      ctx: { sessionKey: 's1' },
+      state: { filterUnsubmitted: vi.fn(), markSubmitted: vi.fn() },
+    })
+    expect(result.submitted).toBe(0)
+    expect(client.extract).not.toHaveBeenCalled()
+  })
+
+  it('spools failed extraction', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn(),
+      extract: vi.fn().mockRejectedValue(new Error('down')),
+    }
+    const retry = { enqueue: vi.fn().mockResolvedValue(undefined) }
+    const result = await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: { success: true, messages: [{ role: 'user', content: 'remember me' }] },
+      ctx: { sessionKey: 's1' },
+      state: {
+        filterUnsubmitted: vi
+          .fn()
+          .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
+        markSubmitted: vi.fn(),
+      },
+      retry,
+    })
+    expect(result.submitted).toBe(0)
+    expect(retry.enqueue).toHaveBeenCalled()
+  })
+})

--- a/memind-integrations/openclaw/tests/client.test.ts
+++ b/memind-integrations/openclaw/tests/client.test.ts
@@ -1,0 +1,33 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveToken } from '../src/client.js'
+
+describe('resolveToken', () => {
+  it('returns string tokens', () => {
+    expect(resolveToken('abc')).toBe('abc')
+  })
+
+  it('resolves env SecretRef values', () => {
+    expect(resolveToken({ source: 'env', id: 'MEMIND_TOKEN' }, { MEMIND_TOKEN: 'secret' })).toBe(
+      'secret',
+    )
+  })
+
+  it('returns undefined for unresolved SecretRef values', () => {
+    expect(resolveToken({ source: 'env', id: 'MISSING' }, {})).toBeUndefined()
+  })
+})

--- a/memind-integrations/openclaw/tests/config.test.ts
+++ b/memind-integrations/openclaw/tests/config.test.ts
@@ -1,0 +1,95 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_CONFIG, parseConfig, shouldRunAutomaticHooks } from '../src/config.js'
+
+describe('parseConfig', () => {
+  it('applies safe defaults', () => {
+    const cfg = parseConfig({})
+    expect(cfg.memindApiUrl).toBe('http://127.0.0.1:8366')
+    expect(cfg.agentId).toBe('openclaw')
+    expect(cfg.agentIdMode).toBe('project')
+    expect(cfg.sourceClient).toBe('openclaw')
+    expect(cfg.autoRetrieve).toBe(true)
+    expect(cfg.autoIngest).toBe(true)
+    expect(cfg.captureToolCalls).toBe(false)
+    expect(cfg.captureMedia).toBe(false)
+    expect(cfg.captureSubagents).toBe(false)
+  })
+
+  it('accepts explicit config values', () => {
+    const cfg = parseConfig({
+      memindApiUrl: 'http://localhost:9999/',
+      memindApiToken: 'token',
+      userId: 'u1',
+      agentId: 'agent',
+      agentIdMode: 'fixed',
+      autoRetrieve: false,
+      retrieveMaxEntries: 3,
+      ingestionRoles: ['user'],
+    })
+    expect(cfg.memindApiUrl).toBe('http://localhost:9999')
+    expect(cfg.memindApiToken).toBe('token')
+    expect(cfg.userId).toBe('u1')
+    expect(cfg.agentId).toBe('agent')
+    expect(cfg.agentIdMode).toBe('fixed')
+    expect(cfg.autoRetrieve).toBe(false)
+    expect(cfg.retrieveMaxEntries).toBe(3)
+    expect(cfg.ingestionRoles).toEqual(['user'])
+  })
+
+  it('accepts SecretRef-shaped token values without inspecting secrets', () => {
+    const token = { source: 'env', provider: 'default', id: 'MEMIND_API_TOKEN' }
+    const cfg = parseConfig({ memindApiToken: token })
+    expect(cfg.memindApiToken).toBe(token)
+  })
+
+  it('rejects unknown keys', () => {
+    expect(() => parseConfig({ unknown: true })).toThrow('unknown keys: unknown')
+  })
+
+  it('rejects invalid numeric values', () => {
+    expect(() => parseConfig({ retrieveMaxEntries: 0 })).toThrow('retrieveMaxEntries')
+    expect(() => parseConfig({ ingestRetryMaxFiles: -1 })).toThrow('ingestRetryMaxFiles')
+  })
+
+  it('rejects unsupported retrieve strategies and reserved capture switches', () => {
+    expect(() => parseConfig({ retrieveStrategy: 'DEEP' })).toThrow('retrieveStrategy')
+    expect(() => parseConfig({ captureToolCalls: true })).toThrow('captureToolCalls')
+    expect(() => parseConfig({ captureMedia: true })).toThrow('captureMedia')
+  })
+})
+
+describe('shouldRunAutomaticHooks', () => {
+  it('runs hooks only when selected in the memory slot or the legacy memoryPluginId field', () => {
+    expect(shouldRunAutomaticHooks('memind-openclaw', { slots: { memory: 'memind-openclaw' } })).toBe(
+      true,
+    )
+    expect(shouldRunAutomaticHooks('memind-openclaw', { memoryPluginId: 'memind-openclaw' })).toBe(
+      true,
+    )
+    expect(shouldRunAutomaticHooks('memind-openclaw', { slots: { memory: 'openclaw-mem0' } })).toBe(
+      false,
+    )
+    expect(shouldRunAutomaticHooks('memind-openclaw', undefined)).toBe(false)
+  })
+})
+
+describe('DEFAULT_CONFIG', () => {
+  it('keeps documented defaults in one object', () => {
+    expect(DEFAULT_CONFIG.retrievePromptPreamble).toContain('Relevant memories from Memind')
+  })
+})

--- a/memind-integrations/openclaw/tests/config.test.ts
+++ b/memind-integrations/openclaw/tests/config.test.ts
@@ -75,9 +75,9 @@ describe('parseConfig', () => {
 
 describe('shouldRunAutomaticHooks', () => {
   it('runs hooks only when selected in the memory slot or the legacy memoryPluginId field', () => {
-    expect(shouldRunAutomaticHooks('memind-openclaw', { slots: { memory: 'memind-openclaw' } })).toBe(
-      true,
-    )
+    expect(
+      shouldRunAutomaticHooks('memind-openclaw', { slots: { memory: 'memind-openclaw' } }),
+    ).toBe(true)
     expect(shouldRunAutomaticHooks('memind-openclaw', { memoryPluginId: 'memind-openclaw' })).toBe(
       true,
     )

--- a/memind-integrations/openclaw/tests/content.test.ts
+++ b/memind-integrations/openclaw/tests/content.test.ts
@@ -1,0 +1,141 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import {
+  extractMessages,
+  readRecentContext,
+  stripInjectedContext,
+  textFromContent,
+} from '../src/content.js'
+
+describe('stripInjectedContext', () => {
+  it('removes Memind and OpenClaw metadata envelopes', () => {
+    const text = [
+      'Sender (untrusted metadata): ```json',
+      '{"id":"u1"}',
+      '```',
+      '<memind_memories>old memory</memind_memories>',
+      'Actual prompt',
+    ].join('\n')
+    expect(stripInjectedContext(text)).toBe('Actual prompt')
+  })
+})
+
+describe('textFromContent', () => {
+  it('extracts string content', () => {
+    expect(textFromContent('hello')).toBe('hello')
+  })
+
+  it('extracts text blocks only by default', () => {
+    const text = textFromContent([
+      { type: 'text', text: 'one' },
+      { type: 'image', source: { type: 'url', url: 'https://example.com/a.png' } },
+      { type: 'toolCall', name: 'shell', arguments: { cmd: 'pwd' } },
+      { type: 'text', text: 'two' },
+    ])
+    expect(text).toBe('one\n\ntwo')
+  })
+})
+
+describe('extractMessages', () => {
+  it('normalizes user and assistant messages', () => {
+    const cfg = parseConfig({})
+    const messages = extractMessages(
+      [
+        { role: 'user', content: 'hello', id: 'u1', timestamp: '2026-05-14T00:00:00Z' },
+        { role: 'assistant', content: [{ type: 'text', text: 'hi' }], id: 'a1' },
+      ],
+      cfg,
+    )
+    expect(messages).toHaveLength(2)
+    const [first, second] = messages
+    if (!first || !second) {
+      throw new Error('expected two extracted messages')
+    }
+    expect(first).toMatchObject({
+      role: 'USER',
+      content: [{ type: 'text', text: 'hello' }],
+      timestamp: '2026-05-14T00:00:00Z',
+    })
+    expect(second).toMatchObject({ role: 'ASSISTANT' })
+    expect(first.fingerprint).not.toBe(second.fingerprint)
+  })
+
+  it('drops unsupported roles and empty messages', () => {
+    const cfg = parseConfig({})
+    const messages = extractMessages(
+      [
+        { role: 'system', content: 'system' },
+        { role: 'toolResult', content: 'result' },
+        { role: 'user', content: '   ' },
+        { role: 'assistant', content: '[Response interrupted by user]' },
+      ],
+      cfg,
+    )
+    expect(messages).toEqual([])
+  })
+
+  it('ignores tool calls when captureToolCalls is false', () => {
+    const cfg = parseConfig({})
+    const messages = extractMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'using tool' },
+            { type: 'toolCall', name: 'shell' },
+          ],
+        },
+      ],
+      cfg,
+    )
+    expect(messages).toEqual([])
+  })
+
+  it('ignores multimodal messages when captureMedia is false', () => {
+    const cfg = parseConfig({})
+    const messages = extractMessages(
+      [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'see this' },
+            { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } },
+          ],
+        },
+      ],
+      cfg,
+    )
+    expect(messages).toEqual([])
+  })
+})
+
+describe('readRecentContext', () => {
+  it('uses the last N turns', () => {
+    const cfg = parseConfig({ retrieveContextTurns: 1 })
+    const context = readRecentContext(
+      [
+        { role: 'user', content: 'old user' },
+        { role: 'assistant', content: 'old assistant' },
+        { role: 'user', content: 'new user' },
+        { role: 'assistant', content: 'new assistant' },
+      ],
+      cfg,
+    )
+    expect(context).toBe('user: new user\nassistant: new assistant')
+  })
+})

--- a/memind-integrations/openclaw/tests/format.test.ts
+++ b/memind-integrations/openclaw/tests/format.test.ts
@@ -41,7 +41,9 @@ describe('formatMemindContext', () => {
 
   it('returns empty string when no memories are available', () => {
     const cfg = parseConfig({})
-    expect(formatMemindContext({ insights: [], items: [], rawData: [], evidences: [] }, cfg)).toBe('')
+    expect(formatMemindContext({ insights: [], items: [], rawData: [], evidences: [] }, cfg)).toBe(
+      '',
+    )
   })
 
   it('respects max chars', () => {

--- a/memind-integrations/openclaw/tests/format.test.ts
+++ b/memind-integrations/openclaw/tests/format.test.ts
@@ -1,0 +1,86 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import { formatMemindContext } from '../src/format.js'
+
+describe('formatMemindContext', () => {
+  it('formats high-level insights before items', () => {
+    const cfg = parseConfig({ retrieveMaxEntries: 3 })
+    const text = formatMemindContext(
+      {
+        insights: [
+          { id: 'leaf', text: 'leaf insight', tier: 'LEAF' },
+          { id: 'root', text: 'root insight', tier: 'ROOT' },
+        ],
+        items: [{ id: 'item-1', text: 'item text', vectorScore: 0.3, finalScore: 0.9 }],
+        rawData: [],
+        evidences: [],
+      },
+      cfg,
+    )
+    expect(text).toContain('<memind_memories>')
+    expect(text).toContain('## Insights')
+    expect(text).toContain('[insight:root] root insight')
+    expect(text).toContain('## Memory Items')
+    expect(text).toContain('[item:item-1] item text')
+  })
+
+  it('returns empty string when no memories are available', () => {
+    const cfg = parseConfig({})
+    expect(formatMemindContext({ insights: [], items: [], rawData: [], evidences: [] }, cfg)).toBe('')
+  })
+
+  it('respects max chars', () => {
+    const cfg = parseConfig({ retrieveMaxChars: 80 })
+    const text = formatMemindContext(
+      {
+        insights: [],
+        items: [{ id: 'item-1', text: 'x'.repeat(500), vectorScore: 0.1, finalScore: 0.2 }],
+        rawData: [],
+        evidences: [],
+      },
+      cfg,
+    )
+    const body = text
+      .replace(/^<memind_memories>\n/, '')
+      .replace(`${cfg.retrievePromptPreamble}\n`, '')
+      .replace(/\n<\/memind_memories>$/, '')
+    expect(body.length).toBeLessThanOrEqual(80)
+  })
+
+  it('keeps the memory envelope valid when truncating', () => {
+    const cfg = parseConfig({ retrieveMaxChars: 12 })
+    const text = formatMemindContext(
+      {
+        insights: [],
+        items: [
+          {
+            id: 'item-1',
+            text: 'abcdefghijklmnopqrstuvwxyz',
+            vectorScore: 0.1,
+            finalScore: 0.2,
+          },
+        ],
+        rawData: [],
+        evidences: [],
+      },
+      cfg,
+    )
+    expect(text).toContain('</memind_memories>')
+    expect(text).toContain('[truncated]')
+  })
+})

--- a/memind-integrations/openclaw/tests/identity.test.ts
+++ b/memind-integrations/openclaw/tests/identity.test.ts
@@ -1,0 +1,76 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import {
+  isNonInteractiveTrigger,
+  isSubagentSession,
+  resolveIdentity,
+  sanitizeIdentityPart,
+} from '../src/identity.js'
+
+describe('resolveIdentity', () => {
+  it('uses configured userId and fixed agentId', () => {
+    const cfg = parseConfig({ userId: 'u1', agentId: 'agent', agentIdMode: 'fixed' })
+    const id = resolveIdentity(cfg, { cwd: '/tmp/project', sessionKey: 'agent:main:main' })
+    expect(id).toEqual({
+      userId: 'u1',
+      agentId: 'agent',
+      sourceClient: 'openclaw',
+      sessionKey: 'agent:main:main',
+    })
+  })
+
+  it('falls back to local system user', () => {
+    const cfg = parseConfig({ agentIdMode: 'fixed' })
+    const id = resolveIdentity(cfg, { systemUser: 'alice' })
+    expect(id.userId).toBe('local__alice')
+  })
+
+  it('adds stable project suffix in project mode', () => {
+    const cfg = parseConfig({ userId: 'u1', agentId: 'openclaw' })
+    const first = resolveIdentity(cfg, { cwd: '/repo/a', gitRemoteUrl: 'git@github.com:x/y.git' })
+    const second = resolveIdentity(cfg, { cwd: '/different', gitRemoteUrl: 'git@github.com:x/y.git' })
+    expect(first.agentId).toMatch(/^openclaw__y-[a-f0-9]{10}$/)
+    expect(second.agentId).toBe(first.agentId)
+  })
+
+  it('uses session suffix in session mode', () => {
+    const cfg = parseConfig({ userId: 'u1', agentId: 'openclaw', agentIdMode: 'session' })
+    const id = resolveIdentity(cfg, { sessionKey: 'agent:main:session:123' })
+    expect(id.agentId).toMatch(/^openclaw__session-[a-f0-9]{10}$/)
+  })
+})
+
+describe('session classification', () => {
+  it('detects subagent sessions', () => {
+    expect(isSubagentSession('agent:main:subagent:abc')).toBe(true)
+    expect(isSubagentSession('agent:main:main')).toBe(false)
+  })
+
+  it('detects non-interactive triggers', () => {
+    expect(isNonInteractiveTrigger('cron', 'agent:main:main')).toBe(true)
+    expect(isNonInteractiveTrigger(undefined, 'agent:main:heartbeat:1')).toBe(true)
+    expect(isNonInteractiveTrigger('user', 'agent:main:main')).toBe(false)
+  })
+})
+
+describe('sanitizeIdentityPart', () => {
+  it('normalizes unsafe identity fragments', () => {
+    expect(sanitizeIdentityPart('Hello World/Repo.git')).toBe('repo')
+    expect(sanitizeIdentityPart('')).toBe('default')
+  })
+})

--- a/memind-integrations/openclaw/tests/identity.test.ts
+++ b/memind-integrations/openclaw/tests/identity.test.ts
@@ -43,7 +43,10 @@ describe('resolveIdentity', () => {
   it('adds stable project suffix in project mode', () => {
     const cfg = parseConfig({ userId: 'u1', agentId: 'openclaw' })
     const first = resolveIdentity(cfg, { cwd: '/repo/a', gitRemoteUrl: 'git@github.com:x/y.git' })
-    const second = resolveIdentity(cfg, { cwd: '/different', gitRemoteUrl: 'git@github.com:x/y.git' })
+    const second = resolveIdentity(cfg, {
+      cwd: '/different',
+      gitRemoteUrl: 'git@github.com:x/y.git',
+    })
     expect(first.agentId).toMatch(/^openclaw__y-[a-f0-9]{10}$/)
     expect(second.agentId).toBe(first.agentId)
   })

--- a/memind-integrations/openclaw/tests/index.test.ts
+++ b/memind-integrations/openclaw/tests/index.test.ts
@@ -1,0 +1,107 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it, vi } from 'vitest'
+
+import plugin from '../src/index.js'
+
+type HookHandler = (...args: unknown[]) => unknown | Promise<unknown>
+type RegisteredService = { start(args: { stateDir?: string }): void; stop(): void }
+type TestApi = ReturnType<typeof api>['api']
+type OptionalPluginConfigApi = Omit<TestApi, 'pluginConfig'> & { pluginConfig?: Record<string, unknown> }
+
+function api(slots: Record<string, string> | undefined = { memory: 'memind-openclaw' }) {
+  const handlers: Record<string, HookHandler> = {}
+  return {
+    api: {
+      pluginConfig: {},
+      config: { plugins: { slots, entries: {} } },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      on: vi.fn((event: string, handler: HookHandler) => {
+        handlers[event] = handler
+      }),
+      registerService: vi.fn(),
+    },
+    handlers,
+  }
+}
+
+describe('plugin entry', () => {
+  it('registers service and hooks when selected as memory slot', () => {
+    const fixture = api()
+    plugin.register(fixture.api as TestApi)
+    expect(fixture.api.registerService).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'memind-openclaw' }),
+    )
+    expect(fixture.api.on).toHaveBeenCalledWith('before_prompt_build', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('agent_end', expect.any(Function))
+  })
+
+  it('warns and skips hooks when not selected as memory slot', () => {
+    const fixture = api({ memory: 'openclaw-mem0' })
+    plugin.register(fixture.api as TestApi)
+    expect(fixture.api.registerService).toHaveBeenCalled()
+    expect(fixture.api.on).not.toHaveBeenCalled()
+    expect(fixture.api.logger.warn).toHaveBeenCalledWith(expect.stringContaining('not selected'))
+  })
+
+  it('reads config from plugin entries when pluginConfig is unavailable', () => {
+    const fixture = api()
+    const pluginConfigApi = fixture.api as OptionalPluginConfigApi
+    delete pluginConfigApi.pluginConfig
+    fixture.api.config.plugins.entries = {
+      'memind-openclaw': { enabled: true, config: { autoRetrieve: false } },
+    }
+    plugin.register(pluginConfigApi as TestApi)
+    expect(fixture.api.on).not.toHaveBeenCalledWith('before_prompt_build', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('agent_end', expect.any(Function))
+  })
+
+  it('registers a minimal memory capability marker when supported by OpenClaw', () => {
+    const fixture = api()
+    const registerMemoryCapability = vi.fn()
+    const apiWithCapability = { ...fixture.api, registerMemoryCapability }
+    plugin.register(apiWithCapability as TestApi & { registerMemoryCapability: typeof registerMemoryCapability })
+    expect(registerMemoryCapability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: expect.objectContaining({ provider: 'memind' }),
+      }),
+    )
+  })
+
+  it('uses OpenClaw stateDir and workspace context after service start', async () => {
+    const fixture = api()
+    fixture.api.pluginConfig = { debug: true, ingestRetrySpool: false }
+    plugin.register(fixture.api as TestApi)
+    const service = (fixture.api.registerService.mock.calls as Array<[RegisteredService]>)[0]?.[0]
+    expect(service).toBeDefined()
+    service?.start({ stateDir: '/tmp/openclaw-plugin-state' })
+    const agentEnd = fixture.handlers.agent_end
+    expect(agentEnd).toBeDefined()
+    await agentEnd?.(
+      {
+        success: false,
+        messages: [],
+      },
+      {
+        sessionKey: 'agent:main:main',
+        workspaceDir: '/repo/from-ctx',
+      },
+    )
+    expect(fixture.api.logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('/tmp/openclaw-plugin-state'),
+    )
+    expect(fixture.api.logger.debug).toHaveBeenCalledWith(expect.stringContaining('/repo/from-ctx'))
+  })
+})

--- a/memind-integrations/openclaw/tests/index.test.ts
+++ b/memind-integrations/openclaw/tests/index.test.ts
@@ -19,7 +19,9 @@ import plugin from '../src/index.js'
 type HookHandler = (...args: unknown[]) => unknown | Promise<unknown>
 type RegisteredService = { start(args: { stateDir?: string }): void; stop(): void }
 type TestApi = ReturnType<typeof api>['api']
-type OptionalPluginConfigApi = Omit<TestApi, 'pluginConfig'> & { pluginConfig?: Record<string, unknown> }
+type OptionalPluginConfigApi = Omit<TestApi, 'pluginConfig'> & {
+  pluginConfig?: Record<string, unknown>
+}
 
 function api(slots: Record<string, string> | undefined = { memory: 'memind-openclaw' }) {
   const handlers: Record<string, HookHandler> = {}
@@ -72,7 +74,9 @@ describe('plugin entry', () => {
     const fixture = api()
     const registerMemoryCapability = vi.fn()
     const apiWithCapability = { ...fixture.api, registerMemoryCapability }
-    plugin.register(apiWithCapability as TestApi & { registerMemoryCapability: typeof registerMemoryCapability })
+    plugin.register(
+      apiWithCapability as TestApi & { registerMemoryCapability: typeof registerMemoryCapability },
+    )
     expect(registerMemoryCapability).toHaveBeenCalledWith(
       expect.objectContaining({
         runtime: expect.objectContaining({ provider: 'memind' }),

--- a/memind-integrations/openclaw/tests/recall.test.ts
+++ b/memind-integrations/openclaw/tests/recall.test.ts
@@ -1,0 +1,80 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import { handleRecall } from '../src/recall.js'
+import type { Identity, MemindMemoryClient } from '../src/types.js'
+
+const identity: Identity = { userId: 'u1', agentId: 'a1', sourceClient: 'openclaw' }
+
+describe('handleRecall', () => {
+  it('retrieves and injects context', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn().mockResolvedValue({
+        insights: [],
+        items: [{ id: 'i1', text: 'remember this', vectorScore: 0.1, finalScore: 0.9 }],
+        rawData: [],
+        evidences: [],
+      }),
+      extract: vi.fn(),
+    }
+    const result = await handleRecall({
+      cfg,
+      client,
+      identity,
+      event: { rawMessage: 'what do you know?' },
+      ctx: {},
+    })
+    expect(client.retrieve).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u1', agentId: 'a1', query: 'what do you know?' }),
+      expect.objectContaining({ maxRetries: 0 }),
+    )
+    expect(result).toEqual({
+      prependContext: expect.stringContaining('<memind_memories>'),
+    })
+  })
+
+  it('fails open on retrieve errors', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn().mockRejectedValue(new Error('down')),
+      extract: vi.fn(),
+    }
+    const result = await handleRecall({
+      cfg,
+      client,
+      identity,
+      event: { rawMessage: 'hello' },
+      ctx: {},
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('skips non-interactive triggers', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = { retrieve: vi.fn(), extract: vi.fn() }
+    const result = await handleRecall({
+      cfg,
+      client,
+      identity,
+      event: { rawMessage: 'hello' },
+      ctx: { trigger: 'cron', sessionKey: 'agent:main:cron:1' },
+    })
+    expect(result).toBeUndefined()
+    expect(client.retrieve).not.toHaveBeenCalled()
+  })
+})

--- a/memind-integrations/openclaw/tests/retry.test.ts
+++ b/memind-integrations/openclaw/tests/retry.test.ts
@@ -1,0 +1,148 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { ExtractMemoryResponse } from '@openmemind/memind'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RetrySpool } from '../src/retry.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'memind-openclaw-retry-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+function successfulExtractResponse(): ExtractMemoryResponse {
+  return {
+    status: 'SUCCESS',
+    rawDataIds: [],
+    itemIds: [],
+    insightIds: [],
+    insightPending: false,
+  }
+}
+
+describe('RetrySpool', () => {
+  it('enqueues and flushes successful extract retries', async () => {
+    const spool = new RetrySpool(dir, { maxFiles: 20, maxAgeDays: 7 })
+    await spool.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f1'],
+      rawContent: { type: 'memind-openclaw-retry-test' },
+    })
+    const extract = vi.fn().mockResolvedValue(successfulExtractResponse())
+    const flushed = await spool.flush({ extract })
+    expect(flushed).toBe(1)
+    expect(await spool.size()).toBe(0)
+  })
+
+  it('keeps failed retries', async () => {
+    const spool = new RetrySpool(dir, { maxFiles: 20, maxAgeDays: 7 })
+    await spool.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f1'],
+      rawContent: { type: 'memind-openclaw-retry-test' },
+    })
+    const extract = vi.fn().mockResolvedValue({
+      ...successfulExtractResponse(),
+      status: 'FAILED',
+      errorMessage: 'server rejected retry',
+    })
+    const flushed = await spool.flush({ extract })
+    expect(flushed).toBe(0)
+    expect(await spool.size()).toBe(1)
+  })
+
+  it('continues flushing after corrupt retry files and failed requests', async () => {
+    const spool = new RetrySpool(dir, { maxFiles: 20, maxAgeDays: 7 })
+    await writeFile(path.join(dir, '000-corrupt.json'), '{not json', 'utf8')
+    await spool.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f1'],
+      rawContent: { type: 'first-retry' },
+    })
+    await spool.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f2'],
+      rawContent: { type: 'second-retry' },
+    })
+    const extract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce(successfulExtractResponse())
+    const flushed = await spool.flush({ extract })
+    expect(flushed).toBe(1)
+    expect(await spool.size()).toBe(1)
+    await expect(readdir(path.join(dir, 'quarantine'))).resolves.toHaveLength(1)
+  })
+
+  it('enforces maxFiles when enqueueing new retry entries', async () => {
+    const disabled = new RetrySpool(path.join(dir, 'disabled'), { maxFiles: 0, maxAgeDays: 7 })
+    await disabled.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f0'],
+      rawContent: { type: 'disabled-retry' },
+    })
+    expect(await disabled.size()).toBe(0)
+
+    const one = new RetrySpool(path.join(dir, 'one'), { maxFiles: 1, maxAgeDays: 7 })
+    await one.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f1'],
+      rawContent: { type: 'first-retry' },
+    })
+    await one.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['f2'],
+      rawContent: { type: 'second-retry' },
+    })
+    expect(await one.size()).toBe(1)
+  })
+})

--- a/memind-integrations/openclaw/tests/runtime.test.ts
+++ b/memind-integrations/openclaw/tests/runtime.test.ts
@@ -1,0 +1,58 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { parseConfig } from '../src/config.js'
+import { createRuntimeStores, resolveWorkspaceDir } from '../src/runtime.js'
+
+describe('resolveWorkspaceDir', () => {
+  it('prefers OpenClaw context workspaceDir over event cwd and process cwd', () => {
+    expect(
+      resolveWorkspaceDir(
+        { cwd: '/repo/from-event' },
+        { workspaceDir: '/repo/from-ctx' },
+        '/repo/from-process',
+      ),
+    ).toBe('/repo/from-ctx')
+  })
+
+  it('uses event cwd when context workspaceDir is unavailable', () => {
+    expect(resolveWorkspaceDir({ cwd: '/repo/from-event' }, {}, '/repo/from-process')).toBe(
+      '/repo/from-event',
+    )
+  })
+})
+
+describe('createRuntimeStores', () => {
+  it('creates stores from the current stateDir lazily', () => {
+    const stores = createRuntimeStores(parseConfig({}), () => '/tmp/openclaw-state')
+    const runtime = stores.current()
+    expect(runtime.stateRoot).toBe(path.join('/tmp/openclaw-state', 'state'))
+    expect(runtime.retryRoot).toBe(path.join('/tmp/openclaw-state', 'retry'))
+    expect(runtime.state).toBe(stores.current().state)
+  })
+
+  it('recreates stores when service start updates stateDir', () => {
+    let stateDir = '/tmp/first'
+    const stores = createRuntimeStores(parseConfig({}), () => stateDir)
+    const first = stores.current()
+    stateDir = '/tmp/second'
+    const second = stores.current()
+    expect(second.stateRoot).toBe(path.join('/tmp/second', 'state'))
+    expect(second.state).not.toBe(first.state)
+  })
+})

--- a/memind-integrations/openclaw/tests/state.test.ts
+++ b/memind-integrations/openclaw/tests/state.test.ts
@@ -1,0 +1,47 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { mkdtemp, rm, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { SubmittedStateStore } from '../src/state.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'memind-openclaw-state-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('SubmittedStateStore', () => {
+  it('marks and filters submitted fingerprints', async () => {
+    const store = new SubmittedStateStore(dir, { maxAgeDays: 14 })
+    await store.markSubmitted('session:1', ['a', 'b'])
+    await expect(store.filterUnsubmitted('session:1', ['a', 'c'])).resolves.toEqual(['c'])
+  })
+
+  it('treats expired state files as empty', async () => {
+    const store = new SubmittedStateStore(dir, { maxAgeDays: 1 })
+    await store.markSubmitted('session:1', ['a'])
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000)
+    await utimes(path.join(dir, 'session_1.json'), twoDaysAgo, twoDaysAgo)
+    await expect(store.filterUnsubmitted('session:1', ['a'])).resolves.toEqual(['a'])
+  })
+})

--- a/memind-integrations/openclaw/tsconfig.json
+++ b/memind-integrations/openclaw/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "test-shims/**/*.ts",
+    "openclaw-plugin-sdk.d.ts",
+    "*.config.ts"
+  ],
+  "exclude": ["node_modules", "dist", ".pack-check"]
+}

--- a/memind-integrations/openclaw/tsup.config.ts
+++ b/memind-integrations/openclaw/tsup.config.ts
@@ -1,0 +1,25 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  external: [/^node:/, /^openclaw\//],
+})

--- a/memind-integrations/openclaw/vitest.config.ts
+++ b/memind-integrations/openclaw/vitest.config.ts
@@ -1,0 +1,31 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    alias: {
+      'openclaw/plugin-sdk/plugin-entry': new URL(
+        './test-shims/plugin-entry.ts',
+        import.meta.url,
+      ).pathname,
+      'openclaw/plugin-sdk': new URL('./test-shims/plugin-sdk.ts', import.meta.url).pathname,
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+})

--- a/memind-integrations/openclaw/vitest.config.ts
+++ b/memind-integrations/openclaw/vitest.config.ts
@@ -17,10 +17,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     alias: {
-      'openclaw/plugin-sdk/plugin-entry': new URL(
-        './test-shims/plugin-entry.ts',
-        import.meta.url,
-      ).pathname,
+      'openclaw/plugin-sdk/plugin-entry': new URL('./test-shims/plugin-entry.ts', import.meta.url)
+        .pathname,
       'openclaw/plugin-sdk': new URL('./test-shims/plugin-sdk.ts', import.meta.url).pathname,
     },
     coverage: {


### PR DESCRIPTION
## Summary
- Add a publishable `@openmemind/memind-openclaw` package with OpenClaw memory-slot activation, manifest, config validation, and package tooling.
- Implement fail-open prompt recall, text-only post-turn ingestion, submitted-message state, and file-backed retry spooling.
- Add user documentation plus CI and npm release workflows for the OpenClaw integration.

## Test Plan
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage` (11 files, 53 tests)
- `pnpm build`
- `pnpm pack:check`
- `tar -tf .pack-check/openmemind-memind-openclaw-0.1.0.tgz | sort`
- `mvn com.mycila:license-maven-plugin:check` (BUILD SUCCESS; linked-worktree JGit warnings only)

## Notes
- The branch diff intentionally excludes `docs/superpowers/**`.
- v0.1 reserves tool-call and media capture for a future explicit data-model and privacy design.