### PR TITLE
fix: delete memory items before vector cleanup

### DIFF
--- a/memind-core/src/main/java/com/openmemind/ai/memory/core/DefaultMemory.java
+++ b/memind-core/src/main/java/com/openmemind/ai/memory/core/DefaultMemory.java
@@ -450,31 +450,54 @@ public class DefaultMemory implements Memory {
 
         return Mono.fromCallable(
                         () -> memoryStore.itemOperations().getItemsByIds(memoryId, requestedIds))
-                .map(
-                        items ->
-                                items.stream()
-                                        .map(MemoryItem::vectorId)
-                                        .filter(Objects::nonNull)
-                                        .distinct()
-                                        .toList())
+                .map(this::collectVectorIds)
                 .flatMap(
                         vectorIds ->
-                                vectorIds.isEmpty()
-                                        ? Mono.<Void>empty()
-                                        : vector.deleteBatch(memoryId, vectorIds))
-                .then(
-                        Mono.fromRunnable(
-                                () ->
-                                        memoryStore
-                                                .threadOperations()
-                                                .markRebuildRequired(memoryId, "item deletion")))
-                .then(
-                        Mono.<Void>fromRunnable(
-                                () ->
-                                        memoryStore
-                                                .itemOperations()
-                                                .deleteItems(memoryId, requestedIds)))
+                                Mono.fromRunnable(
+                                                () ->
+                                                        memoryStore
+                                                                .threadOperations()
+                                                                .markRebuildRequired(
+                                                                        memoryId, "item deletion"))
+                                        .then(
+                                                Mono.<Void>fromRunnable(
+                                                        () ->
+                                                                memoryStore
+                                                                        .itemOperations()
+                                                                        .deleteItems(
+                                                                                memoryId,
+                                                                                requestedIds)))
+                                        .then(
+                                                Mono.defer(
+                                                        () ->
+                                                                cleanupDeletedItemVectors(
+                                                                        memoryId, vectorIds))))
                 .doOnSuccess(ignored -> retriever.onDataChanged(memoryId));
