### PR TITLE
Add Hermes Agent memory provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ Use `memind_extract_text` for one-off text memory. Use `memind_add_message` foll
 Do not expose `/mcp` directly to public networks without an authentication gateway or equivalent
 network controls. MCP tools can read and write scoped memory.
 
+### Hermes Agent
+
+Memind also provides a Hermes Agent memory-provider integration under
+`memind-integrations/hermes`. It retrieves relevant Memind context before Hermes turns,
+captures user/assistant turns after responses, and can expose `memind_retrieve` and
+`memind_extract_text` as Hermes-native tools. See
+[`memind-integrations/hermes/README.md`](./memind-integrations/hermes/README.md).
+
 ### Common commands
 
 ```bash

--- a/memind-integrations/hermes/README.md
+++ b/memind-integrations/hermes/README.md
@@ -1,0 +1,158 @@
+# Memind Hermes Agent Integration
+
+Memind adds persistent project memory to Hermes Agent through a native Hermes memory provider.
+The provider retrieves relevant Memind context before each turn and submits successful
+user/assistant conversation turns to Memind extraction after each response.
+
+Use this integration when you want Hermes to remember project facts, preferences, decisions,
+and prior discussions across sessions.
+
+The integration is intentionally small:
+
+- Uses the official Memind Python client.
+- Connects to an already-running `memind-server`.
+- Does not manage a local Memind daemon.
+- Does not require MCP for automatic memory.
+- Does not ingest tool calls or media in v0.1.
+
+## Requirements
+
+- Hermes Agent with memory provider support.
+- Python 3.10+ in the environment used by Hermes plugins.
+- The official `memind` Python package installed in that same Python environment.
+- A running Memind server, usually at `http://127.0.0.1:8366`.
+
+Check the Memind server before enabling the provider:
+
+```bash
+curl -fsSL http://127.0.0.1:8366/open/v1/health
+```
+
+Install the Python client in the Python environment Hermes uses. If Hermes has a dedicated
+virtual environment, use that interpreter:
+
+```bash
+python3 -m pip install memind
+```
+
+## Quick Start
+
+Copy the provider into Hermes' memory-provider plugin directory:
+
+```bash
+mkdir -p ~/.hermes/plugins/memory
+cp -R memind-integrations/hermes ~/.hermes/plugins/memory/memind
+```
+
+Some older Hermes versions used a flat `~/.hermes/plugins/<name>` directory. If your Hermes
+version still documents that layout, copy the provider to the path required by that version.
+
+Configure Hermes to use Memind as the memory provider:
+
+```bash
+hermes config set memory.provider memind
+```
+
+Restart Hermes and check status:
+
+```bash
+hermes memory status
+```
+
+## Configuration
+
+User overrides live in `~/.memind/hermes.json`:
+
+```json
+{
+  "memindApiUrl": "http://127.0.0.1:8366",
+  "memindApiToken": null,
+  "userId": "local__alice",
+  "agentId": "hermes",
+  "agentIdMode": "project",
+  "sourceClient": "hermes",
+  "memoryMode": "hybrid",
+  "autoRetrieve": true,
+  "autoIngest": true,
+  "retrieveStrategy": "SIMPLE"
+}
+```
+
+Settings load in this order:
+
+1. Built-in defaults from `settings.json`.
+2. User overrides from `~/.memind/hermes.json`.
+3. Environment variables.
+
+Common environment overrides:
+
+```bash
+export MEMIND_API_URL=http://127.0.0.1:8366
+export MEMIND_API_TOKEN=...
+export MEMIND_USER_ID=local__alice
+export MEMIND_AGENT_ID=hermes
+export MEMIND_AGENT_ID_MODE=project
+export MEMIND_SOURCE_CLIENT=hermes
+export MEMIND_MEMORY_MODE=hybrid
+export MEMIND_RETRIEVE_STRATEGY=SIMPLE
+```
+
+## Memory Modes
+
+`memoryMode` controls how Hermes receives memory:
+
+| Mode | Automatic recall | Explicit tools |
+| --- | --- | --- |
+| `hybrid` | Yes | Yes |
+| `context` | Yes | No |
+| `tools` | No | Yes |
+
+`hybrid` is the default. Use `context` when you want invisible automatic memory without
+additional tools. Use `tools` when you want the model to call memory deliberately.
+
+## Tools
+
+When `memoryMode` is `hybrid` or `tools`, the provider exposes:
+
+- `memind_retrieve`: retrieve relevant Memind memory for the configured `userId` and `agentId`.
+- `memind_extract_text`: extract memory from standalone text such as pasted notes or document excerpts.
+
+Normal Hermes conversation turns are captured automatically through the memory provider.
+Use `memind_extract_text` only for one-off text memory.
+
+## Identity Model
+
+By default, Memind stores Hermes memory under:
+
+- `userId`: `local__<system-user>`
+- `agentId`: `hermes__<project-name>-<stable-hash>`
+
+The project hash is based on the Git remote URL when available, otherwise the local project path.
+Set `"agentIdMode": "fixed"` to share one Hermes memory scope across projects. Set
+`"agentIdMode": "session"` to isolate by Hermes session.
+
+## Relationship To HTTP MCP
+
+`memind-server` also exposes an HTTP MCP endpoint at `/mcp`. Hermes users may connect that
+HTTP MCP endpoint if their Hermes version supports remote HTTP MCP, but MCP is optional.
+
+Use the Hermes memory provider for automatic recall and automatic ingestion. Use HTTP MCP only
+when you want generic MCP tool access.
+
+## Security
+
+Keep the default loopback URL unless Memind is running behind an authenticated private deployment.
+If `MEMIND_API_TOKEN` is set, use HTTPS or a trusted tunnel for non-loopback endpoints so bearer
+tokens and memory payloads are not sent over plaintext HTTP.
+
+Do not expose the `/mcp` endpoint publicly without authentication and network controls. MCP tools
+can read and write scoped memory.
+
+## Troubleshooting
+
+- If the provider does not load, confirm the plugin was copied to `~/.hermes/plugins/memory/memind`.
+- If `hermes memory status` cannot reach Memind, confirm `memind-server` is running.
+- If imports fail, install the `memind` Python package into the Python environment Hermes uses.
+- If automatic recall does not happen, confirm `memoryMode` is `hybrid` or `context` and `autoRetrieve` is `true`.
+- If new memories do not appear immediately, ask again on a later turn. Extraction happens after the response.
+- If authenticated requests fail, confirm `MEMIND_API_TOKEN` is present in the Hermes process environment.

