### PR TITLE
Recover stale Claude Code retry claims

### DIFF
--- a/memind-integrations/claude-code/scripts/lib/retry.py
+++ b/memind-integrations/claude-code/scripts/lib/retry.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 
 class RetrySpool:
+    DEFAULT_CLAIM_STALE_SECONDS = 5 * 60
+
     def __init__(self, root):
         self.root = Path(root)
         self.root.mkdir(parents=True, exist_ok=True)
@@ -39,10 +41,30 @@ class RetrySpool:
             claimed = path.with_suffix(".claimed")
             try:
                 path.replace(claimed)
+                claimed.touch()
                 return claimed
             except OSError:
                 continue
         return None
+
+    def recover_orphaned_claims(self, max_age_seconds=None):
+        cutoff = time.time() - (
+            self.DEFAULT_CLAIM_STALE_SECONDS
+            if max_age_seconds is None
+            else max_age_seconds
+        )
+        recovered = 0
+        for path in sorted(self.root.glob("*.claimed"), key=lambda item: item.stat().st_mtime):
+            try:
+                if path.stat().st_mtime > cutoff:
+                    continue
+                target = path.with_suffix(".json")
+                path.replace(target)
+                target.touch()
+                recovered += 1
+            except OSError:
+                continue
+        return recovered
 
     def load_claimed(self, path):
         return json.loads(Path(path).read_text())

--- a/memind-integrations/claude-code/scripts/session_start.py
+++ b/memind-integrations/claude-code/scripts/session_start.py
@@ -48,6 +48,7 @@ async def _run_session_start_async(config):
         claimed = None
         try:
             spool = RetrySpool(retry_root())
+            spool.recover_orphaned_claims()
             claimed = spool.claim_next()
             if claimed:
                 payload = spool.load_claimed(claimed)

--- a/memind-integrations/claude-code/tests/test_hooks.py
+++ b/memind-integrations/claude-code/tests/test_hooks.py
@@ -13,11 +13,13 @@
 #
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
 import types
 import unittest
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -315,6 +317,56 @@ class HookTest(unittest.TestCase):
             with SessionStateStore(state_dir).locked("s1") as state:
                 self.assertFalse(state.is_submitted("fp1"))
             self.assertEqual(len(list(retry_dir.glob("*.json"))), 1)
+            client.extract.assert_awaited_once()
+
+    def test_session_start_recovers_orphaned_claims_before_replay(self):
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import session_start
+        from scripts.lib.retry import RetrySpool
+
+        with tempfile.TemporaryDirectory() as tmp:
+            retry_dir = Path(tmp) / "retry"
+            state_dir = Path(tmp) / "state"
+            spool = RetrySpool(retry_dir)
+            original = spool.enqueue(
+                {
+                    "kind": "extract",
+                    "userId": "u",
+                    "agentId": "a",
+                    "sourceClient": "claude-code",
+                    "sessionId": "s1",
+                    "fingerprints": ["fp1"],
+                    "rawContent": {
+                        "type": "conversation",
+                        "messages": [
+                            {"role": "USER", "content": [{"type": "text", "text": "hello"}]}
+                        ],
+                    },
+                }
+            )
+            claimed = original.with_suffix(".claimed")
+            original.replace(claimed)
+            old_time = time.time() - 10 * 60
+            os.utime(claimed, (old_time, old_time))
+            config = {
+                "memindApiUrl": "http://127.0.0.1:8366",
+                "memindApiToken": None,
+                "ingestRetryMaxFiles": 20,
+                "ingestRetryMaxAgeDays": 7,
+                "stateMaxAgeDays": 14,
+                "debug": False,
+            }
+            with mock.patch.object(session_start, "load_config", return_value=config):
+                with mock.patch.object(session_start, "retry_root", return_value=retry_dir):
+                    with mock.patch.object(session_start, "state_root", return_value=state_dir):
+                        with mock.patch.object(session_start, "MemindClient") as client_cls:
+                            client = client_cls.return_value
+                            client.health = mock.AsyncMock(return_value=types.SimpleNamespace(status="UP"))
+                            client.extract = mock.AsyncMock(return_value=types.SimpleNamespace(status="SUCCESS"))
+                            client.add_message = mock.AsyncMock(return_value=None)
+                            client.commit = mock.AsyncMock(return_value=None)
+                            session_start.main()
+            self.assertEqual(list(retry_dir.glob("*.json")), [])
             client.extract.assert_awaited_once()
 
 

--- a/memind-integrations/claude-code/tests/test_retry.py
+++ b/memind-integrations/claude-code/tests/test_retry.py
@@ -51,6 +51,22 @@ class RetrySpoolTest(unittest.TestCase):
             spool.release(claimed)
             self.assertIsNotNone(spool.claim_next())
 
+    def test_recover_orphaned_claims_restores_dead_claims(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spool = RetrySpool(Path(tmp))
+            original = spool.enqueue({"kind": "commit", "payload": {"userId": "u"}})
+            claimed = original.with_suffix(".claimed")
+            original.replace(claimed)
+            old_time = time.time() - 10 * 60
+            os.utime(claimed, (old_time, old_time))
+
+            recovered = spool.recover_orphaned_claims()
+
+            self.assertEqual(recovered, 1)
+            self.assertTrue(original.exists())
+            self.assertFalse(claimed.exists())
+            self.assertIsNotNone(spool.claim_next())
+
     def test_cleanup_discards_old_payloads(self):
         with tempfile.TemporaryDirectory() as tmp:
             spool = RetrySpool(Path(tmp))


### PR DESCRIPTION
## Summary
- Recover orphaned retry spool files that were left behind as .claimed after a crash.
- Replay recovered payloads during SessionStart before processing the normal retry queue.
- Add regression tests for stale claim recovery and startup replay.

## Test Plan
- [x] python3 -m unittest tests.test_retry tests.test_hooks (from memind-integrations/claude-code)
