### PR TITLE
fix: make runtime config initialization idempotent

### DIFF
--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
@@ -31,6 +31,7 @@ import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.utils.JsonUtils;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
+import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeFactory;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeManager;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeUnavailableException;
@@ -210,18 +211,23 @@ public class MemindServerRuntimeConfiguration {
             ServerRuntimeConfigRepository repository, MemoryOptionsCodec codec) {
         return repository
                 .findActive(MemoryOptionService.CONFIG_KEY)
-                .map(
-                        config ->
-                                new InitialRuntimeState(
-                                        config.getConfigVersion(),
-                                        codec.read(config.getConfigJson())))
+                .map(config -> toInitialRuntimeState(config, codec))
                 .orElseGet(
                         () -> {
                             MemoryBuildOptions defaults = MemoryBuildOptions.defaults();
-                            repository.insertInitial(
-                                    MemoryOptionService.CONFIG_KEY, 1L, codec.write(defaults));
-                            return new InitialRuntimeState(1L, defaults);
+                            return toInitialRuntimeState(
+                                    repository.findOrInsertInitial(
+                                            MemoryOptionService.CONFIG_KEY,
+                                            1L,
+                                            codec.write(defaults)),
+                                    codec);
                         });
+    }
+
+    private static InitialRuntimeState toInitialRuntimeState(
+            ServerRuntimeConfigDO config, MemoryOptionsCodec codec) {
+        return new InitialRuntimeState(
+                config.getConfigVersion(), codec.read(config.getConfigJson()));
     }
 
     private static <T> T requireRuntimeDependency(ObjectProvider<T> provider) {

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/config/MemoryOptionService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/config/MemoryOptionService.java
@@ -15,6 +15,7 @@ package com.openmemind.ai.memory.server.service.config;
 
 import com.openmemind.ai.memory.core.Memory;
 import com.openmemind.ai.memory.core.builder.MemoryBuildOptions;
+import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import com.openmemind.ai.memory.server.domain.config.response.MemoryOptionsSnapshot;
 import com.openmemind.ai.memory.server.domain.config.view.MemoryOptionItemView;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeFactory;
@@ -85,18 +86,18 @@ public class MemoryOptionService {
     private MemoryOptionsState loadOrInitialize() {
         return repository
                 .findActive(CONFIG_KEY)
-                .map(
-                        config ->
-                                new MemoryOptionsState(
-                                        config.getConfigVersion(),
-                                        codec.read(config.getConfigJson())))
+                .map(this::toState)
                 .orElseGet(this::initializeDefaults);
     }
 
     private MemoryOptionsState initializeDefaults() {
         MemoryBuildOptions defaults = MemoryBuildOptions.defaults();
-        repository.insertInitial(CONFIG_KEY, 1L, codec.write(defaults));
-        return new MemoryOptionsState(1L, defaults);
+        return toState(repository.findOrInsertInitial(CONFIG_KEY, 1L, codec.write(defaults)));
+    }
+
+    private MemoryOptionsState toState(ServerRuntimeConfigDO config) {
+        return new MemoryOptionsState(
+                config.getConfigVersion(), codec.read(config.getConfigJson()));
     }
 
     private static OptimisticLockingFailureException versionConflict(

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/config/ServerRuntimeConfigRepository.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/config/ServerRuntimeConfigRepository.java
@@ -15,12 +15,35 @@ package com.openmemind.ai.memory.server.service.config;
 
 import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import java.util.Optional;
+import org.springframework.dao.DuplicateKeyException;
 
 public interface ServerRuntimeConfigRepository {
 
     Optional<ServerRuntimeConfigDO> findActive(String configKey);
 
     void insertInitial(String configKey, long version, String configJson);
+
+    default ServerRuntimeConfigDO findOrInsertInitial(
+            String configKey, long version, String configJson) {
+        return findActive(configKey)
+                .orElseGet(() -> insertInitialAndRead(configKey, version, configJson));
+    }
+
+    private ServerRuntimeConfigDO insertInitialAndRead(
+            String configKey, long version, String configJson) {
+        try {
+            insertInitial(configKey, version, configJson);
+        } catch (DuplicateKeyException e) {
+            // Another server instance inserted the same runtime config row concurrently.
+        }
+        return findActive(configKey)
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Runtime config "
+                                                + configKey
+                                                + " was not found after initial insert"));
+    }
 
     boolean update(String configKey, long expectedVersion, String configJson);
 }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/settings/UiPreferenceService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/settings/UiPreferenceService.java
@@ -17,6 +17,7 @@ import com.openmemind.ai.memory.core.utils.JsonUtils;
 import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import com.openmemind.ai.memory.server.domain.settings.UiPreferences;
 import com.openmemind.ai.memory.server.service.config.ServerRuntimeConfigRepository;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import tools.jackson.core.JacksonException;
@@ -49,16 +50,31 @@ public class UiPreferenceService {
         return repository
                 .findActive(CONFIG_KEY)
                 .map(config -> updateExisting(config, requested))
-                .orElseGet(() -> insertInitial(requested));
+                .orElseGet(() -> insertOrUpdate(requested));
     }
 
     private UiPreferences initializeDefaults() {
-        return insertInitial(UiPreferences.defaults());
+        return read(
+                repository
+                        .findOrInsertInitial(CONFIG_KEY, 1L, write(UiPreferences.defaults()))
+                        .getConfigJson());
     }
 
-    private UiPreferences insertInitial(UiPreferences preferences) {
-        repository.insertInitial(CONFIG_KEY, 1L, write(preferences));
-        return preferences;
+    private UiPreferences insertOrUpdate(UiPreferences preferences) {
+        try {
+            repository.insertInitial(CONFIG_KEY, 1L, write(preferences));
+            return preferences;
+        } catch (DuplicateKeyException e) {
+            ServerRuntimeConfigDO config =
+                    repository
+                            .findActive(CONFIG_KEY)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "UI preferences were not found after initial"
+                                                            + " insert"));
+            return updateExisting(config, preferences);
+        }
     }
 
     private UiPreferences updateExisting(ServerRuntimeConfigDO config, UiPreferences preferences) {

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
@@ -68,10 +68,18 @@ import com.openmemind.ai.memory.plugin.rawdata.document.DocumentSemantics;
 import com.openmemind.ai.memory.plugin.rawdata.document.content.DocumentContent;
 import com.openmemind.ai.memory.plugin.rawdata.image.content.ImageContent;
 import com.openmemind.ai.memory.plugin.rawdata.image.parser.VisionImageContentParser;
+import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeFactory;
+import com.openmemind.ai.memory.server.runtime.MemoryRuntimeManager;
+import com.openmemind.ai.memory.server.service.config.MemoryOptionService;
+import com.openmemind.ai.memory.server.service.config.MemoryOptionsCodec;
+import com.openmemind.ai.memory.server.service.config.ServerRuntimeConfigRepository;
+import com.openmemind.ai.memory.server.support.TestMemory;
 import java.lang.reflect.Proxy;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.audio.transcription.AudioTranscription;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
@@ -84,10 +92,37 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.dao.DuplicateKeyException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 class MemindServerRuntimeConfigurationTest {
+
+    @Test
+    void memoryRuntimeInitializerToleratesConcurrentDefaultConfigInsert() throws Exception {
+        MemoryBuildOptions winner = MemoryBuildOptions.defaults();
+        var codec = new MemoryOptionsCodec(new tools.jackson.databind.ObjectMapper());
+        var repository =
+                new RacingInitialInsertRepository(
+                        MemoryOptionService.CONFIG_KEY, 9, codec.write(winner));
+        var runtimeManager = new MemoryRuntimeManager();
+        var configuration = new MemindServerRuntimeConfiguration();
+        ApplicationRunner initializer =
+                configuration.memoryRuntimeInitializer(
+                        repository,
+                        codec,
+                        runtimeManager,
+                        options ->
+                                new MemoryRuntimeFactory.CreationResult(new TestMemory(), options));
+
+        initializer.run(null);
+
+        assertThat(runtimeManager.currentVersion()).isEqualTo(9);
+        assertThat(runtimeManager.currentHandle().options()).isEqualTo(winner);
+        assertThat(repository.findActive(MemoryOptionService.CONFIG_KEY))
+                .hasValueSatisfying(config -> assertThat(config.getConfigVersion()).isEqualTo(9));
+    }
 
     @Test
     void runtimeFactoryForwardsBubbleTrackerStoreBeanIntoBuiltMemory() {
@@ -634,6 +669,62 @@ class MemindServerRuntimeConfigurationTest {
         public <T> Flux<T> observeFlux(
                 ObservationContext<T> ctx, java.util.function.Supplier<Flux<T>> operation) {
             return operation.get();
+        }
+    }
+
+    private static final class RacingInitialInsertRepository
+            implements ServerRuntimeConfigRepository {
+
+        private final String winnerConfigKey;
+        private final long winnerVersion;
+        private final String winnerConfigJson;
+        private final AtomicBoolean raced = new AtomicBoolean();
+        private ServerRuntimeConfigDO current;
+
+        private RacingInitialInsertRepository(
+                String winnerConfigKey, long winnerVersion, String winnerConfigJson) {
+            this.winnerConfigKey = winnerConfigKey;
+            this.winnerVersion = winnerVersion;
+            this.winnerConfigJson = winnerConfigJson;
+        }
+
+        @Override
+        public Optional<ServerRuntimeConfigDO> findActive(String configKey) {
+            if (current == null || !configKey.equals(current.getConfigKey())) {
+                return Optional.empty();
+            }
+            return Optional.of(copy(current));
+        }
+
+        @Override
+        public void insertInitial(String configKey, long version, String configJson) {
+            if (raced.compareAndSet(false, true)) {
+                current = config(winnerConfigKey, winnerVersion, winnerConfigJson);
+                throw new DuplicateKeyException("simulated concurrent initial insert");
+            }
+            current = config(configKey, version, configJson);
+        }
+
+        @Override
+        public boolean update(String configKey, long expectedVersion, String configJson) {
+            throw new UnsupportedOperationException("not used by this test");
+        }
+
+        private static ServerRuntimeConfigDO config(
+                String configKey, long version, String configJson) {
+            ServerRuntimeConfigDO config = new ServerRuntimeConfigDO();
+            config.setConfigKey(configKey);
+            config.setConfigVersion(version);
+            config.setConfigJson(configJson);
+            return config;
+        }
+
+        private static ServerRuntimeConfigDO copy(ServerRuntimeConfigDO source) {
+            ServerRuntimeConfigDO copy = new ServerRuntimeConfigDO();
+            copy.setConfigKey(source.getConfigKey());
+            copy.setConfigVersion(source.getConfigVersion());
+            copy.setConfigJson(source.getConfigJson());
+            return copy;
         }
     }
 

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/contract/OpenApiDocumentationTest.java
@@ -142,7 +142,7 @@ class OpenApiDocumentationTest {
 
         JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
         writeOpenApiJsonIfRequested(root);
-        assertThat(root.path("paths").size()).isEqualTo(53);
+        assertThat(root.path("paths").size()).isEqualTo(55);
         assertThat(countOperations(root.path("paths"))).isGreaterThanOrEqualTo(40);
         assertThat(tagNames(root.path("tags"))).containsExactly("memory", "admin");
         assertThat(

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/service/config/MemoryOptionServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/service/config/MemoryOptionServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
 import tools.jackson.databind.ObjectMapper;
 
 class MemoryOptionServiceTest {
@@ -67,6 +68,39 @@ class MemoryOptionServiceTest {
                         "memoryThread.lifecycle");
         assertThat(repository.findActive(MemoryOptionService.CONFIG_KEY))
                 .hasValueSatisfying(config -> assertThat(config.getConfigVersion()).isEqualTo(1));
+    }
+
+    @Test
+    void getCurrentToleratesConcurrentInitialInsertRace() {
+        var winner = MemoryBuildOptions.defaults();
+        InMemoryServerRuntimeConfigRepository repository =
+                new RacingInitialInsertRepository(
+                        MemoryOptionService.CONFIG_KEY, 7, codec.write(winner));
+        MemoryRuntimeManager runtimeManager =
+                new MemoryRuntimeManager(
+                        new RuntimeHandle(new TestMemory(), MemoryBuildOptions.defaults(), 1));
+        MemoryOptionService service =
+                new MemoryOptionService(
+                        repository,
+                        projectionMapper,
+                        codec,
+                        runtimeManager,
+                        options ->
+                                new MemoryRuntimeFactory.CreationResult(new TestMemory(), options));
+
+        MemoryOptionsSnapshot snapshot = service.getCurrent();
+
+        assertThat(snapshot.version()).isEqualTo(7);
+        assertThat(findValue(snapshot.config(), "retrieval.simple.itemTopK")).isEqualTo(15);
+        assertThat(repository.findActive(MemoryOptionService.CONFIG_KEY))
+                .hasValueSatisfying(config -> assertThat(config.getConfigVersion()).isEqualTo(7));
+        assertThat(
+                        codec.read(
+                                repository
+                                        .findActive(MemoryOptionService.CONFIG_KEY)
+                                        .orElseThrow()
+                                        .getConfigJson()))
+                .isEqualTo(winner);
     }
 
     @Test
@@ -351,6 +385,32 @@ class MemoryOptionServiceTest {
             copy.setUpdatedAt(source.getUpdatedAt());
             copy.setDeleted(source.getDeleted());
             return copy;
+        }
+    }
+
+    private static final class RacingInitialInsertRepository
+            extends InMemoryServerRuntimeConfigRepository {
+
+        private final String winnerConfigKey;
+        private final long winnerVersion;
+        private final String winnerConfigJson;
+        private boolean raced;
+
+        private RacingInitialInsertRepository(
+                String winnerConfigKey, long winnerVersion, String winnerConfigJson) {
+            this.winnerConfigKey = winnerConfigKey;
+            this.winnerVersion = winnerVersion;
+            this.winnerConfigJson = winnerConfigJson;
+        }
+
+        @Override
+        public void insertInitial(String configKey, long version, String configJson) {
+            if (!raced) {
+                raced = true;
+                super.insertInitial(winnerConfigKey, winnerVersion, winnerConfigJson);
+                throw new DuplicateKeyException("simulated concurrent initial insert");
+            }
+            super.insertInitial(configKey, version, configJson);
         }
     }
 

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/service/settings/UiPreferenceServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/service/settings/UiPreferenceServiceTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.service.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
+import com.openmemind.ai.memory.server.domain.settings.UiPreferences;
+import com.openmemind.ai.memory.server.service.config.ServerRuntimeConfigRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+class UiPreferenceServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void getToleratesConcurrentInitialInsertRace() throws Exception {
+        UiPreferences winner = new UiPreferences("30d", "grid", "dark", false, true);
+        RacingInitialInsertRepository repository =
+                new RacingInitialInsertRepository(UiPreferenceService.CONFIG_KEY, 4, write(winner));
+        UiPreferenceService service = new UiPreferenceService(repository, objectMapper);
+
+        UiPreferences preferences = service.get();
+
+        assertThat(preferences).isEqualTo(winner);
+        assertThat(repository.findActive(UiPreferenceService.CONFIG_KEY))
+                .hasValueSatisfying(config -> assertThat(config.getConfigVersion()).isEqualTo(4));
+    }
+
+    @Test
+    void updateAppliesRequestedPreferencesAfterConcurrentInitialInsertRace() throws Exception {
+        UiPreferences winner = new UiPreferences("90d", "table", "system", true, false);
+        UiPreferences requested = new UiPreferences("30d", "grid", "dark", false, true);
+        RacingInitialInsertRepository repository =
+                new RacingInitialInsertRepository(UiPreferenceService.CONFIG_KEY, 3, write(winner));
+        UiPreferenceService service = new UiPreferenceService(repository, objectMapper);
+
+        UiPreferences preferences = service.update(requested);
+
+        assertThat(preferences).isEqualTo(requested);
+        assertThat(repository.findActive(UiPreferenceService.CONFIG_KEY))
+                .hasValueSatisfying(
+                        config -> {
+                            assertThat(config.getConfigVersion()).isEqualTo(4);
+                            assertThat(read(config.getConfigJson())).isEqualTo(requested);
+                        });
+    }
+
+    private UiPreferences read(String json) throws JacksonException {
+        return objectMapper.readValue(json, UiPreferences.class);
+    }
+
+    private String write(UiPreferences preferences) throws JacksonException {
+        return objectMapper.writeValueAsString(preferences);
+    }
+
+    private static final class RacingInitialInsertRepository
+            implements ServerRuntimeConfigRepository {
+
+        private final String winnerConfigKey;
+        private final long winnerVersion;
+        private final String winnerConfigJson;
+        private boolean raced;
+        private ServerRuntimeConfigDO current;
+
+        private RacingInitialInsertRepository(
+                String winnerConfigKey, long winnerVersion, String winnerConfigJson) {
+            this.winnerConfigKey = winnerConfigKey;
+            this.winnerVersion = winnerVersion;
+            this.winnerConfigJson = winnerConfigJson;
+        }
+
+        @Override
+        public Optional<ServerRuntimeConfigDO> findActive(String configKey) {
+            if (current == null || !configKey.equals(current.getConfigKey())) {
+                return Optional.empty();
+            }
+            return Optional.of(copy(current));
+        }
+
+        @Override
+        public void insertInitial(String configKey, long version, String configJson) {
+            if (!raced) {
+                raced = true;
+                current = config(winnerConfigKey, winnerVersion, winnerConfigJson);
+                throw new DuplicateKeyException("simulated concurrent initial insert");
+            }
+            current = config(configKey, version, configJson);
+        }
+
+        @Override
+        public boolean update(String configKey, long expectedVersion, String configJson) {
+            if (current == null
+                    || !configKey.equals(current.getConfigKey())
+                    || !Long.valueOf(expectedVersion).equals(current.getConfigVersion())) {
+                return false;
+            }
+            current.setConfigVersion(expectedVersion + 1);
+            current.setConfigJson(configJson);
+            return true;
+        }
+
+        private static ServerRuntimeConfigDO config(
+                String configKey, long version, String configJson) {
+            ServerRuntimeConfigDO config = new ServerRuntimeConfigDO();
+            config.setConfigKey(configKey);
+            config.setConfigVersion(version);
+            config.setConfigJson(configJson);
+            return config;
+        }
+
+        private static ServerRuntimeConfigDO copy(ServerRuntimeConfigDO source) {
+            ServerRuntimeConfigDO copy = new ServerRuntimeConfigDO();
+            copy.setConfigKey(source.getConfigKey());
+            copy.setConfigVersion(source.getConfigVersion());
+            copy.setConfigJson(source.getConfigJson());
+            return copy;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an idempotent read-or-create path for server runtime config initialization.
- Re-read the persisted config after duplicate initial insert races instead of failing startup.
- Apply the race handling to memory options, runtime startup initialization, and UI preferences.
- Update the OpenAPI path count assertion to match the current documented API surface.

## Testing
- `mvn -pl memind-server -am -Dlicense.skip=true -Dtest=MemoryOptionServiceTest,MemindServerRuntimeConfigurationTest,UiPreferenceServiceTest test`
- `mvn -pl memind-server -am -Dlicense.skip=true -Dtest=OpenApiDocumentationTest test`
- `mvn -pl memind-server -am -Dlicense.skip=true test`
- `git diff --check`

Closes #97.