--- a/memind-integrations/hermes/__init__.py
+++ b/memind-integrations/hermes/__init__.py
@@ -1,0 +1,25 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from memind_hermes.provider import MemindMemoryProvider, register
+
+__all__ = ["MemindMemoryProvider", "register"]

--- a/memind-integrations/hermes/memind_hermes/__init__.py
+++ b/memind-integrations/hermes/memind_hermes/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from memind_hermes.provider import MemindMemoryProvider, register
+
+__all__ = ["MemindMemoryProvider", "register"]

--- a/memind-integrations/hermes/memind_hermes/client.py
+++ b/memind-integrations/hermes/memind_hermes/client.py
@@ -1,0 +1,69 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def build_conversation_content(role_text_pairs):
+    if not role_text_pairs:
+        raise ValueError("conversation content requires at least one message")
+    from memind import ConversationContent, Message
+
+    messages = []
+    for role, text in role_text_pairs:
+        normalized = str(role).upper()
+        if normalized == "ASSISTANT":
+            messages.append(Message.assistant(text))
+        else:
+            messages.append(Message.user(text))
+    return ConversationContent(messages=messages)
+
+
+class MemindClient:
+    def __init__(self, base_url, token=None, timeout=10, max_retries=0):
+        self.base_url = base_url
+        self.token = token
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+    def _sync_client(self):
+        from memind import MemindClient as OfficialMemindClient
+
+        return OfficialMemindClient(
+            base_url=self.base_url,
+            api_token=self.token,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+        )
+
+    def health(self):
+        with self._sync_client() as client:
+            return client.health()
+
+    def retrieve(self, user_id, agent_id, query, strategy="SIMPLE", trace=False):
+        with self._sync_client() as client:
+            return client.memory.retrieve(
+                user_id=user_id,
+                agent_id=agent_id,
+                query=query,
+                strategy=strategy,
+                trace=trace,
+            )
+
+    def extract(self, user_id, agent_id, raw_content, source_client=None):
+        with self._sync_client() as client:
+            return client.memory.extract(
+                user_id=user_id,
+                agent_id=agent_id,
+                raw_content=raw_content,
+                source_client=source_client,
+            )

--- a/memind-integrations/hermes/memind_hermes/config.py
+++ b/memind-integrations/hermes/memind_hermes/config.py
@@ -1,0 +1,159 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+from pathlib import Path
+
+
+DEFAULT_SETTINGS = {
+    "memindApiUrl": "http://127.0.0.1:8366",
+    "memindApiToken": None,
+    "userId": None,
+    "agentId": "hermes",
+    "agentIdMode": "project",
+    "sourceClient": "hermes",
+    "memoryMode": "hybrid",
+    "autoRetrieve": True,
+    "autoIngest": True,
+    "retrieveStrategy": "SIMPLE",
+    "retrieveMaxEntries": 8,
+    "retrieveMaxChars": 6000,
+    "retrieveContextTurns": 1,
+    "retrievePromptPreamble": "Relevant memories from Memind. Use only when directly helpful:",
+    "ingestionRoles": ["user", "assistant"],
+    "debug": False,
+}
+
+ENV_MAP = {
+    "MEMIND_API_URL": ("memindApiUrl", str),
+    "MEMIND_API_TOKEN": ("memindApiToken", str),
+    "MEMIND_USER_ID": ("userId", str),
+    "MEMIND_AGENT_ID": ("agentId", str),
+    "MEMIND_AGENT_ID_MODE": ("agentIdMode", str),
+    "MEMIND_SOURCE_CLIENT": ("sourceClient", str),
+    "MEMIND_MEMORY_MODE": ("memoryMode", str),
+    "MEMIND_AUTO_RETRIEVE": ("autoRetrieve", "bool"),
+    "MEMIND_AUTO_INGEST": ("autoIngest", "bool"),
+    "MEMIND_RETRIEVE_STRATEGY": ("retrieveStrategy", str),
+    "MEMIND_RETRIEVE_MAX_ENTRIES": ("retrieveMaxEntries", "int"),
+    "MEMIND_RETRIEVE_MAX_CHARS": ("retrieveMaxChars", "int"),
+    "MEMIND_RETRIEVE_CONTEXT_TURNS": ("retrieveContextTurns", "int_allow_zero"),
+    "MEMIND_INGESTION_ROLES": ("ingestionRoles", "list"),
+    "MEMIND_DEBUG": ("debug", "bool"),
+}
+
+VALID_MEMORY_MODES = {"hybrid", "context", "tools"}
+VALID_RETRIEVE_STRATEGIES = {"SIMPLE", "DEEP"}
+
+
+def parse_bool(value):
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_int(value, name, allow_zero=False):
+    parsed = int(value)
+    if parsed < 0 or (parsed == 0 and not allow_zero):
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
+def parse_list(value):
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def _coerce(value, kind, name):
+    if kind == "bool":
+        return parse_bool(value)
+    if kind == "int":
+        return parse_int(value, name)
+    if kind == "int_allow_zero":
+        return parse_int(value, name, allow_zero=True)
+    if kind == "list":
+        return parse_list(value)
+    return kind(value)
+
+
+def _default_user_config_path(home=None):
+    base = Path(home) if home else Path.home()
+    return base / ".memind" / "hermes.json"
+
+
+def _normalize(config):
+    mode = str(config.get("memoryMode", "hybrid")).strip().lower()
+    config["memoryMode"] = mode if mode in VALID_MEMORY_MODES else "hybrid"
+    strategy = str(config.get("retrieveStrategy", "SIMPLE")).strip().upper()
+    config["retrieveStrategy"] = strategy if strategy in VALID_RETRIEVE_STRATEGIES else "SIMPLE"
+    config["memindApiUrl"] = str(config.get("memindApiUrl", DEFAULT_SETTINGS["memindApiUrl"])).rstrip("/")
+    return config
+
+
+def load_config(plugin_root=None, user_config_path=None, env=None):
+    env = os.environ if env is None else env
+    root = Path(plugin_root or Path(__file__).resolve().parents[1])
+    config = dict(DEFAULT_SETTINGS)
+    settings_path = root / "settings.json"
+    if settings_path.exists():
+        config.update(json.loads(settings_path.read_text()))
+    user_path = Path(user_config_path or env.get("MEMIND_HERMES_CONFIG") or _default_user_config_path())
+    if user_path.exists():
+        config.update(json.loads(user_path.read_text()))
+    for env_name, (key, kind) in ENV_MAP.items():
+        if env_name in env and env[env_name] != "":
+            config[key] = _coerce(env[env_name], kind, key)
+    return _normalize(config)
+
+
+def save_config(values, home=None):
+    path = _default_user_config_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    normalized = _normalize({**DEFAULT_SETTINGS, **dict(values)})
+    path.write_text(json.dumps(normalized, indent=2) + "\n")
+    return path
+
+
+def config_schema():
+    return [
+        {
+            "key": "memindApiUrl",
+            "description": "Memind server URL",
+            "default": DEFAULT_SETTINGS["memindApiUrl"],
+            "env_var": "MEMIND_API_URL",
+        },
+        {
+            "key": "memindApiToken",
+            "description": "Memind API token",
+            "secret": True,
+            "required": False,
+            "env_var": "MEMIND_API_TOKEN",
+        },
+        {
+            "key": "userId",
+            "description": "Memind user identity. Defaults to local__<system-user>.",
+            "required": False,
+            "env_var": "MEMIND_USER_ID",
+        },
+        {
+            "key": "agentId",
+            "description": "Base Memind agent identity",
+            "default": DEFAULT_SETTINGS["agentId"],
+            "env_var": "MEMIND_AGENT_ID",
+        },
+        {
+            "key": "memoryMode",
+            "description": "Memory mode: hybrid, context, or tools",
+            "default": DEFAULT_SETTINGS["memoryMode"],
+            "env_var": "MEMIND_MEMORY_MODE",
+        },
+    ]

