### PR TITLE
feat: add server OpenAPI generation

### DIFF
--- a/memind-dependencies/pom.xml
+++ b/memind-dependencies/pom.xml
@@ -65,6 +65,7 @@
 
         <reactor-bom.version>2025.0.2</reactor-bom.version>
         <spring-boot.version>4.0.1</spring-boot.version>
+        <springdoc-openapi.version>3.0.3</springdoc-openapi.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
         <jackson.version>3.0.3</jackson.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -134,6 +135,13 @@
                 <version>${spring-ai.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Springdoc OpenAPI -->
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+                <version>${springdoc-openapi.version}</version>
             </dependency>
 
             <!-- JUnit -->

--- a/memind-server/pom.xml
+++ b/memind-server/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
         </dependency>

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OpenApiConfiguration {
+
+    private static final String TAG_MEMORY = "memory";
+    private static final String TAG_ADMIN = "admin";
+
+    private static final Map<String, String> OPERATION_SUMMARIES =
+            Map.ofEntries(
+                    Map.entry("GET /open/v1/health", "Health"),
+                    Map.entry("POST /open/v1/memory/retrieve", "Retrieve Memory"),
+                    Map.entry("POST /open/v1/memory/sync/extract", "Extract Memory Sync"),
+                    Map.entry("POST /open/v1/memory/sync/add-message", "Add Message Sync"),
+                    Map.entry("POST /open/v1/memory/sync/commit", "Commit Memory Sync"),
+                    Map.entry("POST /open/v1/memory/async/extract", "Extract Memory Async"),
+                    Map.entry("POST /open/v1/memory/async/add-message", "Add Message Async"),
+                    Map.entry("POST /open/v1/memory/async/commit", "Commit Memory Async"),
+                    Map.entry("GET /admin/v1/config/memory-options", "Get Memory Options"),
+                    Map.entry("PUT /admin/v1/config/memory-options", "Update Memory Options"),
+                    Map.entry("GET /admin/v1/dashboard", "Get Dashboard"),
+                    Map.entry("GET /admin/v1/items", "List Memory Items"),
+                    Map.entry("GET /admin/v1/items/{itemId}", "Get Memory Item"),
+                    Map.entry(
+                            "GET /admin/v1/items/{itemId}/memory-threads",
+                            "List Item Memory Threads"),
+                    Map.entry("DELETE /admin/v1/items", "Delete Memory Items"),
+                    Map.entry("GET /admin/v1/insights", "List Insights"),
+                    Map.entry("GET /admin/v1/insights/{insightId}", "Get Insight"),
+                    Map.entry("DELETE /admin/v1/insights", "Delete Insights"),
+                    Map.entry("GET /admin/v1/raw-data", "List Raw Data"),
+                    Map.entry("GET /admin/v1/raw-data/{rawDataId}", "Get Raw Data"),
+                    Map.entry("DELETE /admin/v1/raw-data", "Delete Raw Data"),
+                    Map.entry("GET /admin/v1/memory-threads", "List Memory Threads"),
+                    Map.entry("GET /admin/v1/memory-threads/{threadKey}", "Get Memory Thread"),
+                    Map.entry(
+                            "GET /admin/v1/memory-threads/{threadKey}/items",
+                            "List Memory Thread Items"),
+                    Map.entry("GET /admin/v1/memory-threads/status", "Get Memory Thread Status"),
+                    Map.entry("POST /admin/v1/memory-threads/rebuild", "Rebuild Memory Threads"),
+                    Map.entry("GET /admin/v1/item-graph/summary", "Get Item Graph Summary"),
+                    Map.entry("GET /admin/v1/item-graph/entities", "List Graph Entities"),
+                    Map.entry("GET /admin/v1/item-graph/entities/{id}", "Get Graph Entity"),
+                    Map.entry("DELETE /admin/v1/item-graph/entities", "Delete Graph Entities"),
+                    Map.entry("GET /admin/v1/item-graph/aliases", "List Graph Aliases"),
+                    Map.entry("DELETE /admin/v1/item-graph/aliases", "Delete Graph Aliases"),
+                    Map.entry("GET /admin/v1/item-graph/mentions", "List Graph Mentions"),
+                    Map.entry("DELETE /admin/v1/item-graph/mentions", "Delete Graph Mentions"),
+                    Map.entry("GET /admin/v1/item-graph/item-links", "List Item Graph Links"),
+                    Map.entry("DELETE /admin/v1/item-graph/item-links", "Delete Item Graph Links"),
+                    Map.entry("GET /admin/v1/item-graph/cooccurrences", "List Graph Cooccurrences"),
+                    Map.entry(
+                            "DELETE /admin/v1/item-graph/cooccurrences",
+                            "Delete Graph Cooccurrences"),
+                    Map.entry("GET /admin/v1/item-graph/batches", "List Item Graph Batches"),
+                    Map.entry("GET /admin/v1/buffers/conversations", "List Conversation Buffers"),
+                    Map.entry(
+                            "GET /admin/v1/buffers/conversations/{id}", "Get Conversation Buffer"),
+                    Map.entry(
+                            "PATCH /admin/v1/buffers/conversations/extracted",
+                            "Mark Conversation Buffers Extracted"),
+                    Map.entry(
+                            "DELETE /admin/v1/buffers/conversations",
+                            "Delete Conversation Buffers"),
+                    Map.entry("GET /admin/v1/buffers/insights", "List Insight Buffers"),
+                    Map.entry(
+                            "GET /admin/v1/buffers/insights/groups", "List Insight Buffer Groups"),
+                    Map.entry(
+                            "PATCH /admin/v1/buffers/insights/group",
+                            "Update Insight Buffer Group"),
+                    Map.entry(
+                            "PATCH /admin/v1/buffers/insights/built",
+                            "Update Insight Buffer Built"),
+                    Map.entry("DELETE /admin/v1/buffers/insights", "Delete Insight Buffers"));
+
+    @Bean
+    OpenAPI memindServerOpenApi() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Memind Server API")
+                                .version("v1")
+                                .description(
+                                        "HTTP API for Memind memory ingestion, retrieval, and"
+                                                + " administration."));
+    }
+
+    @Bean
+    OpenApiCustomizer memindServerOpenApiCustomizer() {
+        return openApi -> {
+            openApi.setServers(null);
+            openApi.setTags(
+                    List.of(
+                            tag(
+                                    TAG_MEMORY,
+                                    "Runtime memory ingestion, retrieval, and health endpoints."),
+                            tag(TAG_ADMIN, "Administrative endpoints for memory operations.")));
+            if (openApi.getPaths() == null) {
+                return;
+            }
+            openApi.getPaths()
+                    .forEach(
+                            (path, pathItem) ->
+                                    pathItem.readOperationsMap()
+                                            .forEach(
+                                                    (method, operation) ->
+                                                            customizeOperation(
+                                                                    path, method, operation)));
+        };
+    }
+
+    private static void customizeOperation(
+            String path, PathItem.HttpMethod method, Operation operation) {
+        String tag = tagForPath(path);
+        String group = groupForPath(path);
+        String key = method.name() + " " + path;
+        String summary = OPERATION_SUMMARIES.getOrDefault(key, titleFromPath(path));
+
+        operation.setTags(List.of(tag));
+        operation.setSummary(summary);
+        operation.setOperationId(operationId(summary));
+        operation.addExtension(
+                "x-mint",
+                Map.of(
+                        "href",
+                        href(tag, group, summary),
+                        "metadata",
+                        Map.of(
+                                "title", summary,
+                                "sidebarTitle", summary)));
+    }
+
+    private static Tag tag(String name, String description) {
+        Tag tag = new Tag().name(name).description(description);
+        tag.addExtension("x-group", name);
+        return tag;
+    }
+
+    private static String tagForPath(String path) {
+        if (!path.startsWith("/admin/")) {
+            return TAG_MEMORY;
+        }
+        return TAG_ADMIN;
+    }
+
+    private static String groupForPath(String path) {
+        if (!path.startsWith("/admin/")) {
+            return "";
+        }
+        if (path.startsWith("/admin/v1/config/")) {
+            return "config";
+        }
+        if (path.startsWith("/admin/v1/items")) {
+            return "memory-items";
+        }
+        if (path.startsWith("/admin/v1/raw-data")) {
+            return "raw-data";
+        }
+        if (path.startsWith("/admin/v1/memory-threads")) {
+            return "memory-threads";
+        }
+        if (path.startsWith("/admin/v1/item-graph")) {
+            return "item-graph";
+        }
+        if (path.startsWith("/admin/v1/insights")) {
+            return "insights";
+        }
+        if (path.startsWith("/admin/v1/buffers")) {
+            return "buffers";
+        }
+        return "dashboard";
+    }
+
+    private static String href(String tag, String group, String summary) {
+        if (TAG_MEMORY.equals(tag)) {
+            return "/api-reference/memory/" + slug(summary);
+        }
+        return "/api-reference/admin/" + group + "/" + slug(summary);
+    }
+
+    private static String operationId(String summary) {
+        String words = summary.replace('-', ' ');
+        String[] parts = words.trim().split("\\s+");
+        StringBuilder id = new StringBuilder(parts[0].toLowerCase(Locale.ROOT));
+        for (int i = 1; i < parts.length; i++) {
+            id.append(capitalize(parts[i]));
+        }
+        return id.toString();
+    }
+
+    private static String titleFromPath(String path) {
+        return Optional.of(path)
+                .map(value -> value.replaceAll("\\{([^}]+)}", "$1"))
+                .map(value -> value.replace('-', ' '))
+                .map(value -> value.replace('/', ' '))
+                .map(String::trim)
+                .map(value -> value.replaceFirst("^(open|admin)\\s+v\\d+\\s+", ""))
+                .map(OpenApiConfiguration::titleCase)
+                .orElse("Endpoint");
+    }
+
+    private static String slug(String value) {
+        return value.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("(^-|-$)", "");
+    }
+
+    private static String titleCase(String value) {
+        String[] parts = value.split("\\s+");
+        StringBuilder result = new StringBuilder();
+        for (String part : parts) {
+            if (!result.isEmpty()) {
+                result.append(' ');
+            }
+            result.append(capitalize(part));
+        }
+        return result.toString();
+    }
+
+    private static String capitalize(String value) {
+        if (value.isBlank()) {
+            return value;
+        }
+        return value.substring(0, 1).toUpperCase(Locale.ROOT) + value.substring(1);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.tags.Tag;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -148,17 +149,19 @@ public class OpenApiConfiguration {
         operation.setTags(List.of(tag));
         operation.setSummary(summary);
         operation.setOperationId(operationId(summary));
-        operation.addExtension(
-                "x-mint",
-                Map.of(
-                        "href",
-                        href(tag, group, summary),
-                        "content",
-                        API_PREVIEW_WARNING,
-                        "metadata",
-                        Map.of(
-                                "title", summary,
-                                "sidebarTitle", summary)));
+        operation.addExtension("x-mint", mintExtension(tag, group, summary));
+    }
+
+    private static Map<String, Object> mintExtension(String tag, String group, String summary) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("title", summary);
+        metadata.put("sidebarTitle", summary);
+
+        Map<String, Object> extension = new LinkedHashMap<>();
+        extension.put("href", href(tag, group, summary));
+        extension.put("content", API_PREVIEW_WARNING);
+        extension.put("metadata", metadata);
+        return extension;
     }
 
     private static Tag tag(String name, String description) {

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/OpenApiConfiguration.java
@@ -31,6 +31,9 @@ public class OpenApiConfiguration {
 
     private static final String TAG_MEMORY = "memory";
     private static final String TAG_ADMIN = "admin";
+    private static final String API_PREVIEW_WARNING =
+            "<Warning>The API Reference is under active development. Request and response schemas"
+                    + " may change before a stable release.</Warning>";
 
     private static final Map<String, String> OPERATION_SUMMARIES =
             Map.ofEntries(
@@ -150,6 +153,8 @@ public class OpenApiConfiguration {
                 Map.of(
                         "href",
                         href(tag, group, summary),
+                        "content",
+                        API_PREVIEW_WARNING,
                         "metadata",
                         Map.of(
                                 "title", summary,

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/common/ApiResult.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/common/ApiResult.java
@@ -13,17 +13,4 @@
  */
 package com.openmemind.ai.memory.server.domain.common;
 
-public sealed interface ApiResult<T> permits SuccessResult, ErrorResult {
-
-    static ApiResult<Void> ok() {
-        return new SuccessResult<>(null);
-    }
-
-    static <T> SuccessResult<T> success(T data) {
-        return new SuccessResult<>(data);
-    }
-
-    static <T> ErrorResult<T> failure(String code, String message, T details, String traceId) {
-        return new ErrorResult<>(new ApiError<>(ApiErrorCode.fromValue(code), message, details));
-    }
-}
+public sealed interface ApiResult<T> permits SuccessResult, ErrorResult {}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/common/ApiResult.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/domain/common/ApiResult.java
@@ -13,4 +13,17 @@
  */
 package com.openmemind.ai.memory.server.domain.common;
 
-public sealed interface ApiResult<T> permits SuccessResult, ErrorResult {}
+public sealed interface ApiResult<T> permits SuccessResult, ErrorResult {
+
+    static ApiResult<Void> ok() {
+        return new SuccessResult<>(null);
+    }
+
+    static <T> SuccessResult<T> success(T data) {
+        return new SuccessResult<>(data);
+    }
+
+    static <T> ErrorResult<T> failure(String code, String message, T details, String traceId) {
+        return new ErrorResult<>(new ApiError<>(ApiErrorCode.fromValue(code), message, details));
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.openmemind.ai.memory.server.MemindServerApplication;
+import com.openmemind.ai.memory.server.support.NoopRuntimeTestConfiguration;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest(classes = {MemindServerApplication.class, NoopRuntimeTestConfiguration.class})
+class OpenApiDocumentationTest {
+
+    private static final Path DB_PATH =
+            Path.of("target", "memind-server-openapi-" + UUID.randomUUID() + ".db")
+                    .toAbsolutePath();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.main.web-application-type", () -> "servlet");
+        registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + DB_PATH);
+        registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+        registry.add("memind.store.init-schema", () -> "true");
+        registry.add(
+                "spring.autoconfigure.exclude",
+                () -> NoopRuntimeTestConfiguration.SPRING_AI_AUTOCONFIG_EXCLUDES);
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Files.createDirectories(DB_PATH.getParent());
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @AfterAll
+    static void cleanUpDatabase() throws IOException {
+        Files.deleteIfExists(DB_PATH);
+    }
+
+    @Test
+    void exposesOpenApiJsonForOpenAndAdminEndpoints() throws Exception {
+        MvcResult result =
+                mockMvc.perform(get("/v3/api-docs"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.openapi").exists())
+                        .andExpect(jsonPath("$.info.title").value("Memind Server API"))
+                        .andExpect(jsonPath("$.servers").doesNotExist())
+                        .andExpect(jsonPath("$.paths['/open/v1/health']").exists())
+                        .andExpect(
+                                jsonPath("$.paths['/open/v1/health'].get.tags[0]").value("memory"))
+                        .andExpect(
+                                jsonPath("$.paths['/open/v1/health'].get.summary").value("Health"))
+                        .andExpect(jsonPath("$.paths['/open/v1/memory/async/extract']").exists())
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/extract']"
+                                                        + ".post.tags[0]")
+                                        .value("memory"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/extract']"
+                                                        + ".post.summary")
+                                        .value("Extract Memory Async"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/add-message']"
+                                                        + ".post.operationId")
+                                        .value("addMessageAsync"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/add-message']"
+                                                        + ".post.x-mint.metadata.title")
+                                        .value("Add Message Async"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/add-message']"
+                                                        + ".post.x-mint.metadata.sidebarTitle")
+                                        .value("Add Message Async"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/add-message']"
+                                                        + ".post.x-mint.href")
+                                        .value("/api-reference/memory/add-message-async"))
+                        .andExpect(jsonPath("$.paths['/admin/v1/items']").exists())
+                        .andExpect(
+                                jsonPath("$.paths['/admin/v1/items'].get.tags[0]").value("admin"))
+                        .andExpect(
+                                jsonPath("$.paths['/admin/v1/items'].get.summary")
+                                        .value("List Memory Items"))
+                        .andExpect(
+                                jsonPath("$.paths['/admin/v1/items'].get.x-mint.href")
+                                        .value(
+                                                "/api-reference/admin/memory-items/list-memory-items"))
+                        .andExpect(jsonPath("$.components.schemas.SuccessResult").exists())
+                        .andExpect(jsonPath("$.components.schemas.ErrorResult").exists())
+                        .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        writeOpenApiJsonIfRequested(root);
+        assertThat(root.path("paths").size()).isEqualTo(37);
+        assertThat(countOperations(root.path("paths"))).isGreaterThanOrEqualTo(40);
+        assertThat(tagNames(root.path("tags"))).containsExactly("memory", "admin");
+        assertThat(root.toString()).doesNotContain("controller", "http://localhost:8366");
+    }
+
+    private void writeOpenApiJsonIfRequested(JsonNode root) throws IOException {
+        String outputPath = System.getProperty("memind.openapi.output");
+        if (outputPath == null || outputPath.isBlank()) {
+            return;
+        }
+
+        Path output = Path.of(outputPath).toAbsolutePath().normalize();
+        Path parent = output.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(output.toFile(), root);
+    }
+
+    private static int countOperations(JsonNode paths) {
+        int count = 0;
+        var pathIterator = paths.properties().iterator();
+        while (pathIterator.hasNext()) {
+            JsonNode path = pathIterator.next().getValue();
+            var operationIterator = path.properties().iterator();
+            while (operationIterator.hasNext()) {
+                String method = operationIterator.next().getKey();
+                if (isHttpMethod(method)) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static java.util.List<String> tagNames(JsonNode tags) {
+        java.util.List<String> names = new java.util.ArrayList<>();
+        for (JsonNode tag : tags.values()) {
+            names.add(tag.path("name").asString());
+        }
+        return names;
+    }
+
+    private static boolean isHttpMethod(String method) {
+        return switch (method) {
+            case "get", "post", "put", "patch", "delete", "head", "options", "trace" -> true;
+            default -> false;
+        };
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
@@ -145,6 +145,13 @@ class OpenApiDocumentationTest {
         assertThat(root.path("paths").size()).isEqualTo(37);
         assertThat(countOperations(root.path("paths"))).isGreaterThanOrEqualTo(40);
         assertThat(tagNames(root.path("tags"))).containsExactly("memory", "admin");
+        assertThat(
+                        fieldNames(
+                                root.path("paths")
+                                        .path("/open/v1/memory/async/add-message")
+                                        .path("post")
+                                        .path("x-mint")))
+                .containsExactly("href", "content", "metadata");
         assertThat(root.toString()).doesNotContain("controller", "http://localhost:8366");
     }
 
@@ -183,6 +190,12 @@ class OpenApiDocumentationTest {
         for (JsonNode tag : tags.values()) {
             names.add(tag.path("name").asString());
         }
+        return names;
+    }
+
+    private static java.util.List<String> fieldNames(JsonNode node) {
+        java.util.List<String> names = new java.util.ArrayList<>();
+        names.addAll(node.propertyNames());
         return names;
     }
 

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
@@ -115,6 +115,15 @@ class OpenApiDocumentationTest {
                         .andExpect(
                                 jsonPath(
                                                 "$.paths['/open/v1/memory/async/add-message']"
+                                                        + ".post.x-mint.content")
+                                        .value(
+                                                "<Warning>The API Reference is under active"
+                                                    + " development. Request and response schemas"
+                                                    + " may change before a stable"
+                                                    + " release.</Warning>"))
+                        .andExpect(
+                                jsonPath(
+                                                "$.paths['/open/v1/memory/async/add-message']"
                                                         + ".post.x-mint.href")
                                         .value("/api-reference/memory/add-message-async"))
                         .andExpect(jsonPath("$.paths['/admin/v1/items']").exists())


### PR DESCRIPTION
## Summary
- add Springdoc-based OpenAPI metadata for the memind-server REST API
- document stable memory/admin API grouping and operation metadata
- add contract coverage for the generated OpenAPI document

## Test Plan
- mvnd test

## Notes
- Full reactor test passed locally after the latest rebase.