### PR TITLE
Add agent timeline ingestion for OpenClaw and Hermes

### DIFF
--- a/memind-integrations/hermes/README.md
+++ b/memind-integrations/hermes/README.md
@@ -1,11 +1,11 @@
 # Memind Hermes Agent Integration
 
-Memind adds persistent project memory to Hermes Agent through a native Hermes memory provider.
-The provider retrieves relevant Memind context before each turn and submits successful
-user/assistant conversation turns to Memind extraction after each response.
+Memind adds persistent agent memory to Hermes Agent through a native Hermes memory provider.
+The provider retrieves relevant Memind context before each turn and submits completed Hermes
+activity as Memind `agent_timeline` raw data after each response.
 
-Use this integration when you want Hermes to remember project facts, preferences, decisions,
-and prior discussions across sessions.
+Use this integration when you want Hermes to remember user preferences, durable facts, decisions,
+commitments, task outcomes, and prior discussions across sessions.
 
 The integration is intentionally small:
 
@@ -13,7 +13,8 @@ The integration is intentionally small:
 - Connects to an already-running `memind-server`.
 - Does not manage a local Memind daemon.
 - Does not require MCP for automatic memory.
-- Does not ingest tool calls or media in v0.1.
+- Captures general-agent lifecycle events; it does not enable coding-specific file context.
+- Does not ingest media in v0.1.
 
 ## Requirements
 
@@ -74,6 +75,7 @@ User overrides live in `~/.memind/hermes.json`:
   "memoryMode": "hybrid",
   "autoRetrieve": true,
   "autoIngest": true,
+  "autoIngestAgentTimeline": true,
   "retrieveStrategy": "SIMPLE"
 }
 ```
@@ -95,6 +97,10 @@ export MEMIND_AGENT_ID_MODE=project
 export MEMIND_SOURCE_CLIENT=hermes
 export MEMIND_MEMORY_MODE=hybrid
 export MEMIND_RETRIEVE_STRATEGY=SIMPLE
+export MEMIND_AUTO_INGEST_AGENT_TIMELINE=true
+export MEMIND_TIMELINE_MAX_EVENTS=500
+export MEMIND_TIMELINE_MAX_FIELD_CHARS=8000
+export MEMIND_TIMELINE_FLUSH_MIN_EVENTS=2
 ```
 
 ## Memory Modes
@@ -117,7 +123,8 @@ When `memoryMode` is `hybrid` or `tools`, the provider exposes:
 - `memind_retrieve`: retrieve relevant Memind memory for the configured `userId` and `agentId`.
 - `memind_extract_text`: extract memory from standalone text such as pasted notes or document excerpts.
 
-Normal Hermes conversation turns are captured automatically through the memory provider.
+Normal Hermes turns are captured automatically as `agent_timeline` raw data through the memory
+provider.
 Use `memind_extract_text` only for one-off text memory.
 
 ## Identity Model
@@ -128,8 +135,26 @@ By default, Memind stores Hermes memory under:
 - `agentId`: `hermes__<project-name>-<stable-hash>`
 
 The project hash is based on the Git remote URL when available, otherwise the local project path.
-Set `"agentIdMode": "fixed"` to share one Hermes memory scope across projects. Set
-`"agentIdMode": "session"` to isolate by Hermes session.
+This keeps existing users from unexpectedly merging memories across workspaces.
+
+For general-agent usage where the same assistant should remember across workspaces, channels, or
+sessions, set `"agentIdMode": "fixed"` and choose a stable `"agentId"`. Runtime context such as
+`workspaceDir` and `sessionKey` is stored in `agent_timeline.metadata`; it does not change the
+Memind memory identity. Set `"agentIdMode": "session"` to isolate by Hermes session.
+
+## Agent Timeline Ingestion
+
+Automatic lifecycle capture is controlled by `autoIngest` and `autoIngestAgentTimeline`.
+
+- `sync_turn` appends `user_prompt`, `assistant_message`, and `stop`, then flushes one timeline.
+- `on_memory_write` appends a `notification` event with `metadata.memoryWrite = true`, appends
+  `stop`, then flushes.
+- `on_pre_compress` appends `compact_boundary` and still injects pre-compress retrieval context.
+- `on_session_end` appends `session_end` and force-flushes remaining events.
+
+The submitted payload uses `metadata.profile = "general"` and `metadata.runtime = "hermes"`.
+The explicit `memind_extract_text` tool remains a standalone conversation/raw-text extraction path;
+it is intentionally separate from automatic agent lifecycle capture.
 
 ## Relationship To HTTP MCP
 

--- a/memind-integrations/hermes/memind_hermes/agent_timeline.py
+++ b/memind-integrations/hermes/memind_hermes/agent_timeline.py
@@ -1,0 +1,135 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+from memind_hermes.content import clamp_text
+
+
+def user_prompt_event(text, seq, *, session_id, max_field_chars=8000, metadata=None):
+    cleaned = clamp_text(text, max_field_chars)
+    if not cleaned:
+        return None
+    return _event("user_prompt", seq, session_id, text=cleaned, metadata=metadata)
+
+
+def assistant_message_event(text, seq, *, session_id, max_field_chars=8000, metadata=None):
+    cleaned = clamp_text(text, max_field_chars)
+    if not cleaned:
+        return None
+    return _event("assistant_message", seq, session_id, text=cleaned, metadata=metadata)
+
+
+def memory_write_event(action, target, content, seq, *, session_id, max_field_chars=8000):
+    cleaned = clamp_text(content, max_field_chars)
+    if not cleaned:
+        return None
+    return _event(
+        "notification",
+        seq,
+        session_id,
+        text=cleaned,
+        metadata={
+            "memoryWrite": True,
+            "action": action,
+            "target": target,
+        },
+    )
+
+
+def compact_boundary_event(messages, seq, *, session_id):
+    return _event(
+        "compact_boundary",
+        seq,
+        session_id,
+        status="success",
+        metadata={"messageCount": len(messages or [])},
+    )
+
+
+def stop_event(seq, *, session_id, success=True):
+    return _event("stop", seq, session_id, status="success" if success else "failed")
+
+
+def session_end_event(seq, *, session_id, metadata=None):
+    return _event("session_end", seq, session_id, status="success", metadata=metadata)
+
+
+def build_timeline_content(
+    *,
+    source_client,
+    session_id,
+    agent_turn_id,
+    timeline_id,
+    events,
+    metadata=None,
+):
+    metadata = _compact_metadata(
+        {
+            "profile": "general",
+            "runtime": "hermes",
+            "sessionKey": session_id,
+            **(metadata or {}),
+        }
+    )
+    return {
+        "type": "agent_timeline",
+        "sourceClient": source_client,
+        "sessionId": session_id,
+        "agentTurnId": agent_turn_id,
+        "timelineId": timeline_id,
+        "events": [event for event in events if event],
+        "metadata": metadata,
+    }
+
+
+def _event(kind, seq, session_id, *, text=None, status=None, metadata=None):
+    payload = {
+        "kind": kind,
+        "seq": seq,
+        "sessionId": session_id,
+        "text": text,
+        "status": status,
+        "metadata": metadata or {},
+    }
+    content_hash = _hash(payload)
+    event = {
+        "eventId": f"hermes-{session_id}-{seq}-{content_hash[:12]}",
+        "seq": seq,
+        "kind": kind,
+        "occurredAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "contentHash": content_hash,
+        "metadata": _compact_metadata({"sessionKey": session_id, **(metadata or {})}),
+    }
+    if text:
+        event["text"] = text
+    if status:
+        event["status"] = status
+    return event
+
+
+def _hash(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def _compact_metadata(values):
+    result = {}
+    for key, value in values.items():
+        if isinstance(value, str) and value.strip():
+            result[key] = value
+        elif isinstance(value, (int, float, bool)) and value is not None:
+            result[key] = value
+    return result

--- a/memind-integrations/hermes/memind_hermes/client.py
+++ b/memind-integrations/hermes/memind_hermes/client.py
@@ -16,16 +16,49 @@
 def build_conversation_content(role_text_pairs):
     if not role_text_pairs:
         raise ValueError("conversation content requires at least one message")
-    from memind import ConversationContent, Message
+    try:
+        from memind import ConversationContent, Message
 
-    messages = []
-    for role, text in role_text_pairs:
-        normalized = str(role).upper()
-        if normalized == "ASSISTANT":
-            messages.append(Message.assistant(text))
-        else:
-            messages.append(Message.user(text))
-    return ConversationContent(messages=messages)
+        messages = []
+        for role, text in role_text_pairs:
+            normalized = str(role).upper()
+            if normalized == "ASSISTANT":
+                messages.append(Message.assistant(text))
+            else:
+                messages.append(Message.user(text))
+        return ConversationContent(messages=messages)
+    except Exception:
+        messages = []
+        for role, text in role_text_pairs:
+            normalized = "ASSISTANT" if str(role).upper() == "ASSISTANT" else "USER"
+            messages.append({"role": normalized, "content": [{"type": "text", "text": text}]})
+        return _SimpleRawContent({"type": "conversation", "messages": messages})
+
+
+def build_agent_timeline_content(timeline):
+    timeline = {"type": "agent_timeline", **dict(timeline)}
+    try:
+        from memind import MapRawContent
+
+        return MapRawContent.model_validate(timeline)
+    except Exception:
+        return _SimpleRawContent(dict(timeline))
+
+
+class _SimpleRawContent:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self, by_alias=True, exclude_none=True):
+        return _drop_none(self._payload) if exclude_none else dict(self._payload)
+
+
+def _drop_none(value):
+    if isinstance(value, dict):
+        return {key: _drop_none(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [_drop_none(item) for item in value if item is not None]
+    return value
 
 
 class MemindClient:

--- a/memind-integrations/hermes/memind_hermes/config.py
+++ b/memind-integrations/hermes/memind_hermes/config.py
@@ -27,12 +27,16 @@ DEFAULT_SETTINGS = {
     "memoryMode": "hybrid",
     "autoRetrieve": True,
     "autoIngest": True,
+    "autoIngestAgentTimeline": True,
     "retrieveStrategy": "SIMPLE",
     "retrieveMaxEntries": 8,
     "retrieveMaxChars": 6000,
     "retrieveContextTurns": 1,
     "retrievePromptPreamble": "Relevant memories from Memind. Use only when directly helpful:",
     "ingestionRoles": ["user", "assistant"],
+    "timelineMaxEvents": 500,
+    "timelineMaxFieldChars": 8000,
+    "timelineFlushMinEvents": 2,
     "debug": False,
 }
 
@@ -46,11 +50,15 @@ ENV_MAP = {
     "MEMIND_MEMORY_MODE": ("memoryMode", str),
     "MEMIND_AUTO_RETRIEVE": ("autoRetrieve", "bool"),
     "MEMIND_AUTO_INGEST": ("autoIngest", "bool"),
+    "MEMIND_AUTO_INGEST_AGENT_TIMELINE": ("autoIngestAgentTimeline", "bool"),
     "MEMIND_RETRIEVE_STRATEGY": ("retrieveStrategy", str),
     "MEMIND_RETRIEVE_MAX_ENTRIES": ("retrieveMaxEntries", "int"),
     "MEMIND_RETRIEVE_MAX_CHARS": ("retrieveMaxChars", "int"),
     "MEMIND_RETRIEVE_CONTEXT_TURNS": ("retrieveContextTurns", "int_allow_zero"),
     "MEMIND_INGESTION_ROLES": ("ingestionRoles", "list"),
+    "MEMIND_TIMELINE_MAX_EVENTS": ("timelineMaxEvents", "int"),
+    "MEMIND_TIMELINE_MAX_FIELD_CHARS": ("timelineMaxFieldChars", "int"),
+    "MEMIND_TIMELINE_FLUSH_MIN_EVENTS": ("timelineFlushMinEvents", "int"),
     "MEMIND_DEBUG": ("debug", "bool"),
 }
 

--- a/memind-integrations/hermes/memind_hermes/content.py
+++ b/memind-integrations/hermes/memind_hermes/content.py
@@ -26,3 +26,11 @@ def text_or_empty(value):
     if value is None:
         return ""
     return strip_memind_blocks(str(value)).strip()
+
+
+def clamp_text(value, max_chars):
+    text = text_or_empty(value)
+    if len(text) <= max_chars:
+        return text
+    suffix = "\n[truncated]"
+    return text[: max(0, max_chars - len(suffix))].rstrip() + suffix

--- a/memind-integrations/hermes/memind_hermes/provider.py
+++ b/memind-integrations/hermes/memind_hermes/provider.py
@@ -15,13 +15,24 @@
 import json
 import os
 import threading
+from pathlib import Path
 from urllib.parse import urlparse
 
-from memind_hermes.client import MemindClient, build_conversation_content
+from memind_hermes.agent_timeline import (
+    assistant_message_event,
+    build_timeline_content,
+    compact_boundary_event,
+    memory_write_event,
+    session_end_event,
+    stop_event,
+    user_prompt_event,
+)
+from memind_hermes.client import MemindClient, build_agent_timeline_content, build_conversation_content
 from memind_hermes.config import config_schema, load_config, save_config as save_provider_config
 from memind_hermes.content import text_or_empty
 from memind_hermes.format import format_memind_context
 from memind_hermes.identity import resolve_identity
+from memind_hermes.state import AgentTimelineState
 
 try:
     from agent.memory_provider import MemoryProvider
@@ -51,6 +62,7 @@ class MemindMemoryProvider(MemoryProvider):
         self._prefetch_thread = None
         self._prefetch_result = ""
         self._sync_thread = None
+        self._timeline_state = None
 
     @property
     def name(self):
@@ -88,6 +100,12 @@ class MemindMemoryProvider(MemoryProvider):
         self._cwd = kwargs.get("cwd") or os.getcwd()
         self._identity = resolve_identity(self._config, cwd=self._cwd, session_id=session_id)
         self._client = self._client_factory(self._config)
+        state_root = Path(
+            kwargs.get("state_dir")
+            or self._config.get("stateDir")
+            or Path.home() / ".memind" / "hermes" / "agent-events"
+        )
+        self._timeline_state = AgentTimelineState(state_root, max_events=int(self._config.get("timelineMaxEvents", 500)))
 
     def get_config_schema(self):
         return config_schema()
@@ -149,16 +167,79 @@ class MemindMemoryProvider(MemoryProvider):
             self._identity["sourceClient"],
         )
 
+    def _timeline_metadata(self, **extra):
+        metadata = {
+            "workspaceDir": self._cwd,
+            "agentName": "hermes",
+            **extra,
+        }
+        return {key: value for key, value in metadata.items() if value is not None}
+
+    def _append_timeline_event(self, event):
+        if event and self._timeline_state:
+            self._timeline_state.append(self._session_id, event)
+
+    def _next_timeline_seq(self):
+        return self._timeline_state.next_seq(self._session_id) if self._timeline_state else 1
+
+    def _flush_timeline(self, force=False):
+        if not self._timeline_state:
+            return
+        events = self._timeline_state.list(self._session_id)
+        if not force and len(events) < int(self._config.get("timelineFlushMinEvents", 2)):
+            return
+        timeline = build_timeline_content(
+            source_client=self._identity["sourceClient"],
+            session_id=self._session_id,
+            agent_turn_id=f"{self._session_id}-turn-{events[0].get('seq', 1)}",
+            timeline_id=f"hermes-{self._session_id}-{events[0].get('seq', 1)}-{events[-1].get('seq', 1)}",
+            events=events,
+            metadata=self._timeline_metadata(),
+        )
+        raw_content = build_agent_timeline_content(timeline)
+        result = self._client.extract(
+            self._identity["userId"],
+            self._identity["agentId"],
+            raw_content,
+            self._identity["sourceClient"],
+        )
+        status = getattr(result, "status", None)
+        if status == "SUCCESS" or status is None:
+            self._timeline_state.clear(self._session_id, [event.get("eventId") for event in events])
+
     def sync_turn(self, user=None, assistant=None, **kwargs):
         self._ensure_initialized()
         if not self._config.get("autoIngest", True):
+            return
+        if not self._config.get("autoIngestAgentTimeline", True):
+            self._sync_thread = threading.Thread(target=lambda: None, daemon=True)
+            self._sync_thread.start()
             return
         user_text = kwargs.get("user_content", user)
         assistant_text = kwargs.get("assistant_content", assistant)
 
         def run():
             try:
-                self._extract_pairs([("USER", user_text), ("ASSISTANT", assistant_text)])
+                self._append_timeline_event(
+                    user_prompt_event(
+                        user_text,
+                        self._next_timeline_seq(),
+                        session_id=self._session_id,
+                        max_field_chars=int(self._config.get("timelineMaxFieldChars", 8000)),
+                        metadata=self._timeline_metadata(),
+                    )
+                )
+                self._append_timeline_event(
+                    assistant_message_event(
+                        assistant_text,
+                        self._next_timeline_seq(),
+                        session_id=self._session_id,
+                        max_field_chars=int(self._config.get("timelineMaxFieldChars", 8000)),
+                        metadata=self._timeline_metadata(),
+                    )
+                )
+                self._append_timeline_event(stop_event(self._next_timeline_seq(), session_id=self._session_id, success=True))
+                self._flush_timeline()
             except Exception as exc:
                 self._debug(f"sync turn failed: {exc}")
 
@@ -166,10 +247,26 @@ class MemindMemoryProvider(MemoryProvider):
         self._sync_thread.start()
 
     def on_session_end(self, messages, **kwargs):
+        self._ensure_initialized()
+        if not self._config.get("autoIngest", True) or not self._config.get("autoIngestAgentTimeline", True):
+            return None
+        try:
+            self._append_timeline_event(
+                session_end_event(
+                    self._next_timeline_seq(),
+                    session_id=self._session_id,
+                    metadata=self._timeline_metadata(),
+                )
+            )
+            self._flush_timeline(force=True)
+        except Exception as exc:
+            self._debug(f"session end failed: {exc}")
         return None
 
     def on_pre_compress(self, messages, **kwargs):
         self._ensure_initialized()
+        if self._config.get("autoIngest", True) and self._config.get("autoIngestAgentTimeline", True):
+            self._append_timeline_event(compact_boundary_event(messages, self._next_timeline_seq(), session_id=self._session_id))
         if not self._auto_retrieve_enabled():
             return
         try:
@@ -201,7 +298,20 @@ class MemindMemoryProvider(MemoryProvider):
 
         def run():
             try:
-                self._extract_pairs([("USER", content)])
+                if not self._config.get("autoIngest", True) or not self._config.get("autoIngestAgentTimeline", True):
+                    return
+                self._append_timeline_event(
+                    memory_write_event(
+                        action,
+                        target,
+                        content,
+                        self._next_timeline_seq(),
+                        session_id=self._session_id,
+                        max_field_chars=int(self._config.get("timelineMaxFieldChars", 8000)),
+                    )
+                )
+                self._append_timeline_event(stop_event(self._next_timeline_seq(), session_id=self._session_id, success=True))
+                self._flush_timeline()
             except Exception as exc:
                 self._debug(f"memory write failed: {exc}")
 

--- a/memind-integrations/hermes/memind_hermes/state.py
+++ b/memind-integrations/hermes/memind_hermes/state.py
@@ -1,0 +1,75 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import re
+from pathlib import Path
+
+
+class AgentTimelineState:
+    def __init__(self, root, max_events=500):
+        self.root = Path(root)
+        self.max_events = max_events
+
+    def append(self, session_id, event):
+        if not event or not event.get("eventId"):
+            return
+        state = self._read(session_id)
+        if any(existing.get("eventId") == event["eventId"] for existing in state["events"]):
+            return
+        events = sorted([*state["events"], event], key=_event_key)
+        if len(events) > self.max_events:
+            events = events[-self.max_events :]
+        self._write(session_id, {"version": 1, "events": events})
+
+    def list(self, session_id):
+        return sorted(self._read(session_id)["events"], key=_event_key)
+
+    def clear(self, session_id, event_ids=None):
+        if not event_ids:
+            self._write(session_id, {"version": 1, "events": []})
+            return
+        submitted = set(event_ids)
+        events = [event for event in self.list(session_id) if event.get("eventId") not in submitted]
+        self._write(session_id, {"version": 1, "events": events})
+
+    def next_seq(self, session_id):
+        events = self.list(session_id)
+        if not events:
+            return 1
+        return max(int(event.get("seq") or 0) for event in events) + 1
+
+    def _read(self, session_id):
+        try:
+            parsed = json.loads(self._path(session_id).read_text())
+            if parsed.get("version") == 1 and isinstance(parsed.get("events"), list):
+                return {"version": 1, "events": [event for event in parsed["events"] if event.get("eventId")]}
+        except Exception:
+            pass
+        return {"version": 1, "events": []}
+
+    def _write(self, session_id, state):
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._path(session_id).write_text(json.dumps(state, indent=2, default=str) + "\n")
+
+    def _path(self, session_id):
+        return self.root / f"{_safe_key(session_id)}.json"
+
+
+def _safe_key(value):
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value or "default")) or "default"
+
+
+def _event_key(event):
+    return (int(event.get("seq") or 0), str(event.get("eventId") or ""))