--- a/memind-integrations/hermes/memind_hermes/content.py
+++ b/memind-integrations/hermes/memind_hermes/content.py
@@ -1,0 +1,28 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+
+
+MEMIND_BLOCK_RE = re.compile(r"<memind_memories>.*?</memind_memories>", re.DOTALL)
+
+
+def strip_memind_blocks(text):
+    return MEMIND_BLOCK_RE.sub("", text or "")
+
+
+def text_or_empty(value):
+    if value is None:
+        return ""
+    return strip_memind_blocks(str(value)).strip()

--- a/memind-integrations/hermes/memind_hermes/format.py
+++ b/memind-integrations/hermes/memind_hermes/format.py
@@ -1,0 +1,65 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+TIER_RANK = {"ROOT": 0, "BRANCH": 1, "LEAF": 2}
+
+
+def _as_dict(data):
+    if hasattr(data, "model_dump"):
+        return data.model_dump(by_alias=True)
+    return data or {}
+
+
+def _score(item):
+    if item.get("finalScore") is not None:
+        return item.get("finalScore")
+    return item.get("vectorScore") or 0
+
+
+def format_memind_context(data, config):
+    payload = _as_dict(data)
+    max_entries = int(config.get("retrieveMaxEntries", 8))
+    max_chars = int(config.get("retrieveMaxChars", 6000))
+    preamble = config.get("retrievePromptPreamble") or ""
+
+    insights = [insight for insight in payload.get("insights", []) if insight.get("text")]
+    insights.sort(key=lambda insight: (TIER_RANK.get(str(insight.get("tier", "LEAF")).upper(), 2), str(insight.get("id", ""))))
+    high_level = [insight for insight in insights if str(insight.get("tier", "")).upper() in {"ROOT", "BRANCH"}]
+    selected_insights = (high_level or insights)[: min(3, max_entries)]
+
+    remaining = max_entries - len(selected_insights)
+    items = [item for item in payload.get("items", []) if item.get("text")]
+    items.sort(key=_score, reverse=True)
+    selected_items = items[: max(0, remaining)]
+
+    sections = []
+    if selected_insights:
+        sections.append("## Insights")
+        sections.extend(f"- [insight:{insight.get('id')}] {insight.get('text')}" for insight in selected_insights)
+    if selected_items:
+        if sections:
+            sections.append("")
+        sections.append("## Memory Items")
+        sections.extend(f"- [item:{item.get('id')}] {item.get('text')}" for item in selected_items)
+    if not sections and payload.get("status") != "degraded":
+        return ""
+
+    body = "\n".join(sections)
+    if payload.get("status") == "degraded":
+        body += "\n[Note: Memory retrieval encountered an error. Results may be incomplete.]"
+    if len(body) > max_chars:
+        suffix = "\n[truncated]"
+        body = f"{body[: max(0, max_chars - len(suffix))].rstrip()}{suffix}"
+    return f"<memind_memories>\n{preamble}\n{body}\n</memind_memories>"

--- a/memind-integrations/hermes/memind_hermes/identity.py
+++ b/memind-integrations/hermes/memind_hermes/identity.py
@@ -1,0 +1,74 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import getpass
+import hashlib
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+SEPARATOR = "__"
+SAFE_PART_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _hash(value):
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _git_remote(cwd):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=1,
+        )
+    except Exception:
+        return None
+    remote = result.stdout.strip()
+    return remote or None
+
+
+def _safe_part(value):
+    cleaned = SAFE_PART_RE.sub("_", str(value or "").strip())
+    return cleaned[:128] or "unknown"
+
+
+def project_slug(cwd):
+    path = Path(cwd or os.getcwd()).resolve()
+    name = _safe_part(path.name or "project")
+    remote = _git_remote(path)
+    if remote:
+        return f"{name}-{_hash(remote)}"
+    return f"{name}-{_hash(str(path))}"
+
+
+def resolve_identity(config, cwd=None, session_id=None):
+    user_id = config.get("userId") or f"local{SEPARATOR}{getpass.getuser()}"
+    base_agent = config.get("agentId") or "hermes"
+    mode = config.get("agentIdMode") or "project"
+    if mode == "fixed":
+        agent_id = base_agent
+    elif mode == "session":
+        agent_id = f"{base_agent}{SEPARATOR}session-{_safe_part(session_id or cwd or 'default-session')}"
+    else:
+        agent_id = f"{base_agent}{SEPARATOR}{project_slug(cwd)}"
+    return {
+        "userId": user_id,
+        "agentId": agent_id,
+        "sourceClient": config.get("sourceClient") or "hermes",
+    }