+    }
+
+    private List<String> collectVectorIds(List<MemoryItem> items) {
+        return items.stream()
+                .map(MemoryItem::vectorId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private Mono<Void> cleanupDeletedItemVectors(MemoryId memoryId, List<String> vectorIds) {
+        if (vectorIds.isEmpty()) {
+            return Mono.empty();
+        }
+        return vector.deleteBatch(memoryId, vectorIds)
+                .onErrorResume(
+                        error -> {
+                            log.warn(
+                                    "Vector cleanup failed after item deletion: memoryId={},"
+                                            + " vectorCount={}",
+                                    memoryId.toIdentifier(),
+                                    vectorIds.size(),
+                                    error);
+                            return Mono.empty();
+                        });
     }
 
     @Override

--- a/memind-core/src/test/java/com/openmemind/ai/memory/core/DefaultMemoryTest.java
+++ b/memind-core/src/test/java/com/openmemind/ai/memory/core/DefaultMemoryTest.java
@@ -17,9 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -569,8 +571,8 @@ class DefaultMemoryTest {
     class DeleteApis {
 
         @Test
-        @DisplayName("deleteItems deletes vectors before store rows and invalidates retriever")
-        void deleteItemsDeletesVectorsThenStoreRowsAndInvalidatesRetriever() {
+        @DisplayName("deleteItems deletes store rows before vectors and invalidates retriever")
+        void deleteItemsDeletesStoreRowsBeforeVectorsAndInvalidatesRetriever() {
             var itemIds = List.of(1L, 2L);
             var items = List.of(memoryItem(1L, "vec-1"), memoryItem(2L, "vec-2"));
             when(itemOperations.getItemsByIds(memoryId, itemIds)).thenReturn(items);
@@ -578,10 +580,11 @@ class DefaultMemoryTest {
 
             StepVerifier.create(memind.deleteItems(memoryId, itemIds)).verifyComplete();
 
-            InOrder inOrder = inOrder(itemOperations, vector, retriever);
+            InOrder inOrder = inOrder(itemOperations, vector, threadProjectionStore, retriever);
             inOrder.verify(itemOperations).getItemsByIds(memoryId, itemIds);
-            inOrder.verify(vector).deleteBatch(memoryId, List.of("vec-1", "vec-2"));
+            inOrder.verify(threadProjectionStore).markRebuildRequired(memoryId, "item deletion");
             inOrder.verify(itemOperations).deleteItems(memoryId, itemIds);
+            inOrder.verify(vector).deleteBatch(memoryId, List.of("vec-1", "vec-2"));
             inOrder.verify(retriever).onDataChanged(memoryId);
         }
 
@@ -594,8 +597,9 @@ class DefaultMemoryTest {
 
             StepVerifier.create(memind.deleteItems(memoryId, itemIds)).verifyComplete();
 
-            InOrder inOrder = inOrder(itemOperations, retriever);
+            InOrder inOrder = inOrder(itemOperations, threadProjectionStore, retriever);
             inOrder.verify(itemOperations).getItemsByIds(memoryId, itemIds);
+            inOrder.verify(threadProjectionStore).markRebuildRequired(memoryId, "item deletion");
             inOrder.verify(itemOperations).deleteItems(memoryId, itemIds);
             inOrder.verify(retriever).onDataChanged(memoryId);
             verifyNoInteractions(vector);
@@ -613,9 +617,49 @@ class DefaultMemoryTest {
 
             InOrder inOrder = inOrder(itemOperations, vector, threadProjectionStore, retriever);
             inOrder.verify(itemOperations).getItemsByIds(memoryId, itemIds);
-            inOrder.verify(vector).deleteBatch(memoryId, List.of("vec-101"));
             inOrder.verify(threadProjectionStore).markRebuildRequired(memoryId, "item deletion");
             inOrder.verify(itemOperations).deleteItems(memoryId, itemIds);
+            inOrder.verify(vector).deleteBatch(memoryId, List.of("vec-101"));
+            inOrder.verify(retriever).onDataChanged(memoryId);
+        }
+
+        @Test
+        @DisplayName("deleteItems does not delete vectors when store delete fails")
+        void deleteItemsDoesNotDeleteVectorsWhenStoreDeleteFails() {
+            var itemIds = List.of(201L);
+            when(itemOperations.getItemsByIds(memoryId, itemIds))
+                    .thenReturn(List.of(memoryItem(201L, "vec-201")));
+            doThrow(new IllegalStateException("store unavailable"))
+                    .when(itemOperations)
+                    .deleteItems(memoryId, itemIds);
+
+            StepVerifier.create(memind.deleteItems(memoryId, itemIds))
+                    .expectErrorMessage("store unavailable")
+                    .verify();
+
+            verify(itemOperations).getItemsByIds(memoryId, itemIds);
+            verify(threadProjectionStore).markRebuildRequired(memoryId, "item deletion");
+            verify(itemOperations).deleteItems(memoryId, itemIds);
+            verifyNoInteractions(vector);
+            verify(retriever, never()).onDataChanged(memoryId);
+        }
+
+        @Test
+        @DisplayName("deleteItems succeeds and invalidates retriever when vector cleanup fails")
+        void deleteItemsSucceedsAndInvalidatesRetrieverWhenVectorCleanupFails() {
+            var itemIds = List.of(301L);
+            when(itemOperations.getItemsByIds(memoryId, itemIds))
+                    .thenReturn(List.of(memoryItem(301L, "vec-301")));
+            when(vector.deleteBatch(memoryId, List.of("vec-301")))
+                    .thenReturn(Mono.error(new IllegalStateException("vector unavailable")));
+
+            StepVerifier.create(memind.deleteItems(memoryId, itemIds)).verifyComplete();
+
+            InOrder inOrder = inOrder(itemOperations, vector, threadProjectionStore, retriever);
+            inOrder.verify(itemOperations).getItemsByIds(memoryId, itemIds);
+            inOrder.verify(threadProjectionStore).markRebuildRequired(memoryId, "item deletion");
+            inOrder.verify(itemOperations).deleteItems(memoryId, itemIds);
+            inOrder.verify(vector).deleteBatch(memoryId, List.of("vec-301"));
             inOrder.verify(retriever).onDataChanged(memoryId);
         }
 


### PR DESCRIPTION
## Summary
- Delete item store rows before vector cleanup so a failed store delete cannot leave active items without vectors.
- Keep vector cleanup best-effort after the authoritative store mutation and invalidate retrieval only after the store-delete path succeeds.
- Add regression coverage for store delete failures, vector cleanup failures, no-vector ids, and operation ordering.

## Test Plan
- [x] mvn -pl memind-core -Dtest=DefaultMemoryTest test
- [x] mvn -pl memind-core test
- [x] mvn -pl memind-core spotless:check checkstyle:check
- [x] git diff --check

## Notes
- Fixes #101.
- This PR intentionally leaves durable orphan-vector sweeping as follow-up because MemoryVector does not currently expose a portable list/delete-by-filter contract.