### PR TITLE
fix: sanitize request ids before logging

### DIFF
--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/RequestIdFilter.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/RequestIdFilter.java
@@ -29,12 +29,13 @@ public class RequestIdFilter extends OncePerRequestFilter {
 
     public static final String HEADER = "X-Request-Id";
     public static final String MDC_KEY = "requestId";
+    private static final int MAX_REQUEST_ID_LENGTH = 64;
 
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String requestId = request.getHeader(HEADER);
+        String requestId = sanitizeRequestId(request.getHeader(HEADER));
         if (!StringUtils.hasText(requestId)) {
             requestId = UUID.randomUUID().toString();
         }
@@ -46,5 +47,19 @@ public class RequestIdFilter extends OncePerRequestFilter {
         } finally {
             MDC.remove(MDC_KEY);
         }
+    }
+
+    public static String sanitizeRequestId(String requestId) {
+        if (!StringUtils.hasText(requestId)) {
+            return null;
+        }
+        StringBuilder sanitized =
+                new StringBuilder(Math.min(requestId.length(), MAX_REQUEST_ID_LENGTH));
+        for (int i = 0; i < requestId.length() && sanitized.length() < MAX_REQUEST_ID_LENGTH; i++) {
+            char value = requestId.charAt(i);
+            sanitized.append(Character.isISOControl(value) ? '_' : value);
+        }
+        String result = sanitized.toString();
+        return StringUtils.hasText(result) ? result : null;
     }
 }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandler.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandler.java
@@ -159,6 +159,7 @@ public class ApiExceptionHandler {
         if (requestId == null || requestId.isBlank()) {
             requestId = request.getHeader(RequestIdFilter.HEADER);
         }
+        requestId = RequestIdFilter.sanitizeRequestId(requestId);
         if (requestId == null || requestId.isBlank()) {
             return "-";
         }

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/RequestIdFilterTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/RequestIdFilterTest.java
@@ -50,6 +50,23 @@ class RequestIdFilterTest {
     }
 
     @Test
+    void sanitizesRequestIdHeaderBeforeEchoingIt() throws Exception {
+        mockMvc.perform(
+                        get("/open/v1/health")
+                                .header(
+                                        RequestIdFilter.HEADER,
+                                        "legit-id\n"
+                                            + "ERROR fake\t"
+                                            + "012345678901234567890123456789012345678901234567890123456789"))
+                .andExpect(status().isOk())
+                .andExpect(
+                        header().string(
+                                        RequestIdFilter.HEADER,
+                                        "legit-id_ERROR"
+                                            + " fake_01234567890123456789012345678901234567890123"));
+    }
+
+    @Test
     void generatesMissingRequestIdHeader() throws Exception {
         mockMvc.perform(get("/open/v1/health"))
                 .andExpect(status().isOk())

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandlerTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/handler/ApiExceptionHandlerTest.java
@@ -155,6 +155,26 @@ class ApiExceptionHandlerTest {
                 .contains("rid-2");
     }
 
+    @Test
+    void exceptionLogsUseSanitizedRequestId(CapturedOutput output) throws Exception {
+        mockMvc.perform(
+                        get("/boom/internal")
+                                .header(
+                                        "X-Request-Id",
+                                        "legit-id\n"
+                                            + "ERROR com.openmemind - Fake error injected\tend"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(
+                        header().string(
+                                        "X-Request-Id",
+                                        "legit-id_ERROR com.openmemind - Fake error injected_end"));
+
+        assertThat(output.getOut())
+                .contains("requestId=legit-id_ERROR com.openmemind - Fake error injected_end")
+                .doesNotContain("legit-id\nERROR com.openmemind - Fake error injected")
+                .doesNotContain("Fake error injected\tend");
+    }
+
     @RestController
     private static final class ThrowingController {
 


### PR DESCRIPTION
## Summary
- Normalize incoming `X-Request-Id` values before storing them in MDC or echoing them in responses.
- Replace control characters with underscores and cap client-provided request IDs at 64 characters.
- Reuse the same sanitizer in `ApiExceptionHandler` fallback request-id resolution.
- Add regression coverage for response-header sanitization and exception-log request IDs.

## Testing
- `mvn -pl memind-server -am -Dlicense.skip=true -Dtest=RequestIdFilterTest,ApiExceptionHandlerTest test`
- `mvn -pl memind-server -am -Dlicense.skip=true test`
- `git diff --check`

Closes #99.