### PR TITLE
test: harden rawdata embedding stubs

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/vector/MemoryVector.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/vector/MemoryVector.java
@@ -193,9 +193,13 @@ public interface MemoryVector {
     // ===== Embedding operations =====
 
     /**
-     * Calculate the embedding vector of the text
+     * Calculate the embedding vector of the text.
      *
-     * <p>Used for MMR and other reordering algorithms, requires obtaining the vector representation of the query and candidates
+     * <p>Used for MMR and other reordering algorithms, requires obtaining the vector
+     * representation of the query and candidates.
+     *
+     * <p>Implementations should return a non-empty vector for non-empty text. Vectors produced by
+     * one implementation/model are expected to have a consistent dimension.
      *
      * @param text Text to calculate embedding
      * @return Embedding vector
@@ -203,15 +207,20 @@ public interface MemoryVector {
     Mono<List<Float>> embed(String text);
 
     /**
-     * Batch calculate the embedding vectors of the texts
+     * Batch calculate the embedding vectors of the texts.
      *
-     * <p>Used for MMR and other reordering algorithms, batch obtain the vector representation of candidates
+     * <p>Used for MMR and other reordering algorithms, batch obtain the vector representation of
+     * candidates.
      *
-     * @param texts List of texts to calculate embedding
+     * <p>For non-empty input, the result should contain one embedding per input text, in order.
+     * Each embedding should follow the same dimensionality contract as {@link #embed(String)}.
+     *
      * <p>Stage 3 semantic-linking contract: returned embeddings must live in the same vector space
      * as the scores returned by {@link #search(MemoryId, String, int, double, Map)} and
      * {@link #searchBatch(MemoryId, List, int)} when those values are merged in one semantic-link
      * normalization path.
+     *
+     * @param texts List of texts to calculate embedding
      * @return List of embedding vectors, corresponding to the input texts
      */
     Mono<List<List<Float>>> embedAll(List<String> texts);

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/integration/AgentExtractionPipelineIntegrationTest.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent/src/test/java/com/openmemind/ai/memory/plugin/rawdata/agent/integration/AgentExtractionPipelineIntegrationTest.java
@@ -64,6 +64,8 @@ import reactor.core.publisher.Mono;
 
 class AgentExtractionPipelineIntegrationTest {
 
+    private static final int TEST_EMBEDDING_DIMENSION = 8;
+
     private static final MemoryId MEMORY_ID = DefaultMemoryId.of("user-1", "agent-1");
 
     @Test
@@ -93,6 +95,13 @@ class AgentExtractionPipelineIntegrationTest {
                             assertThat(rawData.segment().metadata())
                                     .containsEntry("segmentType", "agent_episode");
                         });
+        assertThat(fixture.vector().embed("agent episode caption").block())
+                .isNotNull()
+                .hasSize(TEST_EMBEDDING_DIMENSION);
+        assertThat(fixture.vector().embedAll(List.of("tool", "resolution")).block())
+                .isNotNull()
+                .hasSize(2)
+                .allSatisfy(embedding -> assertThat(embedding).hasSize(TEST_EMBEDDING_DIMENSION));
     }
 
     @Test