--- a/memind-integrations/hermes/memind_hermes/provider.py
+++ b/memind-integrations/hermes/memind_hermes/provider.py
@@ -1,0 +1,288 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+import threading
+from urllib.parse import urlparse
+
+from memind_hermes.client import MemindClient, build_conversation_content
+from memind_hermes.config import config_schema, load_config, save_config as save_provider_config
+from memind_hermes.content import text_or_empty
+from memind_hermes.format import format_memind_context
+from memind_hermes.identity import resolve_identity
+
+try:
+    from agent.memory_provider import MemoryProvider
+except ImportError:
+    class MemoryProvider:
+        pass
+
+
+VALID_TOOL_STRATEGIES = {"SIMPLE", "DEEP"}
+
+
+def _valid_url(value):
+    parsed = urlparse(value or "")
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+class MemindMemoryProvider(MemoryProvider):
+    def __init__(self, config_loader=None, client_factory=None):
+        self._config_loader = config_loader or load_config
+        self._client_factory_injected = client_factory is not None
+        self._client_factory = client_factory or self._default_client
+        self._config = None
+        self._client = None
+        self._identity = None
+        self._session_id = None
+        self._cwd = None
+        self._prefetch_thread = None
+        self._prefetch_result = ""
+        self._sync_thread = None
+
+    @property
+    def name(self):
+        return "memind"
+
+    def _default_client(self, config):
+        return MemindClient(
+            config["memindApiUrl"],
+            config.get("memindApiToken"),
+            timeout=10,
+            max_retries=0,
+        )
+
+    def _ensure_initialized(self):
+        if self._config is None:
+            self.initialize("unknown-session", cwd=os.getcwd())
+
+    def _debug(self, message):
+        if self._config and self._config.get("debug"):
+            print(f"memind-hermes: {message}")
+
+    def is_available(self):
+        config = self._config_loader()
+        if not _valid_url(config.get("memindApiUrl")):
+            return False
+        try:
+            import memind  # noqa: F401
+        except ImportError:
+            return self._client_factory_injected
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        self._config = self._config_loader()
+        self._session_id = session_id
+        self._cwd = kwargs.get("cwd") or os.getcwd()
+        self._identity = resolve_identity(self._config, cwd=self._cwd, session_id=session_id)
+        self._client = self._client_factory(self._config)
+
+    def get_config_schema(self):
+        return config_schema()
+
+    def save_config(self, values, hermes_home):
+        save_provider_config(values)
+
+    def system_prompt_block(self):
+        return ""
+
+    def _auto_retrieve_enabled(self):
+        return self._config.get("autoRetrieve", True) and self._config.get("memoryMode", "hybrid") in {"hybrid", "context"}
+
+    def _tools_enabled(self):
+        return self._config.get("memoryMode", "hybrid") in {"hybrid", "tools"}
+
+    def prefetch(self, query, **kwargs):
+        self._ensure_initialized()
+        if not self._auto_retrieve_enabled():
+            return ""
+        cleaned = text_or_empty(query)
+        if len(cleaned) < 5:
+            return ""
+        try:
+            result = self._client.retrieve(
+                self._identity["userId"],
+                self._identity["agentId"],
+                cleaned,
+                self._config.get("retrieveStrategy", "SIMPLE"),
+                False,
+            )
+            return format_memind_context(result, self._config)
+        except Exception as exc:
+            self._debug(f"prefetch failed: {exc}")
+            return ""
+
+    def queue_prefetch(self, query, **kwargs):
+        def run():
+            self._prefetch_result = self.prefetch(query, **kwargs)
+
+        self._prefetch_thread = threading.Thread(target=run, daemon=True)
+        self._prefetch_thread.start()
+
+    def _extract_pairs(self, pairs):
+        allowed_roles = {str(role).upper() for role in self._config.get("ingestionRoles", ["user", "assistant"])}
+        filtered = [
+            (role, text_or_empty(text))
+            for role, text in pairs
+            if str(role).upper() in allowed_roles
+        ]
+        filtered = [(role, text) for role, text in filtered if text]
+        if not filtered:
+            return
+        raw_content = build_conversation_content(filtered)
+        self._client.extract(
+            self._identity["userId"],
+            self._identity["agentId"],
+            raw_content,
+            self._identity["sourceClient"],
+        )
+
+    def sync_turn(self, user=None, assistant=None, **kwargs):
+        self._ensure_initialized()
+        if not self._config.get("autoIngest", True):
+            return
+        user_text = kwargs.get("user_content", user)
+        assistant_text = kwargs.get("assistant_content", assistant)
+
+        def run():
+            try:
+                self._extract_pairs([("USER", user_text), ("ASSISTANT", assistant_text)])
+            except Exception as exc:
+                self._debug(f"sync turn failed: {exc}")
+
+        self._sync_thread = threading.Thread(target=run, daemon=True)
+        self._sync_thread.start()
+
+    def on_session_end(self, messages, **kwargs):
+        return None
+
+    def on_pre_compress(self, messages, **kwargs):
+        self._ensure_initialized()
+        if not self._auto_retrieve_enabled():
+            return
+        try:
+            if any(
+                isinstance(message, dict)
+                and (
+                    "<memind_memories>" in str(message.get("content", ""))
+                    or "[Memind context before compaction]" in str(message.get("content", ""))
+                )
+                for message in messages
+            ):
+                return
+            context_turns = int(self._config.get("retrieveContextTurns", 1))
+            recent = messages[-context_turns * 2 :] if context_turns > 0 else messages[-1:]
+            query = "\n".join(str(message.get("content", "")) for message in recent if isinstance(message, dict))
+            context = self.prefetch(query or kwargs.get("query", "session context"))
+            if context:
+                messages.insert(
+                    0,
+                    {"role": "user", "content": f"[Memind context before compaction]\n{context}"},
+                )
+        except Exception as exc:
+            self._debug(f"pre-compress failed: {exc}")
+
+    def on_memory_write(self, action, target, content, **kwargs):
+        self._ensure_initialized()
+        if action not in {"add", "update"} or not text_or_empty(content):
+            return
+
+        def run():
+            try:
+                self._extract_pairs([("USER", content)])
+            except Exception as exc:
+                self._debug(f"memory write failed: {exc}")
+
+        self._sync_thread = threading.Thread(target=run, daemon=True)
+        self._sync_thread.start()
+
+    def get_tool_schemas(self):
+        self._ensure_initialized()
+        if not self._tools_enabled():
+            return []
+        return [
+            {
+                "name": "memind_retrieve",
+                "description": "Retrieve relevant Memind memories for the current user and agent scope.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Natural-language retrieval query."},
+                        "strategy": {
+                            "type": "string",
+                            "enum": ["SIMPLE", "DEEP"],
+                            "default": "SIMPLE",
+                            "description": "Memind retrieval strategy.",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "memind_extract_text",
+                "description": (
+                    "Extract memory from standalone text such as pasted notes or document excerpts. "
+                    "Normal conversation turns are captured automatically by the Memind Hermes provider."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string", "description": "Standalone text to extract into memory."}
+                    },
+                    "required": ["text"],
+                },
+            },
+        ]
+
+    def handle_tool_call(self, name, args):
+        self._ensure_initialized()
+        try:
+            if name == "memind_retrieve":
+                strategy = str(args.get("strategy") or "SIMPLE").upper()
+                if strategy not in VALID_TOOL_STRATEGIES:
+                    return json.dumps({"error": "strategy must be SIMPLE or DEEP"})
+                result = self._client.retrieve(
+                    self._identity["userId"],
+                    self._identity["agentId"],
+                    args.get("query", ""),
+                    strategy,
+                    False,
+                )
+                payload = result.model_dump(by_alias=True) if hasattr(result, "model_dump") else result
+                return json.dumps(payload or {}, default=str)
+            if name == "memind_extract_text":
+                text = text_or_empty(args.get("text"))
+                if not text:
+                    return json.dumps({"error": "text must not be blank"})
+                raw_content = build_conversation_content([("USER", text)])
+                result = self._client.extract(
+                    self._identity["userId"],
+                    self._identity["agentId"],
+                    raw_content,
+                    self._identity["sourceClient"],
+                )
+                payload = result.model_dump(by_alias=True) if hasattr(result, "model_dump") else {"status": getattr(result, "status", "SUCCESS")}
+                return json.dumps(payload, default=str)
+            return json.dumps({"error": f"Unknown tool: {name}"})
+        except Exception as exc:
+            self._debug(f"tool call failed: {exc}")
+            return json.dumps({"error": str(exc)})
+
+    def shutdown(self, **kwargs):
+        return None
+
+
+def register(ctx):
+    ctx.register_memory_provider(MemindMemoryProvider())