--- a/memind-integrations/hermes/settings.json
+++ b/memind-integrations/hermes/settings.json
@@ -8,11 +8,15 @@
   "memoryMode": "hybrid",
   "autoRetrieve": true,
   "autoIngest": true,
+  "autoIngestAgentTimeline": true,
   "retrieveStrategy": "SIMPLE",
   "retrieveMaxEntries": 8,
   "retrieveMaxChars": 6000,
   "retrieveContextTurns": 1,
   "retrievePromptPreamble": "Relevant memories from Memind. Use only when directly helpful:",
   "ingestionRoles": ["user", "assistant"],
+  "timelineMaxEvents": 500,
+  "timelineMaxFieldChars": 8000,
+  "timelineFlushMinEvents": 2,
   "debug": false
 }

--- a/memind-integrations/hermes/tests/test_agent_timeline.py
+++ b/memind-integrations/hermes/tests/test_agent_timeline.py
@@ -1,0 +1,82 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from memind_hermes.agent_timeline import (
+    assistant_message_event,
+    build_timeline_content,
+    compact_boundary_event,
+    memory_write_event,
+    session_end_event,
+    stop_event,
+    user_prompt_event,
+)
+
+
+class AgentTimelineTest(unittest.TestCase):
+    def test_user_prompt_event_strips_memind_context(self):
+        event = user_prompt_event(
+            "<memind_memories>x</memind_memories>hello",
+            1,
+            session_id="s1",
+            metadata={"turnId": "turn-1"},
+        )
+
+        self.assertEqual(event["kind"], "user_prompt")
+        self.assertEqual(event["text"], "hello")
+        self.assertEqual(event["metadata"]["turnId"], "turn-1")
+        self.assertTrue(event["eventId"].startswith("hermes-"))
+
+    def test_assistant_message_event(self):
+        event = assistant_message_event("hi", 2, session_id="s1")
+
+        self.assertEqual(event["kind"], "assistant_message")
+        self.assertEqual(event["text"], "hi")
+
+    def test_memory_write_event(self):
+        event = memory_write_event("add", "MEMORY.md", "remember espresso", 3, session_id="s1")
+
+        self.assertEqual(event["kind"], "notification")
+        self.assertEqual(event["text"], "remember espresso")
+        self.assertEqual(event["metadata"]["memoryWrite"], True)
+        self.assertEqual(event["metadata"]["target"], "MEMORY.md")
+
+    def test_compact_stop_and_session_end_events(self):
+        self.assertEqual(compact_boundary_event([], 4, session_id="s1")["kind"], "compact_boundary")
+        self.assertEqual(stop_event(5, session_id="s1", success=True)["status"], "success")
+        self.assertEqual(session_end_event(6, session_id="s1")["kind"], "session_end")
+
+    def test_build_timeline_content_sets_general_metadata(self):
+        events = [
+            user_prompt_event("hello", 1, session_id="s1"),
+            stop_event(2, session_id="s1", success=True),
+        ]
+        content = build_timeline_content(
+            source_client="hermes",
+            session_id="s1",
+            agent_turn_id="turn-1",
+            timeline_id="timeline-1",
+            events=events,
+            metadata={"workspaceDir": "/tmp/acme"},
+        )
+
+        self.assertEqual(content["type"], "agent_timeline")
+        self.assertEqual(content["metadata"]["profile"], "general")
+        self.assertEqual(content["metadata"]["runtime"], "hermes")
+        self.assertEqual(content["metadata"]["sessionKey"], "s1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/hermes/tests/test_client.py
+++ b/memind-integrations/hermes/tests/test_client.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from memind_hermes.client import build_conversation_content
+from memind_hermes.client import build_agent_timeline_content, build_conversation_content
 
 
 class ClientTest(unittest.TestCase):
@@ -29,6 +29,22 @@ class ClientTest(unittest.TestCase):
     def test_build_conversation_content_rejects_empty_messages(self):
         with self.assertRaises(ValueError):
             build_conversation_content([])
+
+    def test_build_agent_timeline_content_uses_map_raw_content(self):
+        content = build_agent_timeline_content(
+            {
+                "sourceClient": "hermes",
+                "sessionId": "s1",
+                "agentTurnId": "turn-1",
+                "timelineId": "timeline-1",
+                "events": [{"eventId": "e1", "seq": 1, "kind": "user_prompt"}],
+                "metadata": {"profile": "general", "runtime": "hermes"},
+            }
+        )
+
+        dumped = content.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["type"], "agent_timeline")
+        self.assertEqual(dumped["events"][0]["kind"], "user_prompt")
 
 
 if __name__ == "__main__":

--- a/memind-integrations/hermes/tests/test_config.py
+++ b/memind-integrations/hermes/tests/test_config.py
@@ -49,6 +49,10 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(DEFAULT_SETTINGS["sourceClient"], "hermes")
         self.assertEqual(DEFAULT_SETTINGS["memoryMode"], "hybrid")
         self.assertEqual(DEFAULT_SETTINGS["retrieveStrategy"], "SIMPLE")
+        self.assertTrue(DEFAULT_SETTINGS["autoIngestAgentTimeline"])
+        self.assertEqual(DEFAULT_SETTINGS["timelineMaxEvents"], 500)
+        self.assertEqual(DEFAULT_SETTINGS["timelineMaxFieldChars"], 8000)
+        self.assertEqual(DEFAULT_SETTINGS["timelineFlushMinEvents"], 2)
 
     def test_load_order_settings_user_env(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -60,7 +64,9 @@ class ConfigTest(unittest.TestCase):
                 "MEMIND_RETRIEVE_MAX_ENTRIES": "7",
                 "MEMIND_MEMORY_MODE": "tools",
                 "MEMIND_AUTO_RETRIEVE": "false",
+                "MEMIND_AUTO_INGEST_AGENT_TIMELINE": "false",
                 "MEMIND_INGESTION_ROLES": "user,assistant",
+                "MEMIND_TIMELINE_MAX_EVENTS": "20",
             }
 
             cfg = load_config(plugin_root=root, user_config_path=user_config, env=env)
@@ -68,7 +74,9 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(cfg["retrieveMaxEntries"], 7)
         self.assertEqual(cfg["memoryMode"], "tools")
         self.assertFalse(cfg["autoRetrieve"])
+        self.assertFalse(cfg["autoIngestAgentTimeline"])
         self.assertEqual(cfg["ingestionRoles"], ["user", "assistant"])
+        self.assertEqual(cfg["timelineMaxEvents"], 20)
 
     def test_invalid_strategy_falls_back_to_simple(self):
         cfg = load_config(env={"MEMIND_RETRIEVE_STRATEGY": "bad"})

--- a/memind-integrations/hermes/tests/test_content.py
+++ b/memind-integrations/hermes/tests/test_content.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from memind_hermes.content import strip_memind_blocks, text_or_empty
+from memind_hermes.content import clamp_text, strip_memind_blocks, text_or_empty
 
 
 class ContentTest(unittest.TestCase):
@@ -31,6 +31,11 @@ class ContentTest(unittest.TestCase):
         text = "<memind_memories>memory</memind_memories>remember espresso"
 
         self.assertEqual(text_or_empty(text), "remember espresso")
+
+    def test_clamp_text_strips_context_and_marks_truncation(self):
+        text = "<memind_memories>memory</memind_memories>" + "x" * 20
+
+        self.assertEqual(clamp_text(text, 16), "xxxx\n[truncated]")
 
 
 if __name__ == "__main__":

--- a/memind-integrations/hermes/tests/test_identity.py
+++ b/memind-integrations/hermes/tests/test_identity.py
@@ -42,6 +42,12 @@ class IdentityTest(unittest.TestCase):
         self.assertEqual(identity["userId"], "u")
         self.assertEqual(identity["agentId"], "shared")
 