@@ -608,12 +617,19 @@ class AgentExtractionPipelineIntegrationTest {
 
         @Override
         public Mono<List<Float>> embed(String text) {
-            return Mono.just(List.of());
+            return Mono.just(testEmbedding(text));
         }
 
         @Override
         public Mono<List<List<Float>>> embedAll(List<String> texts) {
-            return Mono.just(List.of());
+            return Mono.just(texts.stream().map(RecordingMemoryVector::testEmbedding).toList());
+        }
+
+        private static List<Float> testEmbedding(String text) {
+            int seed = text == null ? 0 : text.hashCode();
+            return IntStream.range(0, TEST_EMBEDDING_DIMENSION)
+                    .mapToObj(i -> ((seed + i * 31) & 0xff) / 255.0f)
+                    .toList();
         }
     }
 }

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-audio/src/test/java/com/openmemind/ai/memory/plugin/rawdata/audio/integration/AudioExtractionPipelineIntegrationTest.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-audio/src/test/java/com/openmemind/ai/memory/plugin/rawdata/audio/integration/AudioExtractionPipelineIntegrationTest.java
@@ -63,15 +63,19 @@ import reactor.core.publisher.Mono;
 
 class AudioExtractionPipelineIntegrationTest {
 
+    private static final int TEST_EMBEDDING_DIMENSION = 8;
+
     @Test
     void wholeTranscriptPersistenceStillFeedsMemoryItemsWithTranscriptText() {
         MemoryId memoryId = DefaultMemoryId.of("user-1", "agent-1");
         MemoryStore store = recordingStore();
         var memoryItemStep = new RecordingMemoryItemStep("rollback code is R-17");
+        var vector = new StubMemoryVector();
         var extractor =
                 extractor(
                         store,
                         memoryItemStep,
+                        vector,
                         new AudioExtractionOptions(
                                 new SourceLimitOptions(1024),
                                 new ParsedContentLimitOptions(
@@ -114,6 +118,13 @@ class AudioExtractionPipelineIntegrationTest {
                 .extracting(ParsedSegment::caption)
                 .singleElement()
                 .satisfies(caption -> assertThat(caption).doesNotContain("rollback code is R-17"));
+        assertThat(vector.embed("audio transcript caption").block())
+                .isNotNull()
+                .hasSize(TEST_EMBEDDING_DIMENSION);
+        assertThat(vector.embedAll(List.of("intro", "rollback")).block())
+                .isNotNull()
+                .hasSize(2)
+                .allSatisfy(embedding -> assertThat(embedding).hasSize(TEST_EMBEDDING_DIMENSION));
     }
 
     @Test
@@ -124,6 +135,7 @@ class AudioExtractionPipelineIntegrationTest {
                 extractor(
                         store,
                         new RecordingMemoryItemStep(),
+                        new StubMemoryVector(),
                         new AudioExtractionOptions(
                                 new SourceLimitOptions(1024),
                                 new ParsedContentLimitOptions(
@@ -183,15 +195,12 @@ class AudioExtractionPipelineIntegrationTest {
     private static DefaultMemoryExtractor extractor(
             MemoryStore store,
             RecordingMemoryItemStep memoryItemStep,
+            StubMemoryVector vector,
             AudioExtractionOptions options) {
         var processor = new AudioContentProcessor(new TranscriptSegmentChunker(), options);
         var rawDataLayer =
                 new RawDataLayer(
-                        List.of(processor),
-                        new AudioCaptionGenerator(),
-                        store,
-                        new StubMemoryVector(),
-                        16);
+                        List.of(processor), new AudioCaptionGenerator(), store, vector, 16);
         return new DefaultMemoryExtractor(
                 rawDataLayer,
                 memoryItemStep,
@@ -318,12 +327,19 @@ class AudioExtractionPipelineIntegrationTest {
 
         @Override
         public Mono<List<Float>> embed(String text) {
-            return Mono.just(List.of());
+            return Mono.just(testEmbedding(text));
         }
 
         @Override
         public Mono<List<List<Float>>> embedAll(List<String> texts) {
-            return Mono.just(List.of());
+            return Mono.just(texts.stream().map(StubMemoryVector::testEmbedding).toList());
+        }
+
+        private static List<Float> testEmbedding(String text) {
+            int seed = text == null ? 0 : text.hashCode();
+            return IntStream.range(0, TEST_EMBEDDING_DIMENSION)
+                    .mapToObj(i -> ((seed + i * 31) & 0xff) / 255.0f)
+                    .toList();
         }
     }
 }

--- a/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-image/src/test/java/com/openmemind/ai/memory/plugin/rawdata/image/integration/ImageExtractionPipelineIntegrationTest.java
+++ b/memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-image/src/test/java/com/openmemind/ai/memory/plugin/rawdata/image/integration/ImageExtractionPipelineIntegrationTest.java
@@ -61,6 +61,8 @@ import reactor.core.publisher.Mono;
 
 class ImageExtractionPipelineIntegrationTest {
 
+    private static final int TEST_EMBEDDING_DIMENSION = 8;
+
     @Test
     void pluginOwnedParserCanParseFileAndPersistSingleCaptionedRawData() {
         MemoryId memoryId = DefaultMemoryId.of("user-1", "agent-1");
@@ -123,8 +125,22 @@ class ImageExtractionPipelineIntegrationTest {
                             assertThat(rawData.segment().content())
                                     .isEqualTo("Dashboard screenshot showing Total Revenue 30%");
                             assertThat(rawData.caption()).isEqualTo("Revenue dashboard screenshot");
+                            assertThat(rawData.captionVectorId()).isNotBlank();
+                            assertThat(rawData.metadata())
+                                    .containsEntry("vectorId", rawData.captionVectorId());
+                            assertThat(rawData.segment().metadata())
+                                    .containsEntry("vectorId", rawData.captionVectorId());
                         });
         assertThat(vector.storedTexts()).containsExactly("Revenue dashboard screenshot");
+        assertThat(vector.embed("Revenue dashboard screenshot").block())
+                .isNotNull()
+                .hasSize(TEST_EMBEDDING_DIMENSION);
+        assertThat(
+                        vector.embedAll(List.of("Revenue dashboard screenshot", "Total revenue"))
+                                .block())
+                .isNotNull()
+                .hasSize(2)
+                .allSatisfy(embedding -> assertThat(embedding).hasSize(TEST_EMBEDDING_DIMENSION));
     }
 
     private static ContentParser testImageParser() {
@@ -233,12 +249,19 @@ class ImageExtractionPipelineIntegrationTest {
 
         @Override
         public Mono<List<Float>> embed(String text) {
-            return Mono.just(List.of());
+            return Mono.just(testEmbedding(text));
         }
 
         @Override
         public Mono<List<List<Float>>> embedAll(List<String> texts) {
-            return Mono.just(List.of());
+            return Mono.just(texts.stream().map(RecordingMemoryVector::testEmbedding).toList());
+        }
+
+        private static List<Float> testEmbedding(String text) {
+            int seed = text == null ? 0 : text.hashCode();
+            return IntStream.range(0, TEST_EMBEDDING_DIMENSION)
+                    .mapToObj(i -> ((seed + i * 31) & 0xff) / 255.0f)
+                    .toList();
         }
 
         private List<String> storedTexts() {


### PR DESCRIPTION
## Summary
- Replace empty rawdata integration MemoryVector embedding stubs with deterministic non-empty test embeddings.
- Assert embedding dimensionality, embedAll(...) cardinality, and persisted image caption vector IDs.
- Document the MemoryVector embedding contract for non-empty and consistently sized embeddings.

## Testing
- mvn -pl memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-image,memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-audio,memind-plugins/memind-plugin-rawdatas/memind-plugin-rawdata-agent -am -Dlicense.skip=true test
- git diff --check

Closes #91.