--- a/memind-integrations/hermes/plugin.yaml
+++ b/memind-integrations/hermes/plugin.yaml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: memind
 version: 0.1.0
 description: "Persistent long-term memory for Hermes Agent via Memind."

--- a/memind-integrations/hermes/plugin.yaml
+++ b/memind-integrations/hermes/plugin.yaml
@@ -1,0 +1,8 @@
+name: memind
+version: 0.1.0
+description: "Persistent long-term memory for Hermes Agent via Memind."
+author: "OpenMemind"
+homepage: "https://github.com/openmemind/memind"
+hooks:
+  - on_pre_compress
+  - on_memory_write

--- a/memind-integrations/hermes/settings.json
+++ b/memind-integrations/hermes/settings.json
@@ -1,0 +1,18 @@
+{
+  "memindApiUrl": "http://127.0.0.1:8366",
+  "memindApiToken": null,
+  "userId": null,
+  "agentId": "hermes",
+  "agentIdMode": "project",
+  "sourceClient": "hermes",
+  "memoryMode": "hybrid",
+  "autoRetrieve": true,
+  "autoIngest": true,
+  "retrieveStrategy": "SIMPLE",
+  "retrieveMaxEntries": 8,
+  "retrieveMaxChars": 6000,
+  "retrieveContextTurns": 1,
+  "retrievePromptPreamble": "Relevant memories from Memind. Use only when directly helpful:",
+  "ingestionRoles": ["user", "assistant"],
+  "debug": false
+}

--- a/memind-integrations/hermes/tests/test_client.py
+++ b/memind-integrations/hermes/tests/test_client.py
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from memind_hermes.client import build_conversation_content
+
+
+class ClientTest(unittest.TestCase):
+    def test_build_conversation_content_uses_official_models_when_available(self):
+        content = build_conversation_content([("USER", "hello"), ("ASSISTANT", "hi")])
+
+        dumped = content.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["type"], "conversation")
+        self.assertEqual(dumped["messages"][0]["role"], "USER")
+        self.assertEqual(dumped["messages"][0]["content"][0]["text"], "hello")
+
+    def test_build_conversation_content_rejects_empty_messages(self):
+        with self.assertRaises(ValueError):
+            build_conversation_content([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_config.py
+++ b/memind-integrations/hermes/tests/test_config.py
@@ -1,0 +1,109 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from memind_hermes.config import (
+    DEFAULT_SETTINGS,
+    config_schema,
+    load_config,
+    parse_bool,
+    parse_int,
+    parse_list,
+    save_config,
+)
+
+
+class ConfigTest(unittest.TestCase):
+    def test_parse_bool(self):
+        self.assertTrue(parse_bool("true"))
+        self.assertTrue(parse_bool("1"))
+        self.assertTrue(parse_bool("YES"))
+        self.assertFalse(parse_bool("false"))
+        self.assertFalse(parse_bool("0"))
+        self.assertFalse(parse_bool("no"))
+
+    def test_parse_int(self):
+        self.assertEqual(parse_int("8", "retrieveMaxEntries"), 8)
+        with self.assertRaises(ValueError):
+            parse_int("0", "retrieveMaxEntries")
+
+    def test_parse_list(self):
+        self.assertEqual(parse_list("user, assistant,,"), ["user", "assistant"])
+
+    def test_defaults_match_settings(self):
+        self.assertEqual(DEFAULT_SETTINGS["sourceClient"], "hermes")
+        self.assertEqual(DEFAULT_SETTINGS["memoryMode"], "hybrid")
+        self.assertEqual(DEFAULT_SETTINGS["retrieveStrategy"], "SIMPLE")
+
+    def test_load_order_settings_user_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            user_config = root / "hermes.json"
+            (root / "settings.json").write_text(json.dumps({"retrieveMaxEntries": 3}))
+            user_config.write_text(json.dumps({"retrieveMaxEntries": 5, "memoryMode": "context"}))
+            env = {
+                "MEMIND_RETRIEVE_MAX_ENTRIES": "7",
+                "MEMIND_MEMORY_MODE": "tools",
+                "MEMIND_AUTO_RETRIEVE": "false",
+                "MEMIND_INGESTION_ROLES": "user,assistant",
+            }
+
+            cfg = load_config(plugin_root=root, user_config_path=user_config, env=env)
+
+        self.assertEqual(cfg["retrieveMaxEntries"], 7)
+        self.assertEqual(cfg["memoryMode"], "tools")
+        self.assertFalse(cfg["autoRetrieve"])
+        self.assertEqual(cfg["ingestionRoles"], ["user", "assistant"])
+
+    def test_invalid_strategy_falls_back_to_simple(self):
+        cfg = load_config(env={"MEMIND_RETRIEVE_STRATEGY": "bad"})
+
+        self.assertEqual(cfg["retrieveStrategy"], "SIMPLE")
+
+    def test_invalid_memory_mode_falls_back_to_hybrid(self):
+        cfg = load_config(env={"MEMIND_MEMORY_MODE": "bad"})
+
+        self.assertEqual(cfg["memoryMode"], "hybrid")
+
+    def test_save_config_writes_memind_user_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            save_config(
+                {"memindApiUrl": "http://memind.test", "memindApiToken": "secret", "userId": "u"},
+                home=home,
+            )
+            path = home / ".memind" / "hermes.json"
+            saved = json.loads(path.read_text())
+
+        self.assertEqual(saved["memindApiUrl"], "http://memind.test")
+        self.assertEqual(saved["memindApiToken"], "secret")
+        self.assertEqual(saved["userId"], "u")
+
+    def test_config_schema_has_core_fields(self):
+        schema = config_schema()
+        keys = {item["key"] for item in schema}
+
+        self.assertIn("memindApiUrl", keys)
+        self.assertIn("memindApiToken", keys)
+        self.assertIn("userId", keys)
+        self.assertIn("agentId", keys)
+        self.assertIn("memoryMode", keys)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_content.py
+++ b/memind-integrations/hermes/tests/test_content.py
@@ -1,0 +1,37 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from memind_hermes.content import strip_memind_blocks, text_or_empty
+
+
+class ContentTest(unittest.TestCase):
+    def test_strip_memind_blocks(self):
+        text = "hello\n<memind_memories>\nsecret\n</memind_memories>\nworld"
+
+        self.assertEqual(strip_memind_blocks(text).strip(), "hello\n\nworld")
+
+    def test_text_or_empty_handles_none_and_whitespace(self):
+        self.assertEqual(text_or_empty(None), "")
+        self.assertEqual(text_or_empty("  hello  "), "hello")
+
+    def test_text_or_empty_strips_memind_context(self):
+        text = "<memind_memories>memory</memind_memories>remember espresso"
+
+        self.assertEqual(text_or_empty(text), "remember espresso")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_format.py
+++ b/memind-integrations/hermes/tests/test_format.py
@@ -1,0 +1,74 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import types
+import unittest
+
+from memind_hermes.format import format_memind_context
+
+
+class FormatTest(unittest.TestCase):
+    def test_prioritizes_root_branch_insights_then_items(self):
+        data = {
+            "insights": [
+                {"id": "3", "text": "leaf", "tier": "LEAF"},
+                {"id": "2", "text": "branch", "tier": "BRANCH"},
+                {"id": "1", "text": "root", "tier": "ROOT"},
+            ],
+            "items": [
+                {"id": "10", "text": "low", "finalScore": 0.1},
+                {"id": "11", "text": "high", "finalScore": 0.9},
+            ],
+        }
+
+        context = format_memind_context(
+            data,
+            {"retrieveMaxEntries": 4, "retrieveMaxChars": 1000, "retrievePromptPreamble": "P"},
+        )
+
+        self.assertIn("<memind_memories>", context)
+        self.assertLess(context.index("[insight:1] root"), context.index("[insight:2] branch"))
+        self.assertNotIn("leaf", context)
+        self.assertLess(context.index("[item:11] high"), context.index("[item:10] low"))
+
+    def test_accepts_pydantic_like_response(self):
+        response = types.SimpleNamespace(
+            model_dump=lambda by_alias=True: {
+                "insights": [{"id": "1", "text": "root", "tier": "ROOT"}],
+                "items": [],
+            }
+        )
+
+        context = format_memind_context(response, {"retrievePromptPreamble": "P"})
+
+        self.assertIn("[insight:1] root", context)
+
+    def test_includes_degraded_notice_without_results(self):
+        context = format_memind_context({"status": "degraded"}, {"retrievePromptPreamble": ""})
+
+        self.assertIn("Memory retrieval encountered an error", context)
+
+    def test_truncates_body(self):
+        data = {"items": [{"id": "1", "text": "x" * 100, "finalScore": 1.0}]}
+
+        context = format_memind_context(
+            data,
+            {"retrievePromptPreamble": "P", "retrieveMaxChars": 40, "retrieveMaxEntries": 8},
+        )
+
+        self.assertIn("[truncated]", context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_identity.py
+++ b/memind-integrations/hermes/tests/test_identity.py
@@ -1,0 +1,64 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from memind_hermes.identity import project_slug, resolve_identity
+
+
+class IdentityTest(unittest.TestCase):
+    def test_project_mode_appends_stable_project_slug(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            identity = resolve_identity(
+                {"agentId": "hermes", "agentIdMode": "project", "userId": None, "sourceClient": "hermes"},
+                cwd=tmp,
+                session_id="s1",
+            )
+
+        self.assertTrue(identity["userId"].startswith("local__"))
+        self.assertTrue(identity["agentId"].startswith("hermes__"))
+        self.assertEqual(identity["sourceClient"], "hermes")
+
+    def test_fixed_mode_uses_agent_id_as_is(self):
+        identity = resolve_identity(
+            {"agentId": "shared", "agentIdMode": "fixed", "userId": "u", "sourceClient": "hermes"},
+            cwd="/tmp/project",
+            session_id="s1",
+        )
+
+        self.assertEqual(identity["userId"], "u")
+        self.assertEqual(identity["agentId"], "shared")
+
+    def test_session_mode_uses_session_id(self):
+        identity = resolve_identity(
+            {"agentId": "hermes", "agentIdMode": "session", "userId": "u", "sourceClient": "hermes"},
+            cwd="/tmp/project",
+            session_id="abc/def",
+        )
+
+        self.assertEqual(identity["agentId"], "hermes__session-abc_def")
+
+    def test_project_slug_is_stable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = project_slug(Path(tmp))
+            second = project_slug(Path(tmp))
+
+        self.assertEqual(first, second)
+        self.assertIn("-", first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_manifest.py
+++ b/memind-integrations/hermes/tests/test_manifest.py
@@ -1,0 +1,87 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ManifestTest(unittest.TestCase):
+    def test_plugin_manifest_declares_memind_provider(self):
+        manifest = (ROOT / "plugin.yaml").read_text()
+
+        self.assertIn("name: memind", manifest)
+        self.assertIn("Persistent long-term memory for Hermes Agent via Memind", manifest)
+        self.assertIn("on_pre_compress", manifest)
+        self.assertIn("on_memory_write", manifest)
+
+    def test_settings_defaults_match_spec(self):
+        settings = json.loads((ROOT / "settings.json").read_text())
+
+        self.assertEqual(settings["memindApiUrl"], "http://127.0.0.1:8366")
+        self.assertIsNone(settings["memindApiToken"])
+        self.assertIsNone(settings["userId"])
+        self.assertEqual(settings["agentId"], "hermes")
+        self.assertEqual(settings["agentIdMode"], "project")
+        self.assertEqual(settings["sourceClient"], "hermes")
+        self.assertEqual(settings["memoryMode"], "hybrid")
+        self.assertTrue(settings["autoRetrieve"])
+        self.assertTrue(settings["autoIngest"])
+        self.assertEqual(settings["retrieveStrategy"], "SIMPLE")
+        self.assertEqual(settings["retrieveMaxEntries"], 8)
+        self.assertEqual(settings["retrieveMaxChars"], 6000)
+        self.assertEqual(settings["retrieveContextTurns"], 1)
+        self.assertEqual(settings["ingestionRoles"], ["user", "assistant"])
+        self.assertFalse(settings["debug"])
+
+    def test_plugin_root_imports_when_loaded_as_file(self):
+        spec = importlib.util.spec_from_file_location("memind_hermes_plugin", ROOT / "__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        original_path = list(sys.path)
+
+        try:
+            sys.path = [
+                entry
+                for entry in sys.path
+                if Path(entry or ".").resolve() != ROOT
+            ]
+            spec.loader.exec_module(module)
+        finally:
+            sys.path = original_path
+
+        self.assertTrue(hasattr(module, "register"))
+
+    def test_readme_documents_required_operational_topics(self):
+        readme = (ROOT / "README.md").read_text()
+
+        self.assertIn("Hermes Agent", readme)
+        self.assertIn("memory.provider", readme)
+        self.assertIn("~/.memind/hermes.json", readme)
+        self.assertIn("memoryMode", readme)
+        self.assertIn("memind_retrieve", readme)
+        self.assertIn("memind_extract_text", readme)
+        self.assertIn("HTTP MCP", readme)
+        self.assertIn("sourceClient", readme)
+        self.assertIn("HTTPS", readme)
+        self.assertIn("loopback", readme)
+        self.assertIn("network controls", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_provider.py
+++ b/memind-integrations/hermes/tests/test_provider.py
@@ -1,0 +1,287 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+from memind_hermes.provider import MemindMemoryProvider, register
+
+
+class FakeClient:
+    def __init__(self):
+        self.retrieve_calls = []
+        self.extract_calls = []
+        self.health_calls = 0
+        self.health_result = types.SimpleNamespace(status="UP")
+        self.retrieve_result = {
+            "insights": [{"id": "1", "text": "User likes Rust", "tier": "ROOT"}],
+            "items": [],
+        }
+        self.extract_result = types.SimpleNamespace(status="SUCCESS")
+
+    def health(self):
+        self.health_calls += 1
+        return self.health_result
+
+    def retrieve(self, user_id, agent_id, query, strategy="SIMPLE", trace=False):
+        self.retrieve_calls.append(
+            {
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "query": query,
+                "strategy": strategy,
+                "trace": trace,
+            }
+        )
+        return self.retrieve_result
+
+    def extract(self, user_id, agent_id, raw_content, source_client=None):
+        self.extract_calls.append(
+            {
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "raw_content": raw_content,
+                "source_client": source_client,
+            }
+        )
+        return self.extract_result
+
+
+class ProviderTest(unittest.TestCase):
+    def provider(self, client=None, config=None):
+        cfg = {
+            "memindApiUrl": "http://127.0.0.1:8366",
+            "memindApiToken": None,
+            "userId": "u",
+            "agentId": "hermes",
+            "agentIdMode": "fixed",
+            "sourceClient": "hermes",
+            "memoryMode": "hybrid",
+            "autoRetrieve": True,
+            "autoIngest": True,
+            "retrieveStrategy": "SIMPLE",
+            "retrieveMaxEntries": 8,
+            "retrieveMaxChars": 6000,
+            "retrieveContextTurns": 1,
+            "retrievePromptPreamble": "P",
+            "ingestionRoles": ["user", "assistant"],
+            "debug": False,
+        }
+        if config:
+            cfg.update(config)
+        return MemindMemoryProvider(config_loader=lambda: cfg, client_factory=lambda cfg: client or FakeClient())
+
+    def test_register_registers_memory_provider(self):
+        class Ctx:
+            def __init__(self):
+                self.provider = None
+
+            def register_memory_provider(self, provider):
+                self.provider = provider
+
+        ctx = Ctx()
+        register(ctx)
+
+        self.assertIsInstance(ctx.provider, MemindMemoryProvider)
+
+    def test_initialize_resolves_identity(self):
+        provider = self.provider()
+
+        provider.initialize("s1", cwd="/tmp/project")
+
+        self.assertEqual(provider._session_id, "s1")
+        self.assertEqual(provider._identity["userId"], "u")
+        self.assertEqual(provider._identity["agentId"], "hermes")
+
+    def test_is_available_does_not_call_memind_health(self):
+        client = FakeClient()
+
+        self.assertTrue(self.provider(client=client).is_available())
+        self.assertEqual(client.health_calls, 0)
+        self.assertEqual(client.retrieve_calls, [])
+        self.assertEqual(client.extract_calls, [])
+
+    def test_is_available_rejects_invalid_url(self):
+        self.assertFalse(self.provider(config={"memindApiUrl": "not-a-url"}).is_available())
+
+    def test_is_available_returns_true_with_injected_client_factory(self):
+        self.assertTrue(self.provider().is_available())
+
+    def test_prefetch_retrieves_and_formats_context(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        context = provider.prefetch("favorite language")
+
+        self.assertIn("<memind_memories>", context)
+        self.assertIn("User likes Rust", context)
+        self.assertEqual(client.retrieve_calls[0]["strategy"], "SIMPLE")
+
+    def test_prefetch_disabled_in_tools_mode(self):
+        client = FakeClient()
+        provider = self.provider(client=client, config={"memoryMode": "tools"})
+        provider.initialize("s1", cwd="/tmp/project")
+
+        self.assertEqual(provider.prefetch("favorite language"), "")
+        self.assertEqual(client.retrieve_calls, [])
+
+    def test_queue_prefetch_sets_result_and_thread(self):
+        provider = self.provider()
+        provider.initialize("s1", cwd="/tmp/project")
+
+        provider.queue_prefetch("favorite language")
+        provider._prefetch_thread.join(timeout=2)
+
+        self.assertIn("User likes Rust", provider._prefetch_result)
+
+    def test_sync_turn_extracts_conversation_on_background_thread(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        provider.sync_turn("hello <memind_memories>x</memind_memories>", "hi")
+        provider._sync_thread.join(timeout=2)
+
+        self.assertEqual(len(client.extract_calls), 1)
+        call = client.extract_calls[0]
+        self.assertEqual(call["source_client"], "hermes")
+        dumped = call["raw_content"].model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["type"], "conversation")
+        self.assertNotIn("memind_memories", dumped["messages"][0]["content"][0]["text"])
+
+    def test_sync_turn_respects_ingestion_roles(self):
+        client = FakeClient()
+        provider = self.provider(client=client, config={"ingestionRoles": ["user"]})
+        provider.initialize("s1", cwd="/tmp/project")
+
+        provider.sync_turn("remember espresso", "ok")
+        provider._sync_thread.join(timeout=2)
+
+        dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(len(dumped["messages"]), 1)
+        self.assertEqual(dumped["messages"][0]["role"], "USER")
+
+    def test_on_pre_compress_inserts_context(self):
+        provider = self.provider()
+        provider.initialize("s1", cwd="/tmp/project")
+        messages = [{"role": "user", "content": "current prompt"}]
+
+        provider.on_pre_compress(messages, session_id="s1")
+
+        self.assertEqual(messages[0]["role"], "user")
+        self.assertIn("[Memind context before compaction]", messages[0]["content"])
+
+    def test_on_pre_compress_uses_retrieve_context_turns(self):
+        client = FakeClient()
+        provider = self.provider(client=client, config={"retrieveContextTurns": 1})
+        provider.initialize("s1", cwd="/tmp/project")
+        messages = [
+            {"role": "user", "content": "old user"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "recent user"},
+            {"role": "assistant", "content": "recent assistant"},
+        ]
+
+        provider.on_pre_compress(messages, session_id="s1")
+
+        query = client.retrieve_calls[0]["query"]
+        self.assertNotIn("old user", query)
+        self.assertIn("recent user", query)
+        self.assertIn("recent assistant", query)
+
+    def test_on_pre_compress_does_not_duplicate_existing_memind_context(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+        messages = [
+            {"role": "user", "content": "[Memind context before compaction]\n<memind_memories>x</memind_memories>"},
+            {"role": "user", "content": "current prompt"},
+        ]
+
+        provider.on_pre_compress(messages, session_id="s1")
+
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(client.retrieve_calls, [])
+
+    def test_on_memory_write_extracts_standalone_text(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        provider.on_memory_write("add", "MEMORY.md", "remember espresso")
+        provider._sync_thread.join(timeout=2)
+
+        dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["messages"][0]["role"], "USER")
+        self.assertEqual(dumped["messages"][0]["content"][0]["text"], "remember espresso")
+
+    def test_get_config_schema_and_save_config(self):
+        provider = self.provider()
+
+        self.assertTrue(provider.get_config_schema())
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch("memind_hermes.provider.save_provider_config") as save:
+                provider.save_config({"userId": "u"}, tmp)
+        save.assert_called_once_with({"userId": "u"})
+
+    def test_context_mode_hides_tools(self):
+        provider = self.provider(config={"memoryMode": "context"})
+        provider.initialize("s1", cwd="/tmp/project")
+
+        self.assertEqual(provider.get_tool_schemas(), [])
+
+    def test_tools_mode_exposes_tools(self):
+        provider = self.provider(config={"memoryMode": "tools"})
+        provider.initialize("s1", cwd="/tmp/project")
+
+        names = [tool["name"] for tool in provider.get_tool_schemas()]
+        self.assertEqual(names, ["memind_retrieve", "memind_extract_text"])
+
+    def test_handle_retrieve_tool_returns_json_string(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        result = json.loads(provider.handle_tool_call("memind_retrieve", {"query": "rust"}))
+
+        self.assertIn("insights", result)
+        self.assertEqual(client.retrieve_calls[0]["query"], "rust")
+
+    def test_handle_retrieve_tool_rejects_invalid_strategy(self):
+        provider = self.provider()
+        provider.initialize("s1", cwd="/tmp/project")
+
+        result = json.loads(provider.handle_tool_call("memind_retrieve", {"query": "rust", "strategy": "bad"}))
+
+        self.assertIn("error", result)
+
+    def test_handle_extract_text_uses_user_message_content(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        result = json.loads(provider.handle_tool_call("memind_extract_text", {"text": "remember espresso"}))
+
+        self.assertEqual(result["status"], "SUCCESS")
+        dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["messages"][0]["role"], "USER")
+        self.assertEqual(dumped["messages"][0]["content"][0]["text"], "remember espresso")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a native Hermes Agent memory provider integration under `memind-integrations/hermes`.
- Support automatic Memind recall, conversation ingestion, pre-compression context injection, memory write ingestion, and the `memind_retrieve` / `memind_extract_text` Hermes-native tools.
- Add Hermes-specific configuration, identity resolution, formatting, documentation, and a root README pointer.

## Test Plan
- `PYTHONPATH=memind-integrations/hermes:memind-clients/python/src UV_CACHE_DIR=.uv-cache uv run --python /opt/homebrew/bin/python3.12 --with httpx --with pydantic --with typing-extensions python -m unittest discover -s memind-integrations/hermes/tests -v`
- `PYTHONPATH=memind-integrations/claude-code python3 -m unittest discover -s memind-integrations/claude-code/tests -v`
- `PYTHONPATH=memind-integrations/codex /opt/homebrew/bin/python3.12 -m unittest discover -s memind-integrations/codex/tests -v`
- `git diff --cached --check`