+    def test_fixed_agent_id_mode_shares_identity_across_workspaces(self):
+        config = {"agentId": "hermes", "agentIdMode": "fixed", "userId": "u", "sourceClient": "hermes"}
+
+        self.assertEqual(resolve_identity(config, cwd="/tmp/a", session_id="s1")["agentId"], "hermes")
+        self.assertEqual(resolve_identity(config, cwd="/tmp/b", session_id="s2")["agentId"], "hermes")
+
     def test_session_mode_uses_session_id(self):
         identity = resolve_identity(
             {"agentId": "hermes", "agentIdMode": "session", "userId": "u", "sourceClient": "hermes"},

--- a/memind-integrations/hermes/tests/test_provider.py
+++ b/memind-integrations/hermes/tests/test_provider.py
@@ -63,6 +63,8 @@ class FakeClient:
 
 class ProviderTest(unittest.TestCase):
     def provider(self, client=None, config=None):
+        self.addCleanup(lambda: getattr(self, "_tmp_state", None) and self._tmp_state.cleanup())
+        self._tmp_state = tempfile.TemporaryDirectory()
         cfg = {
             "memindApiUrl": "http://127.0.0.1:8366",
             "memindApiToken": None,
@@ -73,12 +75,17 @@ class ProviderTest(unittest.TestCase):
             "memoryMode": "hybrid",
             "autoRetrieve": True,
             "autoIngest": True,
+            "autoIngestAgentTimeline": True,
             "retrieveStrategy": "SIMPLE",
             "retrieveMaxEntries": 8,
             "retrieveMaxChars": 6000,
             "retrieveContextTurns": 1,
             "retrievePromptPreamble": "P",
             "ingestionRoles": ["user", "assistant"],
+            "timelineMaxEvents": 500,
+            "timelineMaxFieldChars": 8000,
+            "timelineFlushMinEvents": 2,
+            "stateDir": self._tmp_state.name,
             "debug": False,
         }
         if config:
@@ -149,7 +156,7 @@ class ProviderTest(unittest.TestCase):
 
         self.assertIn("User likes Rust", provider._prefetch_result)
 
-    def test_sync_turn_extracts_conversation_on_background_thread(self):
+    def test_sync_turn_extracts_agent_timeline_on_background_thread(self):
         client = FakeClient()
         provider = self.provider(client=client)
         provider.initialize("s1", cwd="/tmp/project")
@@ -161,20 +168,20 @@ class ProviderTest(unittest.TestCase):
         call = client.extract_calls[0]
         self.assertEqual(call["source_client"], "hermes")
         dumped = call["raw_content"].model_dump(by_alias=True, exclude_none=True)
-        self.assertEqual(dumped["type"], "conversation")
-        self.assertNotIn("memind_memories", dumped["messages"][0]["content"][0]["text"])
+        self.assertEqual(dumped["type"], "agent_timeline")
+        self.assertEqual(dumped["metadata"]["profile"], "general")
+        self.assertNotIn("memind_memories", dumped["events"][0]["text"])
+        self.assertEqual([event["kind"] for event in dumped["events"]], ["user_prompt", "assistant_message", "stop"])
 
-    def test_sync_turn_respects_ingestion_roles(self):
+    def test_sync_turn_respects_disabled_agent_timeline_ingestion(self):
         client = FakeClient()
-        provider = self.provider(client=client, config={"ingestionRoles": ["user"]})
+        provider = self.provider(client=client, config={"autoIngestAgentTimeline": False})
         provider.initialize("s1", cwd="/tmp/project")
 
         provider.sync_turn("remember espresso", "ok")
         provider._sync_thread.join(timeout=2)
 
-        dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
-        self.assertEqual(len(dumped["messages"]), 1)
-        self.assertEqual(dumped["messages"][0]["role"], "USER")
+        self.assertEqual(client.extract_calls, [])
 
     def test_on_pre_compress_inserts_context(self):
         provider = self.provider()
@@ -227,8 +234,21 @@ class ProviderTest(unittest.TestCase):
         provider._sync_thread.join(timeout=2)
 
         dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
-        self.assertEqual(dumped["messages"][0]["role"], "USER")
-        self.assertEqual(dumped["messages"][0]["content"][0]["text"], "remember espresso")
+        self.assertEqual(dumped["type"], "agent_timeline")
+        self.assertEqual(dumped["events"][0]["kind"], "notification")
+        self.assertEqual(dumped["events"][0]["metadata"]["memoryWrite"], True)
+        self.assertEqual(dumped["events"][0]["text"], "remember espresso")
+
+    def test_on_session_end_flushes_remaining_timeline_events(self):
+        client = FakeClient()
+        provider = self.provider(client=client)
+        provider.initialize("s1", cwd="/tmp/project")
+
+        provider.on_session_end([{"role": "user", "content": "bye"}])
+
+        dumped = client.extract_calls[0]["raw_content"].model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["type"], "agent_timeline")
+        self.assertEqual(dumped["events"][0]["kind"], "session_end")
 
     def test_get_config_schema_and_save_config(self):
         provider = self.provider()

--- a/memind-integrations/hermes/tests/test_state.py
+++ b/memind-integrations/hermes/tests/test_state.py
@@ -1,0 +1,55 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from memind_hermes.state import AgentTimelineState
+
+
+class StateTest(unittest.TestCase):
+    def test_appends_events_in_order_and_ignores_duplicates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state = AgentTimelineState(Path(tmp), max_events=500)
+            state.append("s1", {"eventId": "e2", "seq": 2, "kind": "assistant_message"})
+            state.append("s1", {"eventId": "e1", "seq": 1, "kind": "user_prompt"})
+            state.append("s1", {"eventId": "e1", "seq": 1, "kind": "user_prompt", "text": "dup"})
+
+            self.assertEqual([event["eventId"] for event in state.list("s1")], ["e1", "e2"])
+
+    def test_soft_cap_keeps_latest_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state = AgentTimelineState(Path(tmp), max_events=2)
+            state.append("s1", {"eventId": "e1", "seq": 1, "kind": "user_prompt"})
+            state.append("s1", {"eventId": "e2", "seq": 2, "kind": "assistant_message"})
+            state.append("s1", {"eventId": "e3", "seq": 3, "kind": "stop"})
+
+            self.assertEqual([event["eventId"] for event in state.list("s1")], ["e2", "e3"])
+
+    def test_clear_and_next_seq(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state = AgentTimelineState(Path(tmp), max_events=500)
+            state.append("s1", {"eventId": "e1", "seq": 1, "kind": "user_prompt"})
+            state.append("s1", {"eventId": "e3", "seq": 3, "kind": "stop"})
+
+            self.assertEqual(state.next_seq("s1"), 4)
+            state.clear("s1", ["e1"])
+            self.assertEqual([event["eventId"] for event in state.list("s1")], ["e3"])
+            state.clear("s1")
+            self.assertEqual(state.list("s1"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memind-integrations/openclaw/README.md
+++ b/memind-integrations/openclaw/README.md
@@ -2,19 +2,20 @@
 
 Memind memory backend for OpenClaw.
 
-The plugin retrieves relevant Memind memories before each prompt and submits successful
-user/assistant OpenClaw conversation text to Memind extraction after each agent turn. It connects
-to an already-running Memind server and does not start the server.
+The plugin retrieves relevant Memind memories before each prompt and submits completed OpenClaw
+agent activity as Memind `agent_timeline` raw data after each agent turn. It connects to an
+already-running Memind server and does not start the server.
 
-Use this plugin when you want OpenClaw to remember project facts, preferences, implementation
-decisions, and previous discussions across sessions.
+Use this plugin when you want OpenClaw to remember user preferences, durable facts, decisions,
+commitments, external observations, task outcomes, and previous discussions across sessions.
 
 The integration is intentionally small:
 
 - Uses the official `@openmemind/memind` TypeScript client.
 - Activates only when selected as OpenClaw's memory slot.
 - Does not manage a local Memind daemon.
-- Does not ingest tool calls or media in v0.1.
+- Captures general-agent lifecycle events; it does not enable coding-specific file context.
+- Does not ingest media in v0.1.
 
 ## Requirements
 
@@ -66,8 +67,8 @@ Restart the OpenClaw gateway or session after changing plugin configuration.
 
 - **Retrieval**: `before_prompt_build` calls `MemindClient.memory.retrieve(...)` and injects
   relevant memories into OpenClaw as `<memind_memories>...</memind_memories>`.
-- **Ingestion**: `agent_end` filters successful user/assistant messages and submits a caller-owned
-  conversation payload through `MemindClient.memory.extract(...)`.
+- **Ingestion**: lifecycle hooks append durable events to a local timeline buffer. `agent_end` and
+  `session_end` flush the completed buffer as `rawContent.type = "agent_timeline"`.
 - **Retry**: failed extraction payloads are spooled under OpenClaw's plugin state directory and
   replayed on later `agent_end` hooks.
 - **Source tagging**: all requests use `sourceClient = "openclaw"` by default, so Memind can
@@ -91,7 +92,8 @@ The default configuration works with a local Memind server at `http://127.0.0.1:
 | `agentIdMode`                 | `project`               | `project`, `fixed`, or `session`.                                                       |
 | `sourceClient`                | `openclaw`              | Source marker stored with Memind data.                                                  |
 | `autoRetrieve`                | `true`                  | Enables prompt-time memory retrieval.                                                   |
-| `autoIngest`                  | `true`                  | Enables post-turn conversation extraction.                                              |
+| `autoIngest`                  | `true`                  | Master switch for automatic ingestion.                                                  |
+| `autoIngestAgentTimeline`     | `true`                  | Enables lifecycle capture as `agent_timeline` raw data.                                 |
 | `retrieveStrategy`            | `SIMPLE`                | Memind retrieval strategy.                                                              |
 | `retrieveMaxEntries`          | `8`                     | Maximum formatted memory entries injected into OpenClaw.                                |
 | `retrieveMaxChars`            | `6000`                  | Maximum injected memory body characters, excluding the fixed XML envelope and preamble. |
@@ -104,6 +106,9 @@ The default configuration works with a local Memind server at `http://127.0.0.1:
 | `stateMaxAgeDays`             | `14`                    | Retention window for submitted-message fingerprints.                                    |
 | `ingestRetryMaxFiles`         | `20`                    | Maximum retry payload files to keep.                                                    |
 | `ingestRetryMaxAgeDays`       | `7`                     | Retention window for retry payloads.                                                    |
+| `timelineMaxEvents`           | `500`                   | Soft cap for buffered agent timeline events per session.                                |
+| `timelineMaxFieldChars`       | `8000`                  | Maximum characters kept from a single timeline event field.                             |
+| `timelineFlushMinEvents`      | `2`                     | Minimum buffered events before automatic timeline submission.                           |
 | `captureToolCalls`            | `false`                 | Reserved for a future release; v0.1 rejects `true`.                                     |
 | `captureMedia`                | `false`                 | Reserved for a future release; v0.1 rejects `true`.                                     |
 | `skipNonInteractiveTriggers`  | `true`                  | Skips cron, heartbeat, automation, and schedule sessions.                               |
@@ -138,8 +143,13 @@ By default, Memind stores OpenClaw memory under:
 - `userId`: `local__<system-user>`
 - `agentId`: `openclaw__<project-name>-<stable-hash>`
 
-The project hash is based on the OpenClaw workspace directory. This keeps different repositories
+The project hash is based on the OpenClaw workspace directory. This keeps different workspaces
 separated while allowing memory to survive across OpenClaw sessions in the same project.
+
+For general-agent usage where the same assistant should remember across workspaces, channels, or
+sessions, set `agentIdMode = fixed` and choose a stable `agentId`. Runtime context such as
+`channelId`, `conversationId`, `workspaceDir`, and `sessionKey` is stored in
+`agent_timeline.metadata`; it does not change the Memind memory identity.
 
 To use one shared OpenClaw memory across all projects:
 
@@ -183,25 +193,28 @@ preferred; `LEAF` insights are omitted by default unless no higher-level insight
 `retrieveContextTurns` defaults to `1`, so retrieval can use the current prompt plus the most recent
 conversation turn. Set it to `0` if you want retrieval queries to use only the current prompt.
 
-## Ingestion Behavior
+## Agent Timeline Ingestion
 
-Ingestion runs after successful OpenClaw agent turns when `autoIngest = true`.
+Ingestion runs after successful OpenClaw agent turns when `autoIngest = true` and
+`autoIngestAgentTimeline = true`.
 
-The capture hook:
+The lifecycle capture path:
 
-1. Reads messages from the OpenClaw hook payload.
-2. Extracts text from user and assistant messages.
-3. Strips previously injected `<memind_memories>` blocks to avoid feedback loops.
-4. Skips tool calls, media, unsupported roles, non-interactive triggers, and subagent sessions by
-   default.
-5. Keeps the final user turn and following assistant messages.
-6. Computes stable fingerprints and sends only messages that have not already been submitted.
-7. Builds one caller-owned conversation raw-content payload and submits it through
-   `MemindClient.memory.extract(...)`.
+1. `before_agent_start` appends a `user_prompt` event.
+2. `tool_result_persist` appends `tool_result` or `tool_failure` events.
+3. `after_compaction` appends a `compact_boundary` event.
+4. `agent_end` appends the final assistant message when available, appends `stop`, then flushes.
+5. `session_end` appends `session_end`, then flushes remaining events.
+6. Previously injected `<memind_memories>` blocks are stripped to avoid feedback loops.
+7. Non-interactive triggers and subagent sessions are skipped by default.
 
-The local retry spool stores the full extraction payload plus the covered message fingerprints.
-Fingerprints are marked submitted only after Memind returns `SUCCESS`; `PARTIAL_SUCCESS` and
-failures keep the payload available for later replay.
+The submitted payload uses `metadata.profile = "general"` and `metadata.runtime = "openclaw"`.
+Unlike Claude Code/Codex integrations, OpenClaw does not inject file-centric PreToolUse context or
+project-specific coding retrieval blocks.
+
+The local retry spool stores the full `agent_timeline` extraction payload plus the covered event
+ids. Buffered events are cleared only after Memind returns `SUCCESS`; failures keep the payload
+available for later replay.
 
 ## Troubleshooting
 

--- a/memind-integrations/openclaw/openclaw.plugin.json
+++ b/memind-integrations/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memind-openclaw",
   "name": "Memind Memory",
-  "description": "Memind memory backend for OpenClaw. Retrieves relevant memories before prompts and extracts durable text-only conversation memory after successful turns.",
+  "description": "Memind memory backend for OpenClaw. Retrieves relevant memories before prompts and extracts durable general-agent timeline memory after successful turns.",
   "version": "0.1.0",
   "kind": "memory",
   "configContracts": {
@@ -47,6 +47,10 @@
         "default": true
       },
       "autoIngest": {
+        "type": "boolean",
+        "default": true
+      },
+      "autoIngestAgentTimeline": {
         "type": "boolean",
         "default": true
       },
@@ -109,6 +113,21 @@
         "type": "integer",
         "minimum": 1,
         "default": 7
+      },
+      "timelineMaxEvents": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 500
+      },
+      "timelineMaxFieldChars": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 8000
+      },
+      "timelineFlushMinEvents": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 2
       },
       "captureToolCalls": {
         "type": "boolean",

--- a/memind-integrations/openclaw/src/agent-timeline.ts
+++ b/memind-integrations/openclaw/src/agent-timeline.ts
@@ -1,0 +1,308 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { createHash } from 'node:crypto'
+import path from 'node:path'
+
+import { stripInjectedContext, textFromContent } from './content.js'
+import type { AgentTimelineContent, AgentTimelineEvent, OpenClawTimelineContext } from './types.js'
+
+export function normalizeUserPromptEvent(input: {
+  prompt?: unknown
+  rawMessage?: unknown
+  seq: number
+  context: OpenClawTimelineContext
+  maxFieldChars: number
+}): AgentTimelineEvent | undefined {
+  const text = clampText(textFromPrompt(input.prompt, input.rawMessage), input.maxFieldChars)
+  if (!text) return undefined
+  return event({
+    kind: 'user_prompt',
+    seq: input.seq,
+    text,
+    context: input.context,
+  })
+}
+
+export function normalizeAssistantMessageEvent(input: {
+  messages?: unknown
+  seq: number
+  context: OpenClawTimelineContext
+  maxFieldChars: number
+}): AgentTimelineEvent | undefined {
+  const text = clampText(lastAssistantText(input.messages), input.maxFieldChars)
+  if (!text) return undefined
+  return event({
+    kind: 'assistant_message',
+    seq: input.seq,
+    text,
+    context: input.context,
+  })
+}
+
+export function normalizeToolResultEvent(input: {
+  event: Record<string, unknown>
+  seq: number
+  context: OpenClawTimelineContext
+  maxFieldChars: number
+}): AgentTimelineEvent | undefined {
+  const toolName = firstString(input.event.toolName, input.event.name, input.event.tool)
+  if (!toolName) return undefined
+  const failed = isFailed(input.event)
+  return event({
+    kind: failed ? 'tool_failure' : 'tool_result',
+    seq: input.seq,
+    toolName,
+    input: jsonText(
+      input.event.input ?? input.event.args ?? input.event.arguments,
+      input.maxFieldChars,
+    ),
+    output: jsonText(
+      input.event.output ?? input.event.result ?? input.event.error ?? input.event.errorMessage,
+      input.maxFieldChars,
+    ),
+    status: failed ? 'failed' : 'success',
+    durationMs: numberValue(input.event.durationMs ?? input.event.elapsedMs),
+    context: input.context,
+    metadata: compactMetadata({
+      operation: stringValue(input.event.operation),
+      toolCallId: stringValue(input.event.toolCallId ?? input.event.id),
+    }),
+  })
+}
+
+export function normalizeCompactBoundaryEvent(input: {
+  event: Record<string, unknown>
+  seq: number
+  context: OpenClawTimelineContext
+}): AgentTimelineEvent {
+  return event({
+    kind: 'compact_boundary',
+    seq: input.seq,
+    status: 'success',
+    context: input.context,
+    metadata: compactMetadata({ reason: stringValue(input.event.reason) }),
+  })
+}
+
+export function normalizeStopEvent(input: {
+  success?: unknown
+  seq: number
+  context: OpenClawTimelineContext
+}): AgentTimelineEvent {
+  return event({
+    kind: 'stop',
+    seq: input.seq,
+    status: input.success === false ? 'failed' : 'success',
+    context: input.context,
+  })
+}
+
+export function normalizeSessionEndEvent(input: {
+  event: Record<string, unknown>
+  seq: number
+  context: OpenClawTimelineContext
+}): AgentTimelineEvent {
+  return event({
+    kind: 'session_end',
+    seq: input.seq,
+    status: input.event.success === false ? 'failed' : 'success',
+    context: input.context,
+    metadata: compactMetadata({ reason: stringValue(input.event.reason) }),
+  })
+}
+
+export function buildAgentTimelineContent(input: {
+  sourceClient: string
+  sessionId: string
+  agentTurnId: string
+  events: AgentTimelineEvent[]
+  context: OpenClawTimelineContext
+}): AgentTimelineContent {
+  const events = input.events
+    .filter((event): event is AgentTimelineEvent => Boolean(event))
+    .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
+  const timelineId = `openclaw-${shortHash({
+    sourceClient: input.sourceClient,
+    sessionId: input.sessionId,
+    agentTurnId: input.agentTurnId,
+    eventIds: events.map((event) => event.eventId),
+  })}`
+  const project = input.context.workspaceDir
+    ? {
+        name: path.basename(input.context.workspaceDir),
+        rootPath: input.context.workspaceDir,
+        metadata: {
+          projectSlug: path.basename(input.context.workspaceDir),
+        },
+      }
+    : undefined
+  return {
+    type: 'agent_timeline',
+    sourceClient: input.sourceClient,
+    sessionId: input.sessionId,
+    agentTurnId: input.agentTurnId,
+    timelineId,
+    events,
+    ...(project ? { project } : {}),
+    metadata: compactMetadata({
+      profile: 'general',
+      runtime: 'openclaw',
+      sessionKey: input.context.sessionKey,
+      turnId: input.context.turnId ?? input.agentTurnId,
+      channelId: input.context.channelId,
+      conversationId: input.context.conversationId,
+      workspaceDir: input.context.workspaceDir,
+      agentName: input.context.agentName,
+    }),
+  }
+}
+
+function event(input: {
+  kind: string
+  seq: number
+  context: OpenClawTimelineContext
+  text?: string
+  toolName?: string
+  input?: string
+  output?: string
+  status?: string
+  durationMs?: number
+  metadata?: Record<string, unknown>
+}): AgentTimelineEvent {
+  const occurredAt = new Date().toISOString()
+  const contentHash = hash({
+    kind: input.kind,
+    seq: input.seq,
+    text: input.text,
+    toolName: input.toolName,
+    input: input.input,
+    output: input.output,
+    status: input.status,
+    context: input.context,
+  })
+  return {
+    eventId: `openclaw-${input.context.sessionKey}-${input.seq}-${contentHash.slice(0, 12)}`,
+    seq: input.seq,
+    kind: input.kind,
+    occurredAt,
+    ...(input.text ? { text: input.text } : {}),
+    ...(input.toolName ? { toolName: input.toolName } : {}),
+    ...(input.input ? { input: input.input } : {}),
+    ...(input.output ? { output: input.output } : {}),
+    ...(input.status ? { status: input.status } : {}),
+    ...(input.durationMs !== undefined ? { durationMs: input.durationMs } : {}),
+    contentHash,
+    metadata: compactMetadata({
+      sessionKey: input.context.sessionKey,
+      turnId: input.context.turnId,
+      channelId: input.context.channelId,
+      conversationId: input.context.conversationId,
+      workspaceDir: input.context.workspaceDir,
+      agentName: input.context.agentName,
+      ...input.metadata,
+    }),
+  }
+}
+
+function textFromPrompt(prompt: unknown, rawMessage: unknown): string {
+  if (typeof prompt === 'string') return stripInjectedContext(prompt)
+  if (typeof rawMessage === 'string') return stripInjectedContext(rawMessage)
+  if (rawMessage && typeof rawMessage === 'object') {
+    const message = rawMessage as Record<string, unknown>
+    return textFromContent(message.content ?? message.text)
+  }
+  return ''
+}
+
+function lastAssistantText(messages: unknown): string {
+  if (!Array.isArray(messages)) return ''
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (!message || typeof message !== 'object') continue
+    const record = message as Record<string, unknown>
+    const role = typeof record.role === 'string' ? record.role.toLowerCase() : ''
+    if (role === 'assistant') return textFromContent(record.content ?? record.text)
+  }
+  return ''
+}
+
+function isFailed(event: Record<string, unknown>): boolean {
+  if (event.success === false) return true
+  const status = stringValue(event.status)?.toLowerCase()
+  return status === 'failed' || status === 'error' || status === 'cancelled' || Boolean(event.error)
+}
+
+function jsonText(value: unknown, maxChars: number): string | undefined {
+  if (value === undefined || value === null) return undefined
+  const text = typeof value === 'string' ? value : stableJson(value)
+  return clampText(text, maxChars) || undefined
+}
+
+function clampText(value: string, maxChars: number): string {
+  const text = stripInjectedContext(value)
+  if (text.length <= maxChars) return text
+  const suffix = '\n[truncated]'
+  return text.slice(0, Math.max(0, maxChars - suffix.length)).trimEnd() + suffix
+}
+
+function compactMetadata(
+  values: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(values)) {
+    if (typeof value === 'string' && value.trim()) out[key] = value
+    if (typeof value === 'number' && Number.isFinite(value)) out[key] = value
+    if (typeof value === 'boolean') out[key] = value
+  }
+  return out
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = stringValue(value)
+    if (text) return text
+  }
+  return undefined
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function shortHash(value: unknown): string {
+  return hash(value).slice(0, 16)
+}
+
+function hash(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex')
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value))
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, sortJson(item)]),
+  )
+}

--- a/memind-integrations/openclaw/src/capture.ts
+++ b/memind-integrations/openclaw/src/capture.ts
@@ -12,15 +12,16 @@
 // limitations under the License.
 //
 
-import { RawContent, type RawContentValue } from '@openmemind/memind'
+import type { RawContentValue } from '@openmemind/memind'
 
-import { extractMessages } from './content.js'
+import { buildAgentTimelineContent } from './agent-timeline.js'
 import { isNonInteractiveTrigger, isSubagentSession } from './identity.js'
 import type {
+  AgentTimelineEvent,
   Identity,
   MemindMemoryClient,
   MemindOpenClawConfig,
-  OpenClawMessage,
+  OpenClawTimelineContext,
 } from './types.js'
 
 export type CaptureInput = {
@@ -30,8 +31,8 @@ export type CaptureInput = {
   event: Record<string, unknown>
   ctx?: Record<string, unknown>
   state: {
-    filterUnsubmitted(sessionKey: string, fingerprints: string[]): Promise<string[]>
-    markSubmitted(sessionKey: string, fingerprints: string[]): Promise<void>
+    listAgentEvents(sessionKey: string): Promise<AgentTimelineEvent[]>
+    clearAgentEvents(sessionKey: string, eventIds?: string[]): Promise<void>
   }
   retry?: {
     enqueue(entry: {
@@ -49,7 +50,9 @@ export type CaptureInput = {
 
 export async function handleCapture(input: CaptureInput): Promise<{ submitted: number }> {
   const { cfg, client, identity, event, ctx, state, retry, logger } = input
-  if (!cfg.autoIngest || event.success === false) return { submitted: 0 }
+  if (!cfg.autoIngest || !cfg.autoIngestAgentTimeline || event.success === false) {
+    return { submitted: 0 }
+  }
   const trigger = typeof ctx?.trigger === 'string' ? ctx.trigger : undefined
   const sessionKey =
     typeof ctx?.sessionKey === 'string'
@@ -62,21 +65,19 @@ export async function handleCapture(input: CaptureInput): Promise<{ submitted: n
   }
   if (!cfg.captureSubagents && isSubagentSession(sessionKey)) return { submitted: 0 }
 
-  const rawMessages = selectMessages(event)
-  const messages = selectFinalTurn(extractMessages(rawMessages, cfg))
-  if (messages.length === 0) return { submitted: 0 }
-  const byFingerprint = new Map(messages.map((message) => [message.fingerprint, message]))
-  const selectedFingerprints = (
-    await state.filterUnsubmitted(sessionKey, [...byFingerprint.keys()])
-  ).slice(0, cfg.ingestionMaxMessagesPerHook)
-  if (selectedFingerprints.length === 0) return { submitted: 0 }
-  const selectedMessages = selectedFingerprints
-    .map((fingerprint) => byFingerprint.get(fingerprint))
-    .filter((message): message is NonNullable<typeof message> => Boolean(message))
-  if (selectedMessages.length === 0) return { submitted: 0 }
-  const rawContent = RawContent.conversation(
-    selectedMessages.map(({ fingerprint: _fingerprint, ...message }) => message),
-  )
+  const events = await state.listAgentEvents(sessionKey)
+  if (events.length < cfg.timelineFlushMinEvents) return { submitted: 0 }
+  const selectedFingerprints = events
+    .map((event) => event.eventId)
+    .filter((eventId): eventId is string => Boolean(eventId))
+  const timelineContext = contextFrom(ctx, event, sessionKey, events)
+  const rawContent = buildAgentTimelineContent({
+    sourceClient: identity.sourceClient,
+    sessionId: sessionKey,
+    agentTurnId: timelineContext.turnId ?? `${sessionKey}-turn`,
+    events,
+    context: timelineContext,
+  })
 
   try {
     const response = await client.extract(
@@ -89,8 +90,8 @@ export async function handleCapture(input: CaptureInput): Promise<{ submitted: n
       { timeoutMs: 15_000, maxRetries: 0 },
     )
     if (response.status === 'SUCCESS') {
-      await state.markSubmitted(sessionKey, selectedFingerprints)
-      return { submitted: selectedFingerprints.length }
+      await state.clearAgentEvents(sessionKey, selectedFingerprints)
+      return { submitted: events.length }
     }
     await retry?.enqueue({
       kind: 'extract',
@@ -117,21 +118,31 @@ export async function handleCapture(input: CaptureInput): Promise<{ submitted: n
   }
 }
 
-function selectMessages(event: Record<string, unknown>): OpenClawMessage[] {
-  const context = event.context as { sessionEntry?: { messages?: unknown } } | undefined
-  const fromContext = context?.sessionEntry?.messages
-  if (Array.isArray(fromContext)) return fromContext as OpenClawMessage[]
-  return Array.isArray(event.messages) ? (event.messages as OpenClawMessage[]) : []
+function contextFrom(
+  ctx: Record<string, unknown> | undefined,
+  event: Record<string, unknown>,
+  sessionKey: string,
+  events: AgentTimelineEvent[],
+): OpenClawTimelineContext {
+  return {
+    sessionKey,
+    turnId:
+      stringValue(ctx?.turnId ?? event.turnId) ?? latestEventTurnId(events) ?? `${sessionKey}-turn`,
+    workspaceDir: stringValue(ctx?.workspaceDir ?? event.workspaceDir ?? ctx?.cwd ?? event.cwd),
+    channelId: stringValue(ctx?.channelId ?? event.channelId),
+    conversationId: stringValue(ctx?.conversationId ?? event.conversationId),
+    agentName: stringValue(ctx?.agentName ?? event.agentName),
+  }
 }
 
-function selectFinalTurn<T extends { role: 'USER' | 'ASSISTANT' }>(messages: T[]): T[] {
-  let lastUserIndex = -1
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.role === 'USER') {
-      lastUserIndex = index
-      break
-    }
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function latestEventTurnId(events: AgentTimelineEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const turnId = events[index]?.metadata?.turnId
+    if (typeof turnId === 'string' && turnId.trim()) return turnId
   }
-  if (lastUserIndex < 0) return messages
-  return messages.slice(lastUserIndex)
+  return undefined
 }

--- a/memind-integrations/openclaw/src/config.ts
+++ b/memind-integrations/openclaw/src/config.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONFIG: MemindOpenClawConfig = {
   sourceClient: 'openclaw',
   autoRetrieve: true,
   autoIngest: true,
+  autoIngestAgentTimeline: true,
   retrieveStrategy: 'SIMPLE',
   retrieveMaxEntries: 8,
   retrieveMaxChars: 6000,
@@ -42,6 +43,9 @@ export const DEFAULT_CONFIG: MemindOpenClawConfig = {
   stateMaxAgeDays: 14,
   ingestRetryMaxFiles: 20,
   ingestRetryMaxAgeDays: 7,
+  timelineMaxEvents: 500,
+  timelineMaxFieldChars: 8000,
+  timelineFlushMinEvents: 2,
   captureToolCalls: false,
   captureMedia: false,
   skipNonInteractiveTriggers: true,
@@ -79,6 +83,11 @@ export function parseConfig(value: unknown): MemindOpenClawConfig {
   cfg.sourceClient = stringValue(raw.sourceClient, cfg.sourceClient, 'sourceClient')
   cfg.autoRetrieve = booleanValue(raw.autoRetrieve, cfg.autoRetrieve, 'autoRetrieve')
   cfg.autoIngest = booleanValue(raw.autoIngest, cfg.autoIngest, 'autoIngest')
+  cfg.autoIngestAgentTimeline = booleanValue(
+    raw.autoIngestAgentTimeline,
+    cfg.autoIngestAgentTimeline,
+    'autoIngestAgentTimeline',
+  )
   cfg.retrieveStrategy = enumValue(
     raw.retrieveStrategy,
     cfg.retrieveStrategy,
@@ -132,6 +141,21 @@ export function parseConfig(value: unknown): MemindOpenClawConfig {
     raw.ingestRetryMaxAgeDays,
     cfg.ingestRetryMaxAgeDays,
     'ingestRetryMaxAgeDays',
+  )
+  cfg.timelineMaxEvents = positiveInteger(
+    raw.timelineMaxEvents,
+    cfg.timelineMaxEvents,
+    'timelineMaxEvents',
+  )
+  cfg.timelineMaxFieldChars = positiveInteger(
+    raw.timelineMaxFieldChars,
+    cfg.timelineMaxFieldChars,
+    'timelineMaxFieldChars',
+  )
+  cfg.timelineFlushMinEvents = positiveInteger(
+    raw.timelineFlushMinEvents,
+    cfg.timelineFlushMinEvents,
+    'timelineFlushMinEvents',
   )
   cfg.captureToolCalls = reservedFalseBoolean(raw.captureToolCalls, 'captureToolCalls')
   cfg.captureMedia = reservedFalseBoolean(raw.captureMedia, 'captureMedia')

--- a/memind-integrations/openclaw/src/index.ts
+++ b/memind-integrations/openclaw/src/index.ts
@@ -18,12 +18,21 @@ import path from 'node:path'
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk'
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry'
 
+import {
+  normalizeAssistantMessageEvent,
+  normalizeCompactBoundaryEvent,
+  normalizeSessionEndEvent,
+  normalizeStopEvent,
+  normalizeToolResultEvent,
+  normalizeUserPromptEvent,
+} from './agent-timeline.js'
 import { handleCapture } from './capture.js'
 import { createMemindMemoryClient } from './client.js'
 import { parseConfig, PLUGIN_ID, shouldRunAutomaticHooks } from './config.js'
 import { resolveIdentity } from './identity.js'
 import { handleRecall } from './recall.js'
-import { createRuntimeStores, resolveWorkspaceDir } from './runtime.js'
+import { createRuntimeStores, resolveWorkspaceDir, type RuntimeStores } from './runtime.js'
+import type { AgentTimelineEvent, OpenClawTimelineContext } from './types.js'
 
 const plugin = definePluginEntry({
   id: PLUGIN_ID,
@@ -91,7 +100,75 @@ const plugin = definePluginEntry({
       })
     }
 
-    if (cfg.autoIngest) {
+    if (cfg.autoIngest && cfg.autoIngestAgentTimeline) {
+      api.on('session_start', async () => {
+        const runtime = stores.current()
+        if (runtime.retry) {
+          runtime.retry.flush(client).catch((error: unknown) => {
+            api.logger.warn(`memind-openclaw: retry flush failed: ${String(error)}`)
+          })
+        }
+      })
+
+      api.on('message_received', async () => {
+        // OpenClaw exposes message_received in some runtimes, but automatic lifecycle memory is
+        // anchored on completed agent turns to avoid ingesting partial user text.
+      })
+
+      api.on('before_agent_start', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const runtime = stores.current()
+        const context = await timelineContext(runtime, hookEvent, hookCtx, { startNewTurn: true })
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: normalizeUserPromptEvent({
+            prompt: hookEvent.prompt ?? hookEvent.input,
+            rawMessage: hookEvent.message,
+            seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+            context,
+            maxFieldChars: cfg.timelineMaxFieldChars,
+          }),
+          logger: api.logger,
+        })
+      })
+
+      api.on('tool_result_persist', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const runtime = stores.current()
+        const context = await timelineContext(runtime, hookEvent, hookCtx)
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: normalizeToolResultEvent({
+            event: hookEvent,
+            seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+            context,
+            maxFieldChars: cfg.timelineMaxFieldChars,
+          }),
+          logger: api.logger,
+        })
+      })
+
+      api.on('after_compaction', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const runtime = stores.current()
+        const context = await timelineContext(runtime, hookEvent, hookCtx)
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: normalizeCompactBoundaryEvent({
+            event: hookEvent,
+            seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+            context,
+          }),
+          logger: api.logger,
+        })
+      })
+
       api.on('agent_end', async (event: unknown, ctx: unknown) => {
         const hookEvent = objectRecord(event)
         const hookCtx = objectRecord(ctx)
@@ -107,13 +184,81 @@ const plugin = definePluginEntry({
             api.logger.warn(`memind-openclaw: retry flush failed: ${String(error)}`)
           })
         }
+        const context = await timelineContext(runtime, hookEvent, hookCtx)
+        if (hookEvent.success === false) {
+          await clearIncompleteBufferedTurn(runtime, context.sessionKey, context.turnId)
+          return handleCapture({
+            cfg,
+            client,
+            identity,
+            event: hookEvent,
+            ctx: hookCtx,
+            state: runtime.agentState,
+            retry: runtime.retry,
+            logger: api.logger,
+          })
+        }
+        const assistant = normalizeAssistantMessageEvent({
+          messages: hookEvent.messages,
+          seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+          context,
+          maxFieldChars: cfg.timelineMaxFieldChars,
+        })
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: assistant,
+          logger: api.logger,
+        })
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: normalizeStopEvent({
+            success: hookEvent.success,
+            seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+            context,
+          }),
+          logger: api.logger,
+        })
         return handleCapture({
           cfg,
           client,
           identity,
           event: hookEvent,
           ctx: hookCtx,
-          state: runtime.state,
+          state: runtime.agentState,
+          retry: runtime.retry,
+          logger: api.logger,
+        })
+      })
+
+      api.on('session_end', async (event: unknown, ctx: unknown) => {
+        const hookEvent = objectRecord(event)
+        const hookCtx = objectRecord(ctx)
+        const runtime = stores.current()
+        const cwd = resolveWorkspaceDir(hookEvent, hookCtx, process.cwd())
+        const identity = resolveIdentity(cfg, {
+          cwd,
+          sessionKey: stringValue(hookCtx.sessionKey),
+        })
+        const context = await timelineContext(runtime, hookEvent, hookCtx)
+        await appendTimelineEvent({
+          runtime,
+          sessionKey: context.sessionKey,
+          event: normalizeSessionEndEvent({
+            event: hookEvent,
+            seq: await runtime.agentState.nextAgentEventSeq(context.sessionKey),
+            context,
+          }),
+          logger: api.logger,
+        })
+        return handleCapture({
+          cfg,
+          client,
+          identity,
+          event: hookEvent,
+          ctx: hookCtx,
+          state: runtime.agentState,
           retry: runtime.retry,
           logger: api.logger,
         })
@@ -138,6 +283,72 @@ function objectRecord(value: unknown): Record<string, unknown> {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+async function timelineContext(
+  runtime: RuntimeStores,
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+  options: { startNewTurn?: boolean } = {},
+): Promise<OpenClawTimelineContext> {
+  const sessionKey = stringValue(ctx.sessionKey) ?? stringValue(event.sessionKey) ?? 'default'
+  const turnId =
+    stringValue(ctx.turnId) ??
+    stringValue(event.turnId) ??
+    (options.startNewTurn ? undefined : await latestBufferedTurnId(runtime, sessionKey)) ??
+    `${sessionKey}-turn-${await runtime.agentState.nextAgentEventSeq(sessionKey)}`
+  return {
+    sessionKey,
+    turnId,
+    workspaceDir: stringValue(ctx.workspaceDir ?? event.workspaceDir ?? ctx.cwd ?? event.cwd),
+    channelId: stringValue(ctx.channelId ?? event.channelId),
+    conversationId: stringValue(ctx.conversationId ?? event.conversationId),
+    agentName: stringValue(ctx.agentName ?? event.agentName),
+  }
+}
+
+async function latestBufferedTurnId(
+  runtime: RuntimeStores,
+  sessionKey: string,
+): Promise<string | undefined> {
+  const events = await runtime.agentState.listAgentEvents(sessionKey)
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const turnId = events[index]?.metadata?.turnId
+    if (typeof turnId === 'string' && turnId.trim()) return turnId
+  }
+  return undefined
+}
+
+async function clearIncompleteBufferedTurn(
+  runtime: RuntimeStores,
+  sessionKey: string,
+  turnId: string | undefined,
+): Promise<void> {
+  if (!turnId) return
+  const events = (await runtime.agentState.listAgentEvents(sessionKey)).filter(
+    (event) => event.metadata?.turnId === turnId,
+  )
+  const lastKind = events.at(-1)?.kind
+  if (events.length > 0 && lastKind !== 'stop' && lastKind !== 'session_end') {
+    await runtime.agentState.clearAgentEvents(
+      sessionKey,
+      events.map((event) => event.eventId).filter((eventId): eventId is string => Boolean(eventId)),
+    )
+  }
+}
+
+async function appendTimelineEvent(input: {
+  runtime: RuntimeStores
+  sessionKey: string
+  event: AgentTimelineEvent | undefined
+  logger: OpenClawPluginApi['logger']
+}): Promise<void> {
+  if (!input.event) return
+  try {
+    await input.runtime.agentState.appendAgentEvent(input.sessionKey, input.event)
+  } catch (error: unknown) {
+    input.logger.warn(`memind-openclaw: timeline append failed: ${String(error)}`)
+  }
 }
 
 export default plugin

--- a/memind-integrations/openclaw/src/runtime.ts
+++ b/memind-integrations/openclaw/src/runtime.ts
@@ -15,13 +15,15 @@
 import path from 'node:path'
 
 import { RetrySpool } from './retry.js'
-import { SubmittedStateStore } from './state.js'
+import { AgentTimelineStateStore, SubmittedStateStore } from './state.js'
 import type { MemindOpenClawConfig } from './types.js'
 
 export type RuntimeStores = {
   stateRoot: string
+  agentStateRoot: string
   retryRoot?: string
   state: SubmittedStateStore
+  agentState: AgentTimelineStateStore
   retry?: RetrySpool
 }
 
@@ -50,12 +52,18 @@ export function createRuntimeStores(
       const stateDir = getStateDir()
       if (cached && cachedDir === stateDir) return cached
       const stateRoot = path.join(stateDir, 'state')
+      const agentStateRoot = path.join(stateDir, 'agent-events')
       const retryRoot = path.join(stateDir, 'retry')
       cachedDir = stateDir
       cached = {
         stateRoot,
+        agentStateRoot,
         retryRoot: cfg.ingestRetrySpool ? retryRoot : undefined,
         state: new SubmittedStateStore(stateRoot, { maxAgeDays: cfg.stateMaxAgeDays }),
+        agentState: new AgentTimelineStateStore(agentStateRoot, {
+          maxAgeDays: cfg.stateMaxAgeDays,
+          maxEvents: cfg.timelineMaxEvents,
+        }),
         retry: cfg.ingestRetrySpool
           ? new RetrySpool(retryRoot, {
               maxFiles: cfg.ingestRetryMaxFiles,

--- a/memind-integrations/openclaw/src/state.ts
+++ b/memind-integrations/openclaw/src/state.ts
@@ -15,9 +15,16 @@
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
+import type { AgentTimelineEvent } from './types.js'
+
 type StateFile = {
   version: 1
   submitted: string[]
+}
+
+type AgentTimelineStateFile = {
+  version: 1
+  events: AgentTimelineEvent[]
 }
 
 export class SubmittedStateStore {
@@ -64,6 +71,83 @@ export class SubmittedStateStore {
   }
 }
 
+export class AgentTimelineStateStore {
+  constructor(
+    private readonly root: string,
+    private readonly options: { maxAgeDays: number; maxEvents: number },
+  ) {}
+
+  async appendAgentEvent(sessionKey: string, event: AgentTimelineEvent): Promise<void> {
+    if (!event.eventId) return
+    const state = await this.read(sessionKey)
+    if (state.events.some((candidate) => candidate.eventId === event.eventId)) return
+    const events = [...state.events, event]
+      .sort(compareEvents)
+      .slice(Math.max(0, state.events.length + 1 - this.options.maxEvents))
+    await this.write(sessionKey, { version: 1, events })
+  }
+
+  async listAgentEvents(sessionKey: string): Promise<AgentTimelineEvent[]> {
+    return (await this.read(sessionKey)).events.sort(compareEvents)
+  }
+
+  async clearAgentEvents(sessionKey: string, eventIds?: string[]): Promise<void> {
+    if (!eventIds || eventIds.length === 0) {
+      await this.write(sessionKey, { version: 1, events: [] })
+      return
+    }
+    const submitted = new Set(eventIds)
+    const state = await this.read(sessionKey)
+    await this.write(sessionKey, {
+      version: 1,
+      events: state.events.filter((event) => !event.eventId || !submitted.has(event.eventId)),
+    })
+  }
+
+  async nextAgentEventSeq(sessionKey: string): Promise<number> {
+    const events = await this.listAgentEvents(sessionKey)
+    const maxSeq = events.reduce((max, event) => Math.max(max, event.seq ?? 0), 0)
+    return maxSeq + 1
+  }
+
+  private async read(sessionKey: string): Promise<AgentTimelineStateFile> {
+    try {
+      const statePath = this.pathFor(sessionKey)
+      const info = await stat(statePath)
+      const ageDays = (Date.now() - info.mtimeMs) / 86_400_000
+      if (ageDays > this.options.maxAgeDays) return { version: 1, events: [] }
+      const raw = await readFile(statePath, 'utf8')
+      const parsed = JSON.parse(raw) as AgentTimelineStateFile
+      if (parsed.version === 1 && Array.isArray(parsed.events)) {
+        return {
+          version: 1,
+          events: parsed.events
+            .filter((event): event is AgentTimelineEvent => Boolean(event?.eventId))
+            .sort(compareEvents),
+        }
+      }
+    } catch {
+      return { version: 1, events: [] }
+    }
+    return { version: 1, events: [] }
+  }
+
+  private async write(sessionKey: string, state: AgentTimelineStateFile): Promise<void> {
+    await mkdir(this.root, { recursive: true })
+    await writeFile(this.pathFor(sessionKey), JSON.stringify(state, null, 2), 'utf8')
+  }
+
+  private pathFor(sessionKey: string): string {
+    return path.join(this.root, `${safeKey(sessionKey)}.json`)
+  }
+}
+
 export function safeKey(value: string): string {
   return value.replace(/[^a-zA-Z0-9_.-]+/g, '_') || 'default'
+}
+
+function compareEvents(left: AgentTimelineEvent, right: AgentTimelineEvent): number {
+  const seq = (left.seq ?? Number.MAX_SAFE_INTEGER) - (right.seq ?? Number.MAX_SAFE_INTEGER)
+  if (seq !== 0) return seq
+  return String(left.eventId ?? '').localeCompare(String(right.eventId ?? ''))
 }

--- a/memind-integrations/openclaw/src/types.ts
+++ b/memind-integrations/openclaw/src/types.ts
@@ -32,6 +32,13 @@ export type SlotConfigLike = {
   slots?: Record<string, string>
   memoryPluginId?: string
 }
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
 
 export type MemindOpenClawConfig = {
   memindApiUrl: string
@@ -42,6 +49,7 @@ export type MemindOpenClawConfig = {
   sourceClient: string
   autoRetrieve: boolean
   autoIngest: boolean
+  autoIngestAgentTimeline: boolean
   retrieveStrategy: 'SIMPLE'
   retrieveMaxEntries: number
   retrieveMaxChars: number
@@ -54,6 +62,9 @@ export type MemindOpenClawConfig = {
   stateMaxAgeDays: number
   ingestRetryMaxFiles: number
   ingestRetryMaxAgeDays: number
+  timelineMaxEvents: number
+  timelineMaxFieldChars: number
+  timelineFlushMinEvents: number
   captureToolCalls: boolean
   captureMedia: boolean
   skipNonInteractiveTriggers: boolean
@@ -75,6 +86,46 @@ export type OpenClawMessage = {
 
 export type NormalizedMessage = MessageValue & {
   fingerprint: string
+}
+
+export type AgentTimelineEvent = {
+  eventId?: string
+  seq?: number
+  kind?: string
+  occurredAt?: string
+  text?: string
+  toolName?: string
+  input?: string
+  output?: string
+  status?: string
+  durationMs?: number
+  contentHash?: string
+  path?: string
+  operation?: string
+  command?: string
+  exitCode?: number
+  metadata?: Record<string, JsonValue>
+}
+
+export type AgentTimelineContent = {
+  type: 'agent_timeline'
+  sourceClient?: string
+  sourceVersion?: string
+  sessionId: string
+  agentTurnId: string
+  timelineId: string
+  events: AgentTimelineEvent[]
+  project?: Record<string, JsonValue>
+  metadata?: Record<string, JsonValue>
+}
+
+export type OpenClawTimelineContext = {
+  sessionKey: string
+  workspaceDir?: string
+  channelId?: string
+  conversationId?: string
+  agentName?: string
+  turnId?: string
 }
 
 export type Identity = {

--- a/memind-integrations/openclaw/tests/agent-timeline.test.ts
+++ b/memind-integrations/openclaw/tests/agent-timeline.test.ts
@@ -1,0 +1,151 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildAgentTimelineContent,
+  normalizeAssistantMessageEvent,
+  normalizeStopEvent,
+  normalizeToolResultEvent,
+  normalizeUserPromptEvent,
+} from '../src/agent-timeline.js'
+import type { OpenClawTimelineContext } from '../src/types.js'
+
+const context: OpenClawTimelineContext = {
+  sessionKey: 's1',
+  workspaceDir: '/repo/acme',
+  channelId: 'slack:C123',
+  conversationId: 'thread-456',
+  agentName: 'sales-assistant',
+  turnId: 'turn-1',
+}
+
+describe('agent timeline normalization', () => {
+  it('normalizes user prompts and strips injected Memind context', () => {
+    const event = normalizeUserPromptEvent({
+      prompt: '<memind_memories>old</memind_memories>\nSummarize renewal concerns',
+      seq: 1,
+      context,
+      maxFieldChars: 8000,
+    })
+
+    expect(event).toMatchObject({
+      seq: 1,
+      kind: 'user_prompt',
+      text: 'Summarize renewal concerns',
+      metadata: expect.objectContaining({
+        sessionKey: 's1',
+        turnId: 'turn-1',
+      }),
+    })
+    expect(event?.eventId).toMatch(/^openclaw-/)
+    expect(event?.contentHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('normalizes assistant messages from final messages', () => {
+    const event = normalizeAssistantMessageEvent({
+      messages: [
+        { role: 'user', content: 'question' },
+        { role: 'assistant', content: 'answer' },
+      ],
+      seq: 2,
+      context,
+      maxFieldChars: 8000,
+    })
+
+    expect(event).toMatchObject({
+      seq: 2,
+      kind: 'assistant_message',
+      text: 'answer',
+    })
+  })
+
+  it('normalizes successful tool results', () => {
+    const event = normalizeToolResultEvent({
+      event: {
+        toolName: 'gmail.search',
+        input: { query: 'renewal' },
+        output: { count: 3 },
+        success: true,
+      },
+      seq: 3,
+      context,
+      maxFieldChars: 8000,
+    })
+
+    expect(event).toMatchObject({
+      seq: 3,
+      kind: 'tool_result',
+      toolName: 'gmail.search',
+      status: 'success',
+    })
+    expect(event?.input).toContain('renewal')
+    expect(event?.output).toContain('"count":3')
+  })
+
+  it('normalizes failed tool results and truncates large values', () => {
+    const event = normalizeToolResultEvent({
+      event: {
+        toolName: 'crm.update',
+        input: { id: 'customer-1' },
+        error: 'x'.repeat(100),
+        success: false,
+      },
+      seq: 4,
+      context,
+      maxFieldChars: 32,
+    })
+
+    expect(event).toMatchObject({
+      kind: 'tool_failure',
+      status: 'failed',
+      toolName: 'crm.update',
+    })
+    expect(event?.output?.length).toBeLessThanOrEqual(32)
+    expect(event?.output).toContain('[truncated]')
+  })
+
+  it('builds general agent_timeline raw content', () => {
+    const prompt = normalizeUserPromptEvent({
+      prompt: 'Summarize renewal concerns',
+      seq: 1,
+      context,
+      maxFieldChars: 8000,
+    })
+    const stop = normalizeStopEvent({ success: true, seq: 2, context })
+
+    const payload = buildAgentTimelineContent({
+      sourceClient: 'openclaw',
+      sessionId: 's1',
+      agentTurnId: 'turn-1',
+      events: [prompt, stop].filter((event): event is NonNullable<typeof event> => Boolean(event)),
+      context,
+    })
+
+    expect(payload).toMatchObject({
+      type: 'agent_timeline',
+      sourceClient: 'openclaw',
+      sessionId: 's1',
+      agentTurnId: 'turn-1',
+      metadata: {
+        profile: 'general',
+        runtime: 'openclaw',
+        sessionKey: 's1',
+        turnId: 'turn-1',
+      },
+    })
+    expect(payload.timelineId).toContain('openclaw')
+  })
+})

--- a/memind-integrations/openclaw/tests/capture.test.ts
+++ b/memind-integrations/openclaw/tests/capture.test.ts
@@ -44,110 +44,83 @@ describe('handleCapture', () => {
       extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
     }
     const state = {
-      filterUnsubmitted: vi
-        .fn()
-        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
-      markSubmitted: vi.fn().mockResolvedValue(undefined),
+      listAgentEvents: vi.fn().mockResolvedValue([
+        { eventId: 'prompt-1', seq: 1, kind: 'user_prompt', text: 'remember me' },
+        { eventId: 'stop-1', seq: 2, kind: 'stop', status: 'success' },
+      ]),
+      clearAgentEvents: vi.fn().mockResolvedValue(undefined),
     }
     const result = await handleCapture({
       cfg,
       client,
       identity,
-      event: { success: true, messages: [{ role: 'user', content: 'remember me', id: 'f1' }] },
+      event: { success: true },
       ctx: { sessionKey: 's1' },
       state,
     })
-    expect(result.submitted).toBe(1)
+    expect(result.submitted).toBe(2)
     expect(client.extract).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'u1',
         agentId: 'a1',
         sourceClient: 'openclaw',
-      }),
-      expect.objectContaining({ maxRetries: 0 }),
-    )
-    expect(state.markSubmitted).toHaveBeenCalledWith('s1', expect.any(Array))
-  })
-
-  it('keeps only the final turn by default', async () => {
-    const cfg = parseConfig({})
-    const client: MemindMemoryClient = {
-      retrieve: vi.fn(),
-      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
-    }
-    const state = {
-      filterUnsubmitted: vi
-        .fn()
-        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
-      markSubmitted: vi.fn().mockResolvedValue(undefined),
-    }
-    await handleCapture({
-      cfg,
-      client,
-      identity,
-      event: {
-        success: true,
-        messages: [
-          { role: 'user', content: 'old question', id: 'old-u' },
-          { role: 'assistant', content: 'old answer', id: 'old-a' },
-          { role: 'user', content: 'new question', id: 'new-u' },
-          { role: 'assistant', content: 'new answer', id: 'new-a' },
-        ],
-      },
-      ctx: { sessionKey: 's1' },
-      state,
-    })
-    expect(client.extract).toHaveBeenCalledWith(
-      expect.objectContaining({
         rawContent: expect.objectContaining({
-          type: 'conversation',
-          messages: [
-            expect.objectContaining({
-              role: 'USER',
-              content: [{ type: 'text', text: 'new question' }],
-            }),
-            expect.objectContaining({
-              role: 'ASSISTANT',
-              content: [{ type: 'text', text: 'new answer' }],
-            }),
+          type: 'agent_timeline',
+          metadata: expect.objectContaining({ profile: 'general', runtime: 'openclaw' }),
+          events: [
+            expect.objectContaining({ kind: 'user_prompt' }),
+            expect.objectContaining({ kind: 'stop' }),
           ],
         }),
       }),
-      expect.any(Object),
+      expect.objectContaining({ maxRetries: 0 }),
     )
+    expect(state.clearAgentEvents).toHaveBeenCalledWith('s1', ['prompt-1', 'stop-1'])
   })
 
-  it('respects ingestionMaxMessagesPerHook after final-turn selection', async () => {
-    const cfg = parseConfig({ ingestionMaxMessagesPerHook: 1 })
-    const client: MemindMemoryClient = {
-      retrieve: vi.fn(),
-      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
-    }
+  it('skips capture until enough timeline events are buffered', async () => {
+    const cfg = parseConfig({})
+    const client: MemindMemoryClient = { retrieve: vi.fn(), extract: vi.fn() }
     const state = {
-      filterUnsubmitted: vi
+      listAgentEvents: vi
         .fn()
-        .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
-      markSubmitted: vi.fn().mockResolvedValue(undefined),
+        .mockResolvedValue([
+          { eventId: 'prompt-1', seq: 1, kind: 'user_prompt', text: 'remember me' },
+        ]),
+      clearAgentEvents: vi.fn(),
     }
     const result = await handleCapture({
       cfg,
       client,
       identity,
-      event: {
-        success: true,
-        messages: [
-          { role: 'user', content: 'new question', id: 'new-u' },
-          { role: 'assistant', content: 'new answer', id: 'new-a' },
-        ],
-      },
+      event: { success: true },
       ctx: { sessionKey: 's1' },
       state,
     })
-    expect(result.submitted).toBe(1)
-    expect(state.markSubmitted).toHaveBeenCalledWith(
-      's1',
-      expect.arrayContaining([expect.any(String)]),
-    )
+    expect(result.submitted).toBe(0)
+    expect(client.extract).not.toHaveBeenCalled()
+  })
+
+  it('respects disabled agent timeline ingestion', async () => {
+    const cfg = parseConfig({ autoIngestAgentTimeline: false })
+    const client: MemindMemoryClient = {
+      retrieve: vi.fn(),
+      extract: vi.fn().mockResolvedValue(successfulExtractResponse()),
+    }
+    const state = {
+      listAgentEvents: vi.fn(),
+      clearAgentEvents: vi.fn(),
+    }
+    const result = await handleCapture({
+      cfg,
+      client,
+      identity,
+      event: { success: true },
+      ctx: { sessionKey: 's1' },
+      state,
+    })
+    expect(result.submitted).toBe(0)
+    expect(state.listAgentEvents).not.toHaveBeenCalled()
   })
 
   it('skips failed turns', async () => {
@@ -159,7 +132,7 @@ describe('handleCapture', () => {
       identity,
       event: { success: false, messages: [{ role: 'user', content: 'no' }] },
       ctx: { sessionKey: 's1' },
-      state: { filterUnsubmitted: vi.fn(), markSubmitted: vi.fn() },
+      state: { listAgentEvents: vi.fn(), clearAgentEvents: vi.fn() },
     })
     expect(result.submitted).toBe(0)
     expect(client.extract).not.toHaveBeenCalled()
@@ -179,14 +152,19 @@ describe('handleCapture', () => {
       event: { success: true, messages: [{ role: 'user', content: 'remember me' }] },
       ctx: { sessionKey: 's1' },
       state: {
-        filterUnsubmitted: vi
-          .fn()
-          .mockImplementation(async (_sessionKey: string, fingerprints: string[]) => fingerprints),
-        markSubmitted: vi.fn(),
+        listAgentEvents: vi.fn().mockResolvedValue([
+          { eventId: 'prompt-1', seq: 1, kind: 'user_prompt', text: 'remember me' },
+          { eventId: 'stop-1', seq: 2, kind: 'stop', status: 'success' },
+        ]),
+        clearAgentEvents: vi.fn(),
       },
       retry,
     })
     expect(result.submitted).toBe(0)
-    expect(retry.enqueue).toHaveBeenCalled()
+    expect(retry.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawContent: expect.objectContaining({ type: 'agent_timeline' }),
+      }),
+    )
   })
 })

--- a/memind-integrations/openclaw/tests/config.test.ts
+++ b/memind-integrations/openclaw/tests/config.test.ts
@@ -25,6 +25,10 @@ describe('parseConfig', () => {
     expect(cfg.sourceClient).toBe('openclaw')
     expect(cfg.autoRetrieve).toBe(true)
     expect(cfg.autoIngest).toBe(true)
+    expect(cfg.autoIngestAgentTimeline).toBe(true)
+    expect(cfg.timelineMaxEvents).toBe(500)
+    expect(cfg.timelineMaxFieldChars).toBe(8000)
+    expect(cfg.timelineFlushMinEvents).toBe(2)
     expect(cfg.captureToolCalls).toBe(false)
     expect(cfg.captureMedia).toBe(false)
     expect(cfg.captureSubagents).toBe(false)
@@ -64,6 +68,9 @@ describe('parseConfig', () => {
   it('rejects invalid numeric values', () => {
     expect(() => parseConfig({ retrieveMaxEntries: 0 })).toThrow('retrieveMaxEntries')
     expect(() => parseConfig({ ingestRetryMaxFiles: -1 })).toThrow('ingestRetryMaxFiles')
+    expect(() => parseConfig({ timelineMaxEvents: 0 })).toThrow('timelineMaxEvents')
+    expect(() => parseConfig({ timelineMaxFieldChars: 0 })).toThrow('timelineMaxFieldChars')
+    expect(() => parseConfig({ timelineFlushMinEvents: 0 })).toThrow('timelineFlushMinEvents')
   })
 
   it('rejects unsupported retrieve strategies and reserved capture switches', () => {

--- a/memind-integrations/openclaw/tests/identity.test.ts
+++ b/memind-integrations/openclaw/tests/identity.test.ts
@@ -51,6 +51,13 @@ describe('resolveIdentity', () => {
     expect(second.agentId).toBe(first.agentId)
   })
 
+  it('keeps fixed agent id shared across workspaces', () => {
+    const cfg = parseConfig({ userId: 'u1', agentId: 'openclaw', agentIdMode: 'fixed' })
+
+    expect(resolveIdentity(cfg, { cwd: '/tmp/a' }).agentId).toBe('openclaw')
+    expect(resolveIdentity(cfg, { cwd: '/tmp/b' }).agentId).toBe('openclaw')
+  })
+
   it('uses session suffix in session mode', () => {
     const cfg = parseConfig({ userId: 'u1', agentId: 'openclaw', agentIdMode: 'session' })
     const id = resolveIdentity(cfg, { sessionKey: 'agent:main:session:123' })

--- a/memind-integrations/openclaw/tests/index.test.ts
+++ b/memind-integrations/openclaw/tests/index.test.ts
@@ -12,7 +12,22 @@
 // limitations under the License.
 //
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const memoryMocks = vi.hoisted(() => ({
+  extract: vi.fn().mockResolvedValue({
+    status: 'SUCCESS',
+    rawDataIds: [],
+    itemIds: [],
+    insightIds: [],
+    insightPending: false,
+  }),
+  retrieve: vi.fn().mockResolvedValue({ items: [], rawData: [], insights: [] }),
+}))
+
+vi.mock('@openmemind/memind', () => ({
+  MemindClient: vi.fn(() => ({ memory: memoryMocks })),
+}))
 
 import plugin from '../src/index.js'
 
@@ -40,6 +55,11 @@ function api(slots: Record<string, string> | undefined = { memory: 'memind-openc
 }
 
 describe('plugin entry', () => {
+  beforeEach(() => {
+    memoryMocks.extract.mockClear()
+    memoryMocks.retrieve.mockClear()
+  })
+
   it('registers service and hooks when selected as memory slot', () => {
     const fixture = api()
     plugin.register(fixture.api as TestApi)
@@ -47,7 +67,13 @@ describe('plugin entry', () => {
       expect.objectContaining({ id: 'memind-openclaw' }),
     )
     expect(fixture.api.on).toHaveBeenCalledWith('before_prompt_build', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('session_start', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('before_agent_start', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('tool_result_persist', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('after_compaction', expect.any(Function))
     expect(fixture.api.on).toHaveBeenCalledWith('agent_end', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('session_end', expect.any(Function))
+    expect(fixture.api.on).toHaveBeenCalledWith('message_received', expect.any(Function))
   })
 
   it('warns and skips hooks when not selected as memory slot', () => {
@@ -107,5 +133,61 @@ describe('plugin entry', () => {
       expect.stringContaining('/tmp/openclaw-plugin-state'),
     )
     expect(fixture.api.logger.debug).toHaveBeenCalledWith(expect.stringContaining('/repo/from-ctx'))
+  })
+
+  it('appends lifecycle events and flushes one agent timeline on agent_end', async () => {
+    const fixture = api()
+    fixture.api.pluginConfig = { ingestRetrySpool: false }
+    plugin.register(fixture.api as TestApi)
+    const service = (fixture.api.registerService.mock.calls as Array<[RegisteredService]>)[0]?.[0]
+    service?.start({ stateDir: '/tmp/openclaw-plugin-state' })
+
+    await fixture.handlers.before_agent_start?.(
+      { prompt: 'Summarize renewal concerns' },
+      { sessionKey: 'agent:main:main', workspaceDir: '/repo/from-ctx' },
+    )
+    await fixture.handlers.tool_result_persist?.(
+      { toolName: 'gmail.search', output: { count: 2 }, success: true },
+      { sessionKey: 'agent:main:main', workspaceDir: '/repo/from-ctx' },
+    )
+    await fixture.handlers.agent_end?.(
+      { success: true, messages: [{ role: 'assistant', content: 'Found two concerns.' }] },
+      { sessionKey: 'agent:main:main', workspaceDir: '/repo/from-ctx' },
+    )
+
+    expect(fixture.api.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('capture failed'),
+    )
+    expect(memoryMocks.extract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawContent: expect.objectContaining({
+          type: 'agent_timeline',
+          metadata: expect.objectContaining({
+            profile: 'general',
+            runtime: 'openclaw',
+            turnId: 'agent:main:main-turn-1',
+          }),
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'user_prompt',
+              metadata: expect.objectContaining({ turnId: 'agent:main:main-turn-1' }),
+            }),
+            expect.objectContaining({
+              kind: 'tool_result',
+              metadata: expect.objectContaining({ turnId: 'agent:main:main-turn-1' }),
+            }),
+            expect.objectContaining({
+              kind: 'assistant_message',
+              metadata: expect.objectContaining({ turnId: 'agent:main:main-turn-1' }),
+            }),
+            expect.objectContaining({
+              kind: 'stop',
+              metadata: expect.objectContaining({ turnId: 'agent:main:main-turn-1' }),
+            }),
+          ]),
+        }),
+      }),
+      expect.any(Object),
+    )
   })
 })

--- a/memind-integrations/openclaw/tests/retry.test.ts
+++ b/memind-integrations/openclaw/tests/retry.test.ts
@@ -59,6 +59,38 @@ describe('RetrySpool', () => {
     expect(await spool.size()).toBe(0)
   })
 
+  it('accepts agent_timeline retry payloads', async () => {
+    const spool = new RetrySpool(dir, { maxFiles: 20, maxAgeDays: 7 })
+    await spool.enqueue({
+      kind: 'extract',
+      userId: 'u',
+      agentId: 'a',
+      sourceClient: 'openclaw',
+      sessionKey: 's',
+      fingerprints: ['event-1', 'event-2'],
+      rawContent: {
+        type: 'agent_timeline',
+        sourceClient: 'openclaw',
+        sessionId: 's',
+        agentTurnId: 'turn-1',
+        timelineId: 'openclaw-s-turn-1',
+        events: [
+          { eventId: 'event-1', seq: 1, kind: 'user_prompt', text: 'hello' },
+          { eventId: 'event-2', seq: 2, kind: 'stop', status: 'success' },
+        ],
+        metadata: { profile: 'general', runtime: 'openclaw', sessionKey: 's' },
+      },
+    })
+
+    const extract = vi.fn().mockResolvedValue(successfulExtractResponse())
+    await expect(spool.flush({ extract })).resolves.toBe(1)
+    expect(extract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawContent: expect.objectContaining({ type: 'agent_timeline' }),
+      }),
+    )
+  })
+
   it('keeps failed retries', async () => {
     const spool = new RetrySpool(dir, { maxFiles: 20, maxAgeDays: 7 })
     await spool.enqueue({

--- a/memind-integrations/openclaw/tests/runtime.test.ts
+++ b/memind-integrations/openclaw/tests/runtime.test.ts
@@ -42,8 +42,10 @@ describe('createRuntimeStores', () => {
     const stores = createRuntimeStores(parseConfig({}), () => '/tmp/openclaw-state')
     const runtime = stores.current()
     expect(runtime.stateRoot).toBe(path.join('/tmp/openclaw-state', 'state'))
+    expect(runtime.agentStateRoot).toBe(path.join('/tmp/openclaw-state', 'agent-events'))
     expect(runtime.retryRoot).toBe(path.join('/tmp/openclaw-state', 'retry'))
     expect(runtime.state).toBe(stores.current().state)
+    expect(runtime.agentState).toBe(stores.current().agentState)
   })
 
   it('recreates stores when service start updates stateDir', () => {
@@ -54,5 +56,6 @@ describe('createRuntimeStores', () => {
     const second = stores.current()
     expect(second.stateRoot).toBe(path.join('/tmp/second', 'state'))
     expect(second.state).not.toBe(first.state)
+    expect(second.agentState).not.toBe(first.agentState)
   })
 })

--- a/memind-integrations/openclaw/tests/state.test.ts
+++ b/memind-integrations/openclaw/tests/state.test.ts
@@ -18,7 +18,7 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { SubmittedStateStore } from '../src/state.js'
+import { AgentTimelineStateStore, SubmittedStateStore } from '../src/state.js'
 
 let dir: string
 
@@ -43,5 +43,58 @@ describe('SubmittedStateStore', () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000)
     await utimes(path.join(dir, 'session_1.json'), twoDaysAgo, twoDaysAgo)
     await expect(store.filterUnsubmitted('session:1', ['a'])).resolves.toEqual(['a'])
+  })
+})
+
+describe('AgentTimelineStateStore', () => {
+  it('appends events in order and ignores duplicate event ids', async () => {
+    const store = new AgentTimelineStateStore(dir, { maxAgeDays: 14, maxEvents: 500 })
+    await store.appendAgentEvent('session:1', {
+      eventId: 'event-2',
+      seq: 2,
+      kind: 'assistant_message',
+    })
+    await store.appendAgentEvent('session:1', {
+      eventId: 'event-1',
+      seq: 1,
+      kind: 'user_prompt',
+    })
+    await store.appendAgentEvent('session:1', {
+      eventId: 'event-1',
+      seq: 1,
+      kind: 'user_prompt',
+      text: 'duplicate',
+    })
+
+    await expect(store.listAgentEvents('session:1')).resolves.toMatchObject([
+      { eventId: 'event-1', seq: 1, kind: 'user_prompt' },
+      { eventId: 'event-2', seq: 2, kind: 'assistant_message' },
+    ])
+  })
+
+  it('keeps only latest events when soft cap is reached', async () => {
+    const store = new AgentTimelineStateStore(dir, { maxAgeDays: 14, maxEvents: 2 })
+    await store.appendAgentEvent('session:1', { eventId: 'event-1', seq: 1, kind: 'user_prompt' })
+    await store.appendAgentEvent('session:1', { eventId: 'event-2', seq: 2, kind: 'tool_result' })
+    await store.appendAgentEvent('session:1', { eventId: 'event-3', seq: 3, kind: 'stop' })
+
+    await expect(store.listAgentEvents('session:1')).resolves.toMatchObject([
+      { eventId: 'event-2' },
+      { eventId: 'event-3' },
+    ])
+  })
+
+  it('clears selected submitted events and computes next sequence', async () => {
+    const store = new AgentTimelineStateStore(dir, { maxAgeDays: 14, maxEvents: 500 })
+    await store.appendAgentEvent('session:1', { eventId: 'event-1', seq: 1, kind: 'user_prompt' })
+    await store.appendAgentEvent('session:1', { eventId: 'event-3', seq: 3, kind: 'stop' })
+
+    await expect(store.nextAgentEventSeq('session:1')).resolves.toBe(4)
+    await store.clearAgentEvents('session:1', ['event-1'])
+    await expect(store.listAgentEvents('session:1')).resolves.toMatchObject([
+      { eventId: 'event-3' },
+    ])
+    await store.clearAgentEvents('session:1')
+    await expect(store.listAgentEvents('session:1')).resolves.toEqual([])
   })
 })

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/caption/AgentCaptionGenerator.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/caption/AgentCaptionGenerator.java
@@ -30,10 +30,16 @@ public final class AgentCaptionGenerator implements CaptionGenerator {
 
     private static final String SYSTEM_PROMPT =
             """
-            You summarize one completed coding-agent turn for a memory system.
+            You summarize one completed agent turn for a memory system.
+
+            The agent may be a coding agent or a general-purpose agent. Use profile and runtime \
+            metadata to decide which evidence matters. For coding agents, emphasize task, outcome, \
+            files, commands, validations, failures, decisions, and next steps. For general agents, \
+            emphasize user goal, outcome, decisions, commitments, external observations, tools, \
+            participants, and follow-up.
 
             The summary will be embedded and shown in retrieval results. It must be factual, \
-            concise, and useful for continuing the project later.
+            concise, and useful for continuing later work.
 
             Rules:
             - Use only the provided episode text and metadata.
@@ -108,6 +114,12 @@ public final class AgentCaptionGenerator implements CaptionGenerator {
         # Episode Metadata
 
         targetLanguage: %s
+        profile: %s
+        runtime: %s
+        channelId: %s
+        conversationId: %s
+        workspaceDir: %s
+        agentName: %s
         goal: %s
         outcome: %s
         sourceClient: %s
@@ -126,6 +138,12 @@ public final class AgentCaptionGenerator implements CaptionGenerator {
         """
                 .formatted(
                         string(language),
+                        string(safeMetadata.get("profile")),
+                        string(safeMetadata.get("runtime")),
+                        string(safeMetadata.get("channelId")),
+                        string(safeMetadata.get("conversationId")),
+                        string(safeMetadata.get("workspaceDir")),
+                        string(safeMetadata.get("agentName")),
                         string(safeMetadata.get("goal")),
                         string(safeMetadata.get("outcome")),
                         string(safeMetadata.get("sourceClient")),

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/content/AgentTimelineContent.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/content/AgentTimelineContent.java
@@ -30,7 +30,11 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
- * Raw content for a coding-agent timeline.
+ * Raw content for an agent runtime timeline.
+ *
+ * <p>The same wire format is used by coding agents such as Claude Code/Codex and general agents
+ * such as OpenClaw/Hermes. Runtime-specific behavior is selected through content metadata such as
+ * {@code profile} and {@code runtime}.
  */
 public final class AgentTimelineContent extends RawContent {
 

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemExtractionStrategy.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemExtractionStrategy.java
@@ -267,6 +267,7 @@ public class AgentItemExtractionStrategy implements ItemExtractionStrategy {
             metadata.putAll(item.metadata());
         }
         copy(segment.metadata(), metadata, "episodeId");
+        copyGenericAgentMetadata(segment.metadata(), metadata);
         copy(segment.metadata(), metadata, "sessionId");
         copy(segment.metadata(), metadata, "timelineId");
         copy(segment.metadata(), metadata, "sourceClient");
@@ -281,6 +282,18 @@ public class AgentItemExtractionStrategy implements ItemExtractionStrategy {
         copy(segment.metadata(), metadata, "toolNames");
         copy(segment.metadata(), metadata, "failureSignals");
         return Map.copyOf(metadata);
+    }
+
+    private static void copyGenericAgentMetadata(
+            Map<String, Object> source, Map<String, Object> target) {
+        copy(source, target, "profile");
+        copy(source, target, "runtime");
+        copy(source, target, "channelId");
+        copy(source, target, "conversationId");
+        copy(source, target, "workspaceDir");
+        copy(source, target, "agentName");
+        copy(source, target, "sessionKey");
+        copy(source, target, "turnId");
     }
 
     private static void copy(Map<String, Object> source, Map<String, Object> target, String key) {

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemPrompts.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemPrompts.java
@@ -25,9 +25,17 @@ public final class AgentItemPrompts {
 
     private static final String SYSTEM =
             """
-            You extract durable memory items from one deterministic coding-agent \
-            episode. The episode has already been parsed from raw agent events; do not invent \
-            events, tools, files, or outcomes that are not present in the input.
+            You extract durable memory items from one deterministic agent episode. The episode \
+            has already been parsed from raw agent events; do not invent events, tools, files, or \
+            outcomes that are not present in the input.
+
+            The agent may be a coding agent or a general-purpose agent. Use profile and runtime \
+            metadata to decide which facts are durable. For coding agents, prioritize validated \
+            implementation decisions, file context, commands, failures, resolutions, reusable \
+            workflows, and explicit directives. For general agents, prioritize user preferences, \
+            stable facts, decisions, commitments, external observations, outcomes, directives, and \
+            reusable workflows. Do not create generic tool memories for ordinary general-agent tool \
+            usage unless the tool usage produced durable knowledge.
 
             Categories are limited to: {{categories}}.
 
@@ -86,8 +94,16 @@ public final class AgentItemPrompts {
             # Episode Metadata
 
             episodeId: {{episode_id}}
+            profile: {{profile}}
+            runtime: {{runtime}}
+            channelId: {{channel_id}}
+            conversationId: {{conversation_id}}
+            workspaceDir: {{workspace_dir}}
+            agentName: {{agent_name}}
             sourceClient: {{source_client}}
             sessionId: {{session_id}}
+            sessionKey: {{session_key}}
+            turnId: {{turn_id}}
             timelineId: {{timeline_id}}
             outcome: {{outcome}}
             files: {{files}}
@@ -110,8 +126,16 @@ public final class AgentItemPrompts {
                 .userPrompt(USER_PROMPT)
                 .variable("categories", String.join(", ", categories))
                 .variable("episode_id", string(metadata.get("episodeId")))
+                .variable("profile", string(metadata.get("profile")))
+                .variable("runtime", string(metadata.get("runtime")))
+                .variable("channel_id", string(metadata.get("channelId")))
+                .variable("conversation_id", string(metadata.get("conversationId")))
+                .variable("workspace_dir", string(metadata.get("workspaceDir")))
+                .variable("agent_name", string(metadata.get("agentName")))
                 .variable("source_client", string(metadata.get("sourceClient")))
                 .variable("session_id", string(metadata.get("sessionId")))
+                .variable("session_key", string(metadata.get("sessionKey")))
+                .variable("turn_id", string(metadata.get("turnId")))
                 .variable("timeline_id", string(metadata.get("timelineId")))
                 .variable("outcome", string(metadata.get("outcome")))
                 .variable("files", formatList(metadata.get("files")))

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentMemoryItemFactory.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentMemoryItemFactory.java
@@ -45,6 +45,9 @@ public final class AgentMemoryItemFactory {
         if (episode.commands().isEmpty() && episode.toolNames().isEmpty()) {
             return java.util.Optional.empty();
         }
+        if (episode.generalProfile() && !episode.hasCommandOrValidationEvidence()) {
+            return java.util.Optional.empty();
+        }
 
         String command = episode.commands().isEmpty() ? null : episode.commands().getFirst();
         String toolName = episode.toolNames().isEmpty() ? null : episode.toolNames().getFirst();
@@ -138,6 +141,7 @@ public final class AgentMemoryItemFactory {
     private Map<String, Object> baseMetadata(EpisodeMetadata episode) {
         var metadata = new LinkedHashMap<String, Object>();
         copy(episode.raw(), metadata, "episodeId");
+        copyGenericAgentMetadata(episode.raw(), metadata);
         copy(episode.raw(), metadata, "sessionId");
         copy(episode.raw(), metadata, "timelineId");
         copy(episode.raw(), metadata, "sourceClient");
@@ -154,6 +158,18 @@ public final class AgentMemoryItemFactory {
         metadata.put("toolNames", episode.toolNames());
         metadata.put("failureSignals", episode.failureSignals());
         return metadata;
+    }
+
+    private static void copyGenericAgentMetadata(
+            Map<String, Object> source, Map<String, Object> target) {
+        copy(source, target, "profile");
+        copy(source, target, "runtime");
+        copy(source, target, "channelId");
+        copy(source, target, "conversationId");
+        copy(source, target, "workspaceDir");
+        copy(source, target, "agentName");
+        copy(source, target, "sessionKey");
+        copy(source, target, "turnId");
     }
 
     private ExtractedGraphHints graphHints(
@@ -238,6 +254,10 @@ public final class AgentMemoryItemFactory {
             return string(raw.get("outcome"));
         }
 
+        boolean generalProfile() {
+            return "general".equalsIgnoreCase(string(raw.get("profile")));
+        }
+
         List<String> files() {
             return stringList(raw.get("files"));
         }
@@ -267,6 +287,12 @@ public final class AgentMemoryItemFactory {
                     .filter(Map.class::isInstance)
                     .map(entry -> CommandEvent.from((Map<?, ?>) entry))
                     .toList();
+        }
+
+        boolean hasCommandOrValidationEvidence() {
+            return !commands().isEmpty()
+                    || !commandEvents().isEmpty()
+                    || !failureSignals().isEmpty();
         }
 
         List<FileEvent> fileEvents() {

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/plugin/AgentRawDataPlugin.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/plugin/AgentRawDataPlugin.java
@@ -26,7 +26,7 @@ import com.openmemind.ai.memory.plugin.rawdata.agent.processor.AgentTimelineCont
 import java.util.List;
 
 /**
- * RawData plugin contribution for coding-agent timelines.
+ * RawData plugin contribution for agent runtime timelines.
  */
 public final class AgentRawDataPlugin implements RawDataPlugin {
 

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/processor/AgentTimelineContentProcessor.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/main/java/com/openmemind/ai/memory/plugin/rawdata/agent/processor/AgentTimelineContentProcessor.java
@@ -28,7 +28,10 @@ import java.util.Set;
 import reactor.core.publisher.Mono;
 
 /**
- * RawData processor for coding-agent timelines.
+ * RawData processor for agent runtime timelines.
+ *
+ * <p>The processor keeps one wire format for coding and general-purpose agents; profile-specific
+ * behavior is handled by prompts, deterministic extraction, and metadata.
  */
 public final class AgentTimelineContentProcessor
         implements RawContentProcessor<AgentTimelineContent> {

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/caption/AgentCaptionGeneratorTest.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/caption/AgentCaptionGeneratorTest.java
@@ -100,6 +100,58 @@ class AgentCaptionGeneratorTest {
     }
 
     @Test
+    void shouldIncludeGeneralAgentProfileMetadataInCaptionPrompt() {
+        CapturingChatClient client =
+                new CapturingChatClient(
+                        new AgentCaptionGenerator.AgentCaptionResponse(
+                                "Summarize the customer's renewal concerns",
+                                "The agent reviewed recent customer messages and identified renewal"
+                                        + " concerns around onboarding and support response time.",
+                                "success",
+                                List.of(
+                                        "Searched email history.",
+                                        "Captured the renewal concerns."),
+                                List.of("Tool: gmail.search"),
+                                ""));
+
+        new AgentCaptionGenerator(client)
+                .generate(
+                        "Goal: Summarize renewal concerns.\nEvents:\n- prompt-1 user_prompt",
+                        Map.of(
+                                "profile",
+                                "general",
+                                "runtime",
+                                "openclaw",
+                                "channelId",
+                                "slack:C123",
+                                "conversationId",
+                                "thread-456",
+                                "workspaceDir",
+                                "/tmp/acme",
+                                "agentName",
+                                "sales-assistant",
+                                "goal",
+                                "Summarize the customer's renewal concerns",
+                                "toolNames",
+                                List.of("gmail.search"),
+                                "eventIds",
+                                List.of("prompt-1", "tool-1", "stop-1")),
+                        "English")
+                .block();
+
+        assertThat(client.userPrompt())
+                .contains(
+                        "profile: general",
+                        "runtime: openclaw",
+                        "channelId: slack:C123",
+                        "conversationId: thread-456",
+                        "workspaceDir: /tmp/acme",
+                        "agentName: sales-assistant",
+                        "Summarize the customer's renewal concerns",
+                        "gmail.search");
+    }
+
+    @Test
     void shouldFallbackToDeterministicCaptionWhenLlmFails() {
         String caption =
                 new AgentCaptionGenerator(new FailingChatClient())

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemExtractionStrategyLlmTest.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/item/AgentItemExtractionStrategyLlmTest.java
@@ -217,6 +217,91 @@ class AgentItemExtractionStrategyLlmTest {
     }
 
     @Test
+    void shouldPropagateGeneralAgentMetadataFromLlmItems() {
+        var client =
+                new StubStructuredChatClient(
+                        response(
+                                new MemoryItemExtractionResponse.ExtractedItem(
+                                        "The customer is concerned about renewal onboarding and"
+                                                + " support response time.",
+                                        0.88f,
+                                        null,
+                                        List.of("experiences"),
+                                        Map.of("evidenceEventIds", List.of("prompt-1")),
+                                        "event")));
+        AgentItemExtractionStrategy strategy = strategy(client);
+
+        List<ExtractedMemoryEntry> entries =
+                strategy.extract(
+                                List.of(generalEpisodeWithToolOnly()),
+                                DefaultInsightTypes.all(),
+                                allScopeConfig())
+                        .block();
+
+        assertThat(client.lastMessages())
+                .anySatisfy(
+                        message ->
+                                assertThat(message.content())
+                                        .contains(
+                                                "profile: general",
+                                                "runtime: hermes",
+                                                "channelId: slack:C123",
+                                                "conversationId: thread-456",
+                                                "sessionKey: hermes-s1",
+                                                "turnId: turn-7"));
+        assertThat(entries)
+                .filteredOn(entry -> "event".equals(entry.category()))
+                .singleElement()
+                .satisfies(
+                        entry ->
+                                assertThat(entry.metadata())
+                                        .containsEntry("profile", "general")
+                                        .containsEntry("runtime", "hermes")
+                                        .containsEntry("channelId", "slack:C123")
+                                        .containsEntry("conversationId", "thread-456")
+                                        .containsEntry("sessionKey", "hermes-s1")
+                                        .containsEntry("turnId", "turn-7"));
+    }
+
+    @Test
+    void shouldNotCreateDeterministicToolMemoryForGeneralAgentToolOnlyEpisode() {
+        AgentItemExtractionStrategy strategy = strategy(null);
+
+        List<ExtractedMemoryEntry> entries =
+                strategy.extract(
+                                List.of(generalEpisodeWithToolOnly()),
+                                DefaultInsightTypes.all(),
+                                allScopeConfig())
+                        .block();
+
+        assertThat(entries).noneMatch(entry -> "tool".equals(entry.category()));
+    }
+
+    @Test
+    void shouldKeepDeterministicToolMemoryForCodingAgentCommandEpisode() {
+        AgentItemExtractionStrategy strategy = strategy(null);
+
+        List<ExtractedMemoryEntry> entries =
+                strategy.extract(
+                                List.of(codingEpisodeWithCommand()),
+                                DefaultInsightTypes.all(),
+                                allScopeConfig())
+                        .block();
+
+        assertThat(entries)
+                .filteredOn(entry -> "tool".equals(entry.category()))
+                .singleElement()
+                .satisfies(
+                        entry ->
+                                assertThat(entry.metadata())
+                                        .containsEntry("profile", "coding")
+                                        .containsEntry("runtime", "codex")
+                                        .containsEntry("channelId", "terminal")
+                                        .containsEntry("sessionKey", "session-123")
+                                        .containsEntry("turnId", "turn-1"));
+    }
+
+    @Test
     void shouldAcceptSubagentBackedPlaybookWhenEvidenceBelongsToEpisode() {
         var client =
                 new StubStructuredChatClient(
@@ -359,6 +444,53 @@ class AgentItemExtractionStrategyLlmTest {
                                                 "rounding mismatch"),
                                         commandEvent(
                                                 "e4", 4, "npm test payment", "success", "passed"))),
+                        Map.entry(
+                                "fileEvents", List.of(fileEvent("e3", 3, "src/payment/calc.ts")))));
+    }
+
+    private static ParsedSegment generalEpisodeWithToolOnly() {
+        return segment(
+                Map.ofEntries(
+                        Map.entry("segmentType", "agent_episode"),
+                        Map.entry("episodeId", "episode-general"),
+                        Map.entry("profile", "general"),
+                        Map.entry("runtime", "hermes"),
+                        Map.entry("channelId", "slack:C123"),
+                        Map.entry("conversationId", "thread-456"),
+                        Map.entry("workspaceDir", "/tmp/acme"),
+                        Map.entry("agentName", "sales-assistant"),
+                        Map.entry("sessionKey", "hermes-s1"),
+                        Map.entry("turnId", "turn-7"),
+                        Map.entry("sourceClient", "hermes"),
+                        Map.entry("sessionId", "s1"),
+                        Map.entry("timelineId", "tl-1"),
+                        Map.entry("outcome", "success"),
+                        Map.entry("toolNames", List.of("gmail.search")),
+                        Map.entry("eventIds", List.of("prompt-1", "tool-1", "stop-1")),
+                        Map.entry("eventKinds", List.of("user_prompt", "tool_result", "stop"))));
+    }
+
+    private static ParsedSegment codingEpisodeWithCommand() {
+        return segment(
+                Map.ofEntries(
+                        Map.entry("segmentType", "agent_episode"),
+                        Map.entry("episodeId", "episode-coding"),
+                        Map.entry("profile", "coding"),
+                        Map.entry("runtime", "codex"),
+                        Map.entry("channelId", "terminal"),
+                        Map.entry("sessionKey", "session-123"),
+                        Map.entry("turnId", "turn-1"),
+                        Map.entry("sourceClient", "codex"),
+                        Map.entry("sessionId", "session-123"),
+                        Map.entry("timelineId", "timeline-123"),
+                        Map.entry("outcome", "success"),
+                        Map.entry("files", List.of("src/payment/calc.ts")),
+                        Map.entry("commands", List.of("mvn test")),
+                        Map.entry("toolNames", List.of("Bash")),
+                        Map.entry("eventIds", List.of("e1", "e2", "e3")),
+                        Map.entry(
+                                "commandEvents",
+                                List.of(commandEvent("e2", 2, "mvn test", "success", "passed"))),
                         Map.entry(
                                 "fileEvents", List.of(fileEvent("e3", 3, "src/payment/calc.ts")))));
     }


### PR DESCRIPTION
## Summary
- Make rawdata-agent profile-aware so general agent timelines can reuse the existing agent_timeline pipeline without introducing a new rawdata type.
- Refactor OpenClaw automatic ingestion to buffer lifecycle events and flush completed agent_timeline raw data.
- Refactor Hermes automatic lifecycle ingestion to submit agent_timeline raw data while keeping explicit text extraction as standalone conversation content.

## Test Plan
- `PATH=/Users/zhengyate/.nvm/versions/node/v22.22.0/bin:$PATH COREPACK_HOME=/tmp/memind-corepack corepack pnpm --dir memind-integrations/openclaw test`
- `PATH=/Users/zhengyate/.nvm/versions/node/v22.22.0/bin:$PATH COREPACK_HOME=/tmp/memind-corepack corepack pnpm --dir memind-integrations/openclaw typecheck`
- `PATH=/Users/zhengyate/.nvm/versions/node/v22.22.0/bin:$PATH COREPACK_HOME=/tmp/memind-corepack corepack pnpm --dir memind-integrations/openclaw lint`
- `PATH=/Users/zhengyate/.nvm/versions/node/v22.22.0/bin:$PATH COREPACK_HOME=/tmp/memind-corepack corepack pnpm --dir memind-integrations/openclaw format:check`
- `PYTHONPATH=memind-integrations/hermes python3 -m unittest discover -s memind-integrations/hermes/tests`
- `mvn -pl memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent -am test`