### PR TITLE
fix: harden HTTP resource fetching against SSRF

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/exception/ResourceFetchAccessDeniedException.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/exception/ResourceFetchAccessDeniedException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.exception;
+
+/**
+ * Raised when a remote resource fetch is denied by the configured access policy.
+ */
+public final class ResourceFetchAccessDeniedException extends IllegalArgumentException {
+
+    public ResourceFetchAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/HttpResourceFetchPolicy.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/HttpResourceFetchPolicy.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.resource;
+
+import com.openmemind.ai.memory.core.exception.ResourceFetchAccessDeniedException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Security policy applied before opening remote HTTP resources.
+ */
+public final class HttpResourceFetchPolicy {
+
+    private static final int DEFAULT_MAX_REDIRECTS = 5;
+    private static final byte[] IPV6_NAT64_WELL_KNOWN_PREFIX =
+            new byte[] {0x00, 0x64, (byte) 0xff, (byte) 0x9b, 0, 0, 0, 0, 0, 0, 0, 0};
+    private static final byte[] IPV6_NAT64_LOCAL_USE_PREFIX =
+            new byte[] {0x00, 0x64, (byte) 0xff, (byte) 0x9b, 0x00, 0x01};
+
+    private final boolean allowPrivateNetwork;
+    private final int maxRedirects;
+
+    private HttpResourceFetchPolicy(Builder builder) {
+        this.allowPrivateNetwork = builder.allowPrivateNetwork;
+        this.maxRedirects = builder.maxRedirects;
+    }
+
+    public static HttpResourceFetchPolicy secureDefaults() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Whether RFC1918 IPv4 ranges and IPv6 unique-local/site-local addresses are allowed.
+     *
+     * <p>This does not allow loopback, any-local, link-local, multicast, or other reserved
+     * addresses.
+     */
+    public boolean allowPrivateNetwork() {
+        return allowPrivateNetwork;
+    }
+
+    /**
+     * Maximum number of redirects followed manually after validating each redirect target.
+     */
+    public int maxRedirects() {
+        return maxRedirects;
+    }
+
+    void validateUri(URI uri) {
+        Objects.requireNonNull(uri, "uri is required");
+        String scheme = uri.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            deny(uri, "scheme must be http or https");
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank()) {
+            deny(uri, "host is required");
+        }
+        if (uri.getUserInfo() != null) {
+            deny(uri, "userinfo is not allowed");
+        }
+    }
+
+    void validateResolvedAddresses(URI uri, List<InetAddress> addresses) {
+        Objects.requireNonNull(addresses, "addresses is required");
+        if (addresses.isEmpty()) {
+            deny(uri, "host did not resolve to any address");
+        }
+        for (InetAddress address : addresses) {
+            if (!isAddressAllowed(address)) {
+                deny(uri, "resolved address is not allowed");
+            }
+        }
+    }
+
+    static String describe(URI uri) {
+        if (uri == null) {
+            return "<unknown>";
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append("scheme=").append(uri.getScheme() == null ? "<none>" : uri.getScheme());
+        builder.append(", host=").append(uri.getHost() == null ? "<none>" : uri.getHost());
+        if (uri.getPort() >= 0) {
+            builder.append(", port=").append(uri.getPort());
+        }
+        return builder.toString();
+    }
+
+    private boolean isAddressAllowed(InetAddress address) {
+        Objects.requireNonNull(address, "address is required");
+        if (address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isMulticastAddress()) {
+            return false;
+        }
+        if (address instanceof Inet4Address) {
+            return isIpv4AddressAllowed(address.getAddress());
+        }
+        if (address instanceof Inet6Address) {
+            return isIpv6AddressAllowed(address.getAddress(), address.isSiteLocalAddress());
+        }
+        return false;
+    }
+
+    private boolean isIpv4AddressAllowed(byte[] bytes) {
+        int first = unsigned(bytes[0]);
+        int second = unsigned(bytes[1]);
+        int third = unsigned(bytes[2]);
+        if (isPrivateIpv4(first, second)) {
+            return allowPrivateNetwork;
+        }
+        return !isReservedIpv4(first, second, third);
+    }
+
+    private boolean isIpv6AddressAllowed(byte[] bytes, boolean siteLocal) {
+        if (isIpv4MappedIpv6(bytes) || isIpv4CompatibleIpv6(bytes)) {
+            return isIpv4AddressAllowed(new byte[] {bytes[12], bytes[13], bytes[14], bytes[15]});
+        }
+        if (matchesPrefix(bytes, IPV6_NAT64_WELL_KNOWN_PREFIX, 96)) {
+            return isIpv4AddressAllowed(new byte[] {bytes[12], bytes[13], bytes[14], bytes[15]});
+        }
+        if (isUniqueLocalIpv6(bytes) || siteLocal) {
+            return allowPrivateNetwork;
+        }
+        return !isBlockedSpecialUseIpv6(bytes);
+    }
+
+    private boolean isPrivateIpv4(int first, int second) {
+        return first == 10
+                || (first == 172 && second >= 16 && second <= 31)
+                || (first == 192 && second == 168);
+    }
+
+    private boolean isReservedIpv4(int first, int second, int third) {
+        if (first == 0 || first == 127 || first >= 224) {
+            return true;
+        }
+        if (first == 100 && second >= 64 && second <= 127) {
+            return true;
+        }
+        if (first == 169 && second == 254) {
+            return true;
+        }
+        if (first == 192 && second == 0 && third == 0) {
+            return true;
+        }
+        if (first == 192 && second == 0 && third == 2) {
+            return true;
+        }
+        if (first == 192 && second == 88 && third == 99) {
+            return true;
+        }
+        if (first == 198 && (second == 18 || second == 19)) {
+            return true;
+        }
+        if (first == 198 && second == 51 && third == 100) {
+            return true;
+        }
+        return first == 203 && second == 0 && third == 113;
+    }
+
+    private boolean isIpv4MappedIpv6(byte[] bytes) {
+        for (int index = 0; index < 10; index++) {
+            if (bytes[index] != 0) {
+                return false;
+            }
+        }
+        return bytes[10] == (byte) 0xff && bytes[11] == (byte) 0xff;
+    }
+
+    private boolean isIpv4CompatibleIpv6(byte[] bytes) {
+        for (int index = 0; index < 12; index++) {
+            if (bytes[index] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isUniqueLocalIpv6(byte[] bytes) {
+        return (bytes[0] & 0xfe) == 0xfc;
+    }
+
+    private boolean isBlockedSpecialUseIpv6(byte[] bytes) {
+        return matchesPrefix(bytes, IPV6_NAT64_LOCAL_USE_PREFIX, 48)
+                || matchesPrefix(bytes, new byte[] {0x01, 0x00, 0, 0, 0, 0, 0, 0}, 64)
+                || matchesPrefix(bytes, new byte[] {0x01, 0x00, 0, 0, 0, 0, 0, 1}, 64)
+                || matchesPrefix(bytes, new byte[] {0x20, 0x01, 0, 0}, 32)
+                || matchesPrefix(bytes, new byte[] {0x20, 0x01, 0, 0x02}, 48)
+                || matchesPrefix(bytes, new byte[] {0x20, 0x01, 0, 0x10}, 28)
+                || matchesPrefix(bytes, new byte[] {0x20, 0x01, 0x0d, (byte) 0xb8}, 32)
+                || matchesPrefix(bytes, new byte[] {0x20, 0x02}, 16)
+                || matchesPrefix(bytes, new byte[] {0x3f, (byte) 0xff, 0}, 20)
+                || matchesPrefix(bytes, new byte[] {0x5f, 0x00}, 16);
+    }
+
+    private boolean matchesPrefix(byte[] bytes, byte[] prefix, int prefixLength) {
+        int fullBytes = prefixLength / 8;
+        for (int index = 0; index < fullBytes; index++) {
+            if (bytes[index] != prefix[index]) {
+                return false;
+            }
+        }
+        int remainingBits = prefixLength % 8;
+        if (remainingBits == 0) {
+            return true;
+        }
+        int mask = 0xff << (8 - remainingBits);
+        return (bytes[fullBytes] & mask) == (prefix[fullBytes] & mask);
+    }
+
+    private int unsigned(byte value) {
+        return value & 0xff;
+    }
+
+    private void deny(URI uri, String reason) {
+        throw new ResourceFetchAccessDeniedException(
+                "Resource fetch denied: " + reason + ", target=" + describe(uri));
+    }
+
+    public static final class Builder {
+
+        private boolean allowPrivateNetwork;
+        private int maxRedirects = DEFAULT_MAX_REDIRECTS;
+
+        private Builder() {}
+
+        /**
+         * Allow RFC1918 IPv4 ranges and IPv6 unique-local/site-local addresses.
+         */
+        public Builder allowPrivateNetwork(boolean allowPrivateNetwork) {
+            this.allowPrivateNetwork = allowPrivateNetwork;
+            return this;
+        }
+
+        /**
+         * Set the maximum redirect count. Use zero to reject redirects.
+         */
+        public Builder maxRedirects(int maxRedirects) {
+            if (maxRedirects < 0) {
+                throw new IllegalArgumentException("maxRedirects must not be negative");
+            }
+            this.maxRedirects = maxRedirects;
+            return this;
+        }
+
+        public HttpResourceFetchPolicy build() {
+            return new HttpResourceFetchPolicy(this);
+        }
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/HttpResourceFetcher.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/HttpResourceFetcher.java
@@ -13,9 +13,11 @@
  */
 package com.openmemind.ai.memory.core.resource;
 
+import com.openmemind.ai.memory.core.exception.ResourceFetchAccessDeniedException;
 import com.openmemind.ai.memory.core.exception.SourceTooLargeException;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLConnection;
 import java.net.URLDecoder;
@@ -27,11 +29,17 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Default {@link ResourceFetcher} backed by JDK {@link HttpClient}.
+ *
+ * <p>The default policy is secure-by-default for untrusted URLs: it validates resolved addresses
+ * before sending outbound requests and follows redirects manually so each redirect target is
+ * revalidated.
  */
 public class HttpResourceFetcher implements ResourceFetcher {
 
@@ -42,55 +50,155 @@ public class HttpResourceFetcher implements ResourceFetcher {
 
     private final HttpClient httpClient;
     private final Duration requestTimeout;
+    private final HttpResourceFetchPolicy fetchPolicy;
+    private final ResourceAddressResolver addressResolver;
 
     public HttpResourceFetcher() {
-        this(
-                HttpClient.newBuilder()
-                        .followRedirects(HttpClient.Redirect.NORMAL)
-                        .connectTimeout(DEFAULT_CONNECT_TIMEOUT)
-                        .build(),
-                DEFAULT_REQUEST_TIMEOUT);
+        this(defaultHttpClient(), DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    public HttpResourceFetcher(HttpResourceFetchPolicy fetchPolicy) {
+        this(defaultHttpClient(), DEFAULT_REQUEST_TIMEOUT, fetchPolicy);
     }
 
     public HttpResourceFetcher(HttpClient httpClient) {
         this(httpClient, DEFAULT_REQUEST_TIMEOUT);
     }
 
+    public HttpResourceFetcher(HttpClient httpClient, HttpResourceFetchPolicy fetchPolicy) {
+        this(httpClient, DEFAULT_REQUEST_TIMEOUT, fetchPolicy);
+    }
+
     public HttpResourceFetcher(HttpClient httpClient, Duration requestTimeout) {
+        this(httpClient, requestTimeout, HttpResourceFetchPolicy.secureDefaults());
+    }
+
+    public HttpResourceFetcher(
+            HttpClient httpClient, Duration requestTimeout, HttpResourceFetchPolicy fetchPolicy) {
+        this(httpClient, requestTimeout, fetchPolicy, ResourceAddressResolver.system());
+    }
+
+    HttpResourceFetcher(
+            HttpClient httpClient,
+            Duration requestTimeout,
+            HttpResourceFetchPolicy fetchPolicy,
+            ResourceAddressResolver addressResolver) {
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient is required");
+        if (this.httpClient.followRedirects() != HttpClient.Redirect.NEVER) {
+            throw new IllegalArgumentException(
+                    "httpClient must not follow redirects automatically");
+        }
         this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout is required");
+        this.fetchPolicy = Objects.requireNonNull(fetchPolicy, "fetchPolicy is required");
+        this.addressResolver =
+                Objects.requireNonNull(addressResolver, "addressResolver is required");
     }
 
     @Override
     public Mono<FetchSession> open(ResourceFetchRequest request) {
         Objects.requireNonNull(request, "request is required");
+        URI sourceUri = URI.create(request.sourceUrl());
+        return sendWithRedirects(request, sourceUri, 0)
+                .map(response -> toFetchSession(request, response.finalUri(), response.response()));
+    }
 
+    private Mono<ValidatedHttpResponse> sendWithRedirects(
+            ResourceFetchRequest request, URI uri, int redirectCount) {
+        return validateTarget(uri)
+                .then(Mono.defer(() -> Mono.fromCompletionStage(send(uri))))
+                .flatMap(
+                        response -> {
+                            URI responseUri = response.uri() == null ? uri : response.uri();
+                            if (!isRedirect(response.statusCode())) {
+                                return validateTarget(responseUri)
+                                        .thenReturn(
+                                                new ValidatedHttpResponse(responseUri, response))
+                                        .doOnError(error -> closeBody(response));
+                            }
+                            if (redirectCount >= fetchPolicy.maxRedirects()) {
+                                closeBody(response);
+                                return Mono.error(
+                                        new IllegalStateException(
+                                                "Resource download failed: too many redirects,"
+                                                        + " source="
+                                                        + HttpResourceFetchPolicy.describe(
+                                                                URI.create(request.sourceUrl()))));
+                            }
+                            URI nextUri;
+                            try {
+                                nextUri = resolveRedirectUri(responseUri, response);
+                            } finally {
+                                closeBody(response);
+                            }
+                            return sendWithRedirects(request, nextUri, redirectCount + 1);
+                        });
+    }
+
+    private Mono<Void> validateTarget(URI uri) {
+        return Mono.fromCallable(
+                        () -> {
+                            fetchPolicy.validateUri(uri);
+                            List<InetAddress> addresses = addressResolver.resolve(uri.getHost());
+                            fetchPolicy.validateResolvedAddresses(uri, addresses);
+                            return true;
+                        })
+                .subscribeOn(Schedulers.boundedElastic())
+                .then();
+    }
+
+    private CompletionStage<HttpResponse<InputStream>> send(URI uri) {
         HttpRequest httpRequest =
                 HttpRequest.newBuilder()
-                        .uri(URI.create(request.sourceUrl()))
+                        .uri(uri)
                         .header("Accept", "*/*")
                         .timeout(requestTimeout)
                         .GET()
                         .build();
-
-        return Mono.fromFuture(
-                        httpClient.sendAsync(
-                                httpRequest, HttpResponse.BodyHandlers.ofInputStream()))
-                .map(response -> toFetchSession(request, response));
+        return httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream());
     }
 
+    private URI resolveRedirectUri(URI currentUri, HttpResponse<InputStream> response) {
+        String location =
+                response.headers()
+                        .firstValue("Location")
+                        .filter(value -> !value.isBlank())
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Resource download failed: redirect missing"
+                                                        + " Location"));
+        URI redirectUri = currentUri.resolve(location);
+        if ("https".equalsIgnoreCase(currentUri.getScheme())
+                && "http".equalsIgnoreCase(redirectUri.getScheme())) {
+            throw new ResourceFetchAccessDeniedException(
+                    "Resource fetch denied: https to http redirect is not allowed, target="
+                            + HttpResourceFetchPolicy.describe(redirectUri));
+        }
+        return redirectUri;
+    }
+
+    private boolean isRedirect(int statusCode) {
+        return statusCode == 301
+                || statusCode == 302
+                || statusCode == 303
+                || statusCode == 307
+                || statusCode == 308;
+    }
+
+    private record ValidatedHttpResponse(URI finalUri, HttpResponse<InputStream> response) {}
+
     private FetchSession toFetchSession(
-            ResourceFetchRequest request, HttpResponse<InputStream> response) {
+            ResourceFetchRequest request, URI finalUri, HttpResponse<InputStream> response) {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            closeBody(response);
             throw new IllegalStateException(
                     "Resource download failed: status="
                             + response.statusCode()
-                            + ", sourceUrl="
-                            + request.sourceUrl());
+                            + ", source="
+                            + HttpResourceFetchPolicy.describe(URI.create(request.sourceUrl())));
         }
-
         String sourceUrl = request.sourceUrl();
-        String finalUrl = response.uri() == null ? sourceUrl : response.uri().toString();
+        String finalUrl = finalUri == null ? sourceUrl : finalUri.toString();
         String resolvedFileName = resolveFileName(sourceUrl, request.requestedFileName(), response);
         String resolvedMimeType =
                 resolveMimeType(resolvedFileName, request.requestedMimeType(), response);
@@ -164,6 +272,25 @@ public class HttpResourceFetcher implements ResourceFetcher {
                         });
             }
         };
+    }
+
+    private static HttpClient defaultHttpClient() {
+        return HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(DEFAULT_CONNECT_TIMEOUT)
+                .build();
+    }
+
+    private void closeBody(HttpResponse<InputStream> response) {
+        InputStream body = response.body();
+        if (body == null) {
+            return;
+        }
+        try {
+            body.close();
+        } catch (Exception ignored) {
+            // Closing a discarded response body is best effort.
+        }
     }
 
     private String resolveFileName(

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/ResourceAddressResolver.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/ResourceAddressResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.resource;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+@FunctionalInterface
+interface ResourceAddressResolver {
+
+    List<InetAddress> resolve(String host) throws UnknownHostException;
+
+    static ResourceAddressResolver system() {
+        return host -> List.of(InetAddress.getAllByName(host));
+    }
+}

--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/ResourceFetchRequest.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/resource/ResourceFetchRequest.java
@@ -18,6 +18,9 @@ import java.util.Objects;
 
 /**
  * Input to a downloader before opening the remote resource.
+ *
+ * <p>{@code sourceUrl} is treated as untrusted input. The default HTTP fetcher validates the
+ * scheme, host, resolved addresses, and redirect targets before sending outbound requests.
  */
 public record ResourceFetchRequest(
         MemoryId memoryId, String sourceUrl, String requestedFileName, String requestedMimeType) {

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/resource/HttpResourceFetchPolicyTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/resource/HttpResourceFetchPolicyTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.core.resource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HttpResourceFetchPolicyTest {
+
+    private static final URI TARGET = URI.create("https://documents.example/report.pdf");
+
+    @Test
+    void validateUriShouldRejectMissingHostAndUserInfo() {
+        var policy = HttpResourceFetchPolicy.secureDefaults();
+
+        assertThatThrownBy(() -> policy.validateUri(URI.create("https:///report.pdf")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host is required");
+        assertThatThrownBy(() -> policy.validateUri(URI.create("https://user@example.com/report")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("userinfo is not allowed");
+    }
+
+    @Test
+    void validateResolvedAddressesShouldAllowGlobalAddresses() {
+        var policy = HttpResourceFetchPolicy.secureDefaults();
+
+        validate(policy, "93.184.216.34");
+        validate(policy, "2606:2800:220:1:248:1893:25c8:1946");
+    }
+
+    @Test
+    void validateResolvedAddressesShouldRejectDocumentationRanges() {
+        var policy = HttpResourceFetchPolicy.secureDefaults();
+
+        assertThatThrownBy(() -> validate(policy, "203.0.113.1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "2001:db8::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "3fff::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+    }
+
+    @Test
+    void validateResolvedAddressesShouldRejectIpv6TransitionAndSpecialUseRanges() {
+        var policy = HttpResourceFetchPolicy.secureDefaults();
+
+        assertThatThrownBy(() -> validate(policy, "::10.1.2.3"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "64:ff9b::a9fe:a9fe"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "64:ff9b:1::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "2001::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "2002::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "100::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(policy, "5f00::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+    }
+
+    @Test
+    void validateResolvedAddressesShouldAllowPrivateNetworkOnlyForExplicitRanges() {
+        var defaultPolicy = HttpResourceFetchPolicy.secureDefaults();
+        var privatePolicy = HttpResourceFetchPolicy.builder().allowPrivateNetwork(true).build();
+
+        assertThatThrownBy(() -> validate(defaultPolicy, "fc00::1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+
+        validate(privatePolicy, "10.1.2.3");
+        validate(privatePolicy, "fc00::1");
+
+        assertThatThrownBy(() -> validate(privatePolicy, "100.64.1.1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(privatePolicy, "169.254.169.254"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThatThrownBy(() -> validate(privatePolicy, "192.88.99.2"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+    }
+
+    @Test
+    void builderShouldRejectNegativeRedirectLimit() {
+        assertThatThrownBy(() -> HttpResourceFetchPolicy.builder().maxRedirects(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxRedirects");
+    }
+
+    private static void validate(HttpResourceFetchPolicy policy, String address) {
+        policy.validateResolvedAddresses(TARGET, List.of(address(address)));
+    }
+
+    private static InetAddress address(String value) {
+        try {
+            return InetAddress.getByName(value);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Invalid test address: " + value, ex);
+        }
+    }
+}

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/resource/HttpResourceFetcherTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/resource/HttpResourceFetcherTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.CookieHandler;
+import java.net.InetAddress;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -30,9 +31,12 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.net.ssl.SSLContext;
@@ -52,7 +56,7 @@ class HttpResourceFetcherTest {
                         Map.of("Content-Type", List.of("application/pdf")));
 
         var session =
-                new HttpResourceFetcher(new StubHttpClient(response))
+                fetcher(new StubHttpClient(response))
                         .open(
                                 new ResourceFetchRequest(
                                         DefaultMemoryId.of("user-1", "agent-1"),
@@ -76,27 +80,182 @@ class HttpResourceFetcherTest {
     }
 
     @Test
-    void openShouldInferFileNameFromRedirectTarget() {
-        var response =
-                new StubHttpResponse(
-                        200,
-                        URI.create("https://example.com/downloads/final.pdf"),
-                        "payload".getBytes(StandardCharsets.UTF_8),
-                        Map.of("Content-Type", List.of("application/pdf")));
+    void openShouldRejectLoopbackAddressBeforeSendingRequest() {
+        var client =
+                new StubHttpClient(
+                        okResponse(
+                                URI.create("http://127.0.0.1/admin"),
+                                "secret".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("text/plain"))));
+
+        assertThatThrownBy(() -> fetcher(client).open(request("http://127.0.0.1/admin")).block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThat(client.sentRequests()).isEmpty();
+    }
+
+    @Test
+    void openShouldRejectHostThatResolvesToPrivateAddress() throws Exception {
+        var client =
+                new StubHttpClient(
+                        okResponse(
+                                URI.create("https://documents.example/report.pdf"),
+                                "secret".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("application/pdf"))));
+
+        assertThatThrownBy(
+                        () ->
+                                fetcher(client, host -> List.of(address("10.1.2.3")))
+                                        .open(request("https://documents.example/report.pdf"))
+                                        .block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThat(client.sentRequests()).isEmpty();
+    }
+
+    @Test
+    void openShouldRejectHostWhenAnyResolvedAddressIsPrivate() throws Exception {
+        var client =
+                new StubHttpClient(
+                        okResponse(
+                                URI.create("https://documents.example/report.pdf"),
+                                "secret".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("application/pdf"))));
+
+        assertThatThrownBy(
+                        () ->
+                                fetcher(
+                                                client,
+                                                host ->
+                                                        List.of(
+                                                                address("93.184.216.34"),
+                                                                address("192.168.1.10")))
+                                        .open(request("https://documents.example/report.pdf"))
+                                        .block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThat(client.sentRequests()).isEmpty();
+    }
+
+    @Test
+    void openShouldAllowPrivateNetworkWhenExplicitlyConfigured() throws Exception {
+        var client =
+                new StubHttpClient(
+                        okResponse(
+                                URI.create("https://documents.example/report.pdf"),
+                                "payload".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("application/pdf"))));
+        var policy = HttpResourceFetchPolicy.builder().allowPrivateNetwork(true).build();
 
         var session =
-                new HttpResourceFetcher(new StubHttpClient(response))
-                        .open(
-                                new ResourceFetchRequest(
-                                        DefaultMemoryId.of("user-1", "agent-1"),
-                                        "https://example.com/redirect",
-                                        null,
-                                        null))
+                fetcher(client, policy, host -> List.of(address("10.1.2.3")))
+                        .open(request("https://documents.example/report.pdf"))
                         .block();
+
+        assertThat(session).isNotNull();
+        assertThat(client.sentRequests())
+                .extracting(request -> request.uri().toString())
+                .containsExactly("https://documents.example/report.pdf");
+    }
+
+    @Test
+    void openShouldRejectLinkLocalEvenWhenPrivateNetworkIsAllowed() throws Exception {
+        var client =
+                new StubHttpClient(
+                        okResponse(
+                                URI.create("https://metadata.example/latest"),
+                                "secret".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("text/plain"))));
+        var policy = HttpResourceFetchPolicy.builder().allowPrivateNetwork(true).build();
+
+        assertThatThrownBy(
+                        () ->
+                                fetcher(client, policy, host -> List.of(address("169.254.169.254")))
+                                        .open(request("https://metadata.example/latest"))
+                                        .block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThat(client.sentRequests()).isEmpty();
+    }
+
+    @Test
+    void openShouldRejectRedirectToBlockedAddress() {
+        var client =
+                new StubHttpClient(
+                        new StubHttpResponse(
+                                302,
+                                URI.create("https://documents.example/redirect"),
+                                new byte[0],
+                                Map.of(
+                                        "Location",
+                                        List.of("http://169.254.169.254/latest/meta-data/"))),
+                        okResponse(
+                                URI.create("http://169.254.169.254/latest/meta-data/"),
+                                "secret".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("text/plain"))));
+
+        assertThatThrownBy(
+                        () ->
+                                fetcher(client)
+                                        .open(request("https://documents.example/redirect"))
+                                        .block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("denied");
+        assertThat(client.sentRequests())
+                .extracting(request -> request.uri().toString())
+                .containsExactly("https://documents.example/redirect");
+    }
+
+    @Test
+    void openShouldRejectHttpsToHttpRedirectDowngrade() {
+        var client =
+                new StubHttpClient(
+                        new StubHttpResponse(
+                                302,
+                                URI.create("https://example.com/redirect"),
+                                new byte[0],
+                                Map.of(
+                                        "Location",
+                                        List.of("http://example.com/downloads/final.pdf"))),
+                        okResponse(
+                                URI.create("http://example.com/downloads/final.pdf"),
+                                "payload".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("application/pdf"))));
+
+        assertThatThrownBy(
+                        () -> fetcher(client).open(request("https://example.com/redirect")).block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("https to http redirect");
+        assertThat(client.sentRequests())
+                .extracting(request -> request.uri().toString())
+                .containsExactly("https://example.com/redirect");
+    }
+
+    @Test
+    void openShouldInferFileNameFromRedirectTarget() {
+        var client =
+                new StubHttpClient(
+                        new StubHttpResponse(
+                                302,
+                                URI.create("https://example.com/redirect"),
+                                new byte[0],
+                                Map.of(
+                                        "Location",
+                                        List.of("https://example.com/downloads/final.pdf"))),
+                        okResponse(
+                                URI.create("https://example.com/downloads/final.pdf"),
+                                "payload".getBytes(StandardCharsets.UTF_8),
+                                Map.of("Content-Type", List.of("application/pdf"))));
+
+        var session = fetcher(client).open(request("https://example.com/redirect")).block();
 
         assertThat(session).isNotNull();
         assertThat(session.resolvedFileName()).isEqualTo("final.pdf");
         assertThat(session.finalUrl()).isEqualTo("https://example.com/downloads/final.pdf");
+        assertThat(client.sentRequests())
+                .extracting(request -> request.uri().toString())
+                .containsExactly(
+                        "https://example.com/redirect", "https://example.com/downloads/final.pdf");
     }
 
     @Test
@@ -109,7 +268,7 @@ class HttpResourceFetcherTest {
                         Map.of("Content-Type", List.of("text/plain")));
 
         var session =
-                new HttpResourceFetcher(new StubHttpClient(response))
+                fetcher(new StubHttpClient(response))
                         .open(
                                 new ResourceFetchRequest(
                                         DefaultMemoryId.of("user-1", "agent-1"),
@@ -135,7 +294,7 @@ class HttpResourceFetcherTest {
                                 "Content-Length", List.of("4096")));
 
         var session =
-                new HttpResourceFetcher(new StubHttpClient(response))
+                fetcher(new StubHttpClient(response))
                         .open(
                                 new ResourceFetchRequest(
                                         DefaultMemoryId.of("user-1", "agent-1"),
@@ -151,6 +310,13 @@ class HttpResourceFetcherTest {
     }
 
     @Test
+    void constructorShouldRejectClientsThatFollowRedirectsAutomatically() {
+        assertThatThrownBy(() -> new HttpResourceFetcher(new RedirectingStubHttpClient()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not follow redirects");
+    }
+
+    @Test
     void openShouldFailWhenStatusIsNotSuccessful() {
         var response =
                 new StubHttpResponse(
@@ -161,7 +327,7 @@ class HttpResourceFetcherTest {
 
         assertThatThrownBy(
                         () ->
-                                new HttpResourceFetcher(new StubHttpClient(response))
+                                fetcher(new StubHttpClient(response))
                                         .open(
                                                 new ResourceFetchRequest(
                                                         DefaultMemoryId.of("user-1", "agent-1"),
@@ -173,12 +339,56 @@ class HttpResourceFetcherTest {
                 .hasMessageContaining("status=404");
     }
 
-    private static final class StubHttpClient extends HttpClient {
+    private static HttpResourceFetcher fetcher(StubHttpClient client) {
+        return fetcher(client, HttpResourceFetchPolicy.secureDefaults(), publicResolver());
+    }
 
-        private final HttpResponse<InputStream> response;
+    private static HttpResourceFetcher fetcher(
+            StubHttpClient client, ResourceAddressResolver resolver) {
+        return fetcher(client, HttpResourceFetchPolicy.secureDefaults(), resolver);
+    }
 
-        private StubHttpClient(HttpResponse<InputStream> response) {
-            this.response = response;
+    private static HttpResourceFetcher fetcher(
+            StubHttpClient client,
+            HttpResourceFetchPolicy policy,
+            ResourceAddressResolver resolver) {
+        return new HttpResourceFetcher(client, Duration.ofSeconds(30), policy, resolver);
+    }
+
+    private static ResourceAddressResolver publicResolver() {
+        return host -> List.of(address(host.matches("[0-9.]+") ? host : "93.184.216.34"));
+    }
+
+    private static InetAddress address(String address) {
+        try {
+            return InetAddress.getByName(address);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Invalid test address: " + address, ex);
+        }
+    }
+
+    private static ResourceFetchRequest request(String sourceUrl) {
+        return new ResourceFetchRequest(
+                DefaultMemoryId.of("user-1", "agent-1"), sourceUrl, null, null);
+    }
+
+    private static StubHttpResponse okResponse(
+            URI uri, byte[] body, Map<String, List<String>> headers) {
+        return new StubHttpResponse(200, uri, body, headers);
+    }
+
+    private static class StubHttpClient extends HttpClient {
+
+        private final Queue<HttpResponse<InputStream>> responses;
+        private final List<HttpRequest> sentRequests = new ArrayList<>();
+
+        @SafeVarargs
+        private StubHttpClient(HttpResponse<InputStream>... responses) {
+            this.responses = new ArrayDeque<>(List.of(responses));
+        }
+
+        private List<HttpRequest> sentRequests() {
+            return List.copyOf(sentRequests);
         }
 
         @Override
@@ -193,7 +403,7 @@ class HttpResourceFetcherTest {
 
         @Override
         public Redirect followRedirects() {
-            return Redirect.NORMAL;
+            return Redirect.NEVER;
         }
 
         @Override
@@ -236,6 +446,12 @@ class HttpResourceFetcherTest {
         @SuppressWarnings("unchecked")
         public <T> CompletableFuture<HttpResponse<T>> sendAsync(
                 HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            sentRequests.add(request);
+            HttpResponse<InputStream> response = responses.poll();
+            if (response == null) {
+                return CompletableFuture.failedFuture(
+                        new AssertionError("No stubbed response for " + request.uri()));
+            }
             return CompletableFuture.completedFuture((HttpResponse<T>) response);
         }
 
@@ -245,6 +461,18 @@ class HttpResourceFetcherTest {
                 HttpResponse.BodyHandler<T> responseBodyHandler,
                 HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
             return sendAsync(request, responseBodyHandler);
+        }
+    }
+
+    private static final class RedirectingStubHttpClient extends StubHttpClient {
+
+        private RedirectingStubHttpClient() {
+            super();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NORMAL;
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a secure default HTTP resource fetch policy that validates schemes, hosts, userinfo, and resolved addresses before any outbound request.
- Disable automatic `HttpClient` redirects and follow redirects manually so each redirect target is revalidated, with redirect-count enforcement and HTTPS-to-HTTP downgrade rejection.
- Add an explicit private-network opt-in while keeping loopback, link-local, multicast, and special-use ranges blocked, and document `sourceUrl` as untrusted.

Fixes #100

## Compatibility
- Custom `HttpClient` instances passed to `HttpResourceFetcher` must use `HttpClient.Redirect.NEVER`; clients with automatic redirects are rejected so redirect targets can be validated safely.

## Test Plan
- `mvn -pl memind-core -Dtest=HttpResourceFetcherTest,HttpResourceFetchPolicyTest test`
- `mvn -pl memind-core test`
- `mvn -pl memind-core spotless:check checkstyle:check`