### PR TITLE
Expand Memind MCP memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,19 +185,24 @@ Claude Code can connect to the local server with:
 claude mcp add --transport http memind http://localhost:8366/mcp
 ```
 
-Available MCP tools:
+Default MCP tools:
 
-- `memind_retrieve`: retrieve memory for a `userId` and `agentId` with a natural-language `query`;
-  `strategy` can be `SIMPLE` or `DEEP`, and defaults to `SIMPLE`.
-- `memind_extract_text`: immediately extract memory from standalone text, such as pasted notes,
-  document excerpts, or summaries.
-- `memind_add_message`: add one `user` or `assistant` conversation message to Memind's pending
-  conversation buffer.
-- `memind_commit`: commit pending conversation messages for the same `userId` and `agentId`.
+- Retrieval and context: `memind_compile_context`, `memind_retrieve`, `memind_recent`.
+- Write flows: `memind_extract_text`, `memind_extract_rawdata`, `memind_add_message`,
+  `memind_commit`.
+- Memory item inspection: `memind_items_search`, `memind_items_get`, `memind_items_sources`.
+- Rawdata inspection: `memind_rawdata_search`, `memind_rawdata_get`.
 
-Use `memind_extract_text` for one-off text memory. Use `memind_add_message` followed by
-`memind_commit` for conversation-style memory. To disable the MCP endpoint, set
-`MEMIND_MCP_ENABLED=false` before starting `memind-server`.
+Use `memind_compile_context` when an agent needs a concise, sectioned context pack. Use
+`memind_retrieve` when it needs the structured retrieval response. Use `memind_extract_text` for
+one-off text memory, `memind_extract_rawdata` for typed rawdata payloads, and
+`memind_add_message` followed by `memind_commit` for conversation-style memory.
+
+The optional governance tool `memind_forget` is disabled by default. Enable it with
+`MEMIND_MCP_GOVERNANCE_ENABLED=true`; it defaults to dry-run mode, requires a non-blank reason,
+and deletes only `ITEM` or `RAWDATA` records that match the supplied `userId` and `agentId`.
+
+To disable the MCP endpoint, set `MEMIND_MCP_ENABLED=false` before starting `memind-server`.
 
 Do not expose `/mcp` directly to public networks without an authentication gateway or equivalent
 network controls. MCP tools can read and write scoped memory.

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,15 +190,20 @@ Claude Code 可以这样连接本地服务：
 claude mcp add --transport http memind http://localhost:8366/mcp
 ```
 
-当前暴露的 MCP tools：
+默认 MCP tools：
 
-- `memind_retrieve`：按 `userId`、`agentId` 和自然语言 `query` 检索记忆；`strategy`
-  可选 `SIMPLE` 或 `DEEP`，默认是 `SIMPLE`。
-- `memind_extract_text`：立即从一段独立文本中提取记忆，适合用户粘贴的笔记、文档片段或总结。
-- `memind_add_message`：向 Memind 的待提交对话缓冲区添加一条 `user` 或 `assistant` 消息。
-- `memind_commit`：提交同一个 `userId` 和 `agentId` 下的待处理对话消息。
+- 检索与上下文：`memind_compile_context`、`memind_retrieve`、`memind_recent`。
+- 写入流程：`memind_extract_text`、`memind_extract_rawdata`、`memind_add_message`、`memind_commit`。
+- Memory item 检查：`memind_items_search`、`memind_items_get`、`memind_items_sources`。
+- Rawdata 检查：`memind_rawdata_search`、`memind_rawdata_get`。
 
-`memind_extract_text` 适合一次性的文本记忆；`memind_add_message` 加 `memind_commit` 适合对话流式记忆。
+当 Agent 需要一段精简、分组后的上下文时，优先使用 `memind_compile_context`；当它需要结构化检索结果时，使用
+`memind_retrieve`。`memind_extract_text` 适合一次性的文本记忆，`memind_extract_rawdata` 适合 typed rawdata，
+`memind_add_message` 加 `memind_commit` 适合对话流式记忆。
+
+可选治理工具 `memind_forget` 默认关闭。设置 `MEMIND_MCP_GOVERNANCE_ENABLED=true` 后启用；它默认 dry-run，
+要求填写非空 reason，并且只会删除匹配传入 `userId` 和 `agentId` 的 `ITEM` 或 `RAWDATA` 记录。
+
 如果要关闭 MCP 端点，在启动 `memind-server` 前设置 `MEMIND_MCP_ENABLED=false`。
 
 不要在没有鉴权网关或等价网络控制的情况下把 `/mcp` 直接暴露到公网。MCP tools 可以读写对应作用域下的记忆。

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/MemindServerApplication.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/MemindServerApplication.java
@@ -17,8 +17,10 @@ import org.apache.ibatis.annotations.Mapper;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 @MapperScan(value = "com.openmemind.ai.memory.server", annotationClass = Mapper.class)
 public class MemindServerApplication {
 

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpGovernanceToolService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpGovernanceToolService.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.request.MemindForgetToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindForgetToolRequest.TargetType;
+import com.openmemind.ai.memory.server.mcp.response.MemindForgetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemsGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRawDataGetResponse;
+import com.openmemind.ai.memory.server.service.item.ItemDeleteService;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryAssetQueryService;
+import com.openmemind.ai.memory.server.service.rawdata.RawDataDeleteService;
+import java.util.List;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(prefix = "memind.mcp", name = "governance-enabled", havingValue = "true")
+public class MemindMcpGovernanceToolService implements MemindMcpToolProvider {
+
+    private final OpenMemoryAssetQueryService assetQueryService;
+    private final ItemDeleteService itemDeleteService;
+    private final RawDataDeleteService rawDataDeleteService;
+    private final MemindMcpToolProperties properties;
+
+    public MemindMcpGovernanceToolService(
+            OpenMemoryAssetQueryService assetQueryService,
+            ItemDeleteService itemDeleteService,
+            RawDataDeleteService rawDataDeleteService,
+            MemindMcpToolProperties properties) {
+        this.assetQueryService = assetQueryService;
+        this.itemDeleteService = itemDeleteService;
+        this.rawDataDeleteService = rawDataDeleteService;
+        this.properties = properties;
+    }
+
+    @McpTool(
+            name = "memind_forget",
+            title = "Forget scoped Memind records",
+            description =
+                    "Delete memory items or rawdata after a scoped lookup. Defaults to dry-run "
+                            + "and requires an explicit reason.")
+    public MemindForgetResponse forget(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Target type: ITEM or RAWDATA.") String targetType,
+            @McpToolParam(description = "Target IDs.") List<String> ids,
+            @McpToolParam(description = "Reason for the forget request.") String reason,
+            @McpToolParam(required = false, description = "Dry-run mode. Defaults to true.")
+                    Boolean dryRun) {
+        var request =
+                MemindForgetToolRequest.of(
+                        userId,
+                        agentId,
+                        targetType,
+                        ids,
+                        reason,
+                        dryRun,
+                        properties.maxIdsPerRequest());
+        return switch (request.targetType()) {
+            case ITEM -> forgetItems(request);
+            case RAWDATA -> forgetRawData(request);
+        };
+    }
+
+    private MemindForgetResponse forgetItems(MemindForgetToolRequest request) {
+        MemindItemsGetResponse lookup =
+                assetQueryService.getItemsByIds(
+                        request.userId(),
+                        request.agentId(),
+                        request.longIds(properties.maxIdsPerRequest()));
+        List<String> foundIds = lookup.items().stream().map(item -> item.id()).toList();
+        if (request.dryRun()) {
+            return MemindForgetResponse.dryRun(TargetType.ITEM, foundIds, lookup.missingItemIds());
+        }
+        itemDeleteService.deleteItems(foundIds.stream().map(Long::valueOf).toList());
+        return MemindForgetResponse.deleted(TargetType.ITEM, foundIds, lookup.missingItemIds());
+    }
+
+    private MemindForgetResponse forgetRawData(MemindForgetToolRequest request) {
+        MemindRawDataGetResponse lookup =
+                assetQueryService.getRawDataByIds(
+                        request.userId(),
+                        request.agentId(),
+                        request.ids(),
+                        false,
+                        properties.maxRawSegmentChars());
+        List<String> foundIds = lookup.rawData().stream().map(rawData -> rawData.id()).toList();
+        if (request.dryRun()) {
+            return MemindForgetResponse.dryRun(
+                    TargetType.RAWDATA, foundIds, lookup.missingRawDataIds());
+        }
+        rawDataDeleteService.deleteRawData(foundIds);
+        return MemindForgetResponse.deleted(
+                TargetType.RAWDATA, foundIds, lookup.missingRawDataIds());
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolConfiguration.java
@@ -37,7 +37,7 @@ class MemindMcpToolConfiguration {
 
     @Bean
     List<McpStatelessServerFeatures.SyncToolSpecification> memindMcpToolSpecifications(
-            MemindMcpToolService toolService) {
-        return SyncMcpAnnotationProviders.statelessToolSpecifications(List.of(toolService));
+            List<MemindMcpToolProvider> toolProviders) {
+        return SyncMcpAnnotationProviders.statelessToolSpecifications(List.copyOf(toolProviders));
     }
 }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolProvider.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolProvider.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+public interface MemindMcpToolProvider {}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolService.java
@@ -13,29 +13,112 @@
  */
 package com.openmemind.ai.memory.server.mcp;
 
+import com.openmemind.ai.memory.core.extraction.rawdata.content.RawContent;
+import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.MetadataFilter;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryItemsRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryRawDataRequest;
 import com.openmemind.ai.memory.server.domain.memory.response.AddMessageResponse;
 import com.openmemind.ai.memory.server.domain.memory.response.ExtractMemoryResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryItemsResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryRawDataResponse;
 import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.mcp.compiler.MemindMcpContextCompiler;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
 import com.openmemind.ai.memory.server.mcp.request.MemindAddMessageToolRequest;
 import com.openmemind.ai.memory.server.mcp.request.MemindCommitToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindCompileContextToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindExtractRawDataToolRequest;
 import com.openmemind.ai.memory.server.mcp.request.MemindExtractTextToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindGetItemsToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindGetRawDataToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindItemSourcesToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindQueryItemsToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindQueryRawDataToolRequest;
+import com.openmemind.ai.memory.server.mcp.request.MemindRecentToolRequest;
 import com.openmemind.ai.memory.server.mcp.request.MemindRetrieveToolRequest;
+import com.openmemind.ai.memory.server.mcp.response.MemindCompiledContextResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemSourcesResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemsGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRawDataGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRecentResponse;
 import com.openmemind.ai.memory.server.service.memory.OpenMemoryApplicationService;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryAssetQueryService;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.json.JsonMapper;
 
 @Service
-public class MemindMcpToolService {
+public class MemindMcpToolService implements MemindMcpToolProvider {
 
     private static final Logger log = LoggerFactory.getLogger(MemindMcpToolService.class);
 
     private final OpenMemoryApplicationService memoryService;
+    private final OpenMemoryAssetQueryService assetQueryService;
+    private final MemindMcpContextCompiler contextCompiler;
+    private final MemindMcpToolProperties properties;
+    private final JsonMapper rawDataObjectMapper;
 
-    public MemindMcpToolService(OpenMemoryApplicationService memoryService) {
+    public MemindMcpToolService(
+            OpenMemoryApplicationService memoryService,
+            OpenMemoryAssetQueryService assetQueryService,
+            MemindMcpContextCompiler contextCompiler,
+            MemindMcpToolProperties properties,
+            JsonMapper rawDataObjectMapper) {
         this.memoryService = memoryService;
+        this.assetQueryService = assetQueryService;
+        this.contextCompiler = contextCompiler;
+        this.properties = properties;
+        this.rawDataObjectMapper = rawDataObjectMapper;
+    }
+
+    @McpTool(
+            name = "memind_compile_context",
+            title = "Compile Memind context",
+            description =
+                    "Retrieve Memind memory and compile it into a concise, sectioned context "
+                            + "payload for an AI agent.")
+    public MemindCompiledContextResponse compileContext(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Natural-language retrieval query.") String query,
+            @McpToolParam(
+                            required = false,
+                            description = "Retrieval strategy: SIMPLE or DEEP. Defaults to SIMPLE.")
+                    String strategy,
+            @McpToolParam(required = false, description = "Maximum memory items to render.")
+                    Integer maxItems,
+            @McpToolParam(required = false, description = "Approximate token budget.")
+                    Integer tokenBudget,
+            @McpToolParam(required = false, description = "Whether to include source references.")
+                    Boolean includeSources,
+            @McpToolParam(required = false, description = "Optional metadata filter.")
+                    MetadataFilter metadataFilter) {
+        var request =
+                new MemindCompileContextToolRequest(
+                        userId,
+                        agentId,
+                        query,
+                        strategy,
+                        maxItems,
+                        tokenBudget,
+                        includeSources,
+                        metadataFilter);
+        RetrieveMemoryResponse response = memoryService.retrieve(request.toApplicationRequest());
+        return contextCompiler.compile(
+                response,
+                request.effectiveMaxItems(properties),
+                request.effectiveTokenBudget(properties),
+                request.effectiveIncludeSources());
     }
 
     @McpTool(
@@ -66,6 +149,65 @@ public class MemindMcpToolService {
     }
 
     @McpTool(
+            name = "memind_recent",
+            title = "List recent Memind memory assets",
+            description = "List recent memory items and rawdata for a userId and agentId.")
+    public MemindRecentResponse recent(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(required = false, description = "Entry types: ITEM and/or RAWDATA.")
+                    List<String> types,
+            @McpToolParam(required = false, description = "Maximum entries to return.")
+                    Integer limit,
+            @McpToolParam(required = false, description = "Reserved pagination cursor.")
+                    String cursor,
+            @McpToolParam(required = false, description = "Optional metadata filter.")
+                    MetadataFilter metadataFilter) {
+        var request =
+                new MemindRecentToolRequest(userId, agentId, types, limit, cursor, metadataFilter);
+        int effectiveLimit = request.effectiveLimit(properties);
+        List<MemindRecentResponse.Entry> entries = new ArrayList<>();
+        if (request.effectiveTypes().contains(MemindRecentToolRequest.EntryType.ITEM)) {
+            var items =
+                    assetQueryService.queryItems(
+                            new QueryMemoryItemsRequest(
+                                    request.requiredUserId(),
+                                    request.requiredAgentId(),
+                                    null,
+                                    List.of(),
+                                    List.of(),
+                                    List.of(),
+                                    null,
+                                    metadataFilter,
+                                    effectiveLimit,
+                                    cursor));
+            entries.addAll(items.items().stream().map(MemindMcpToolService::recentItem).toList());
+        }
+        if (request.effectiveTypes().contains(MemindRecentToolRequest.EntryType.RAWDATA)) {
+            var rawData =
+                    assetQueryService.queryRawData(
+                            new QueryMemoryRawDataRequest(
+                                    request.requiredUserId(),
+                                    request.requiredAgentId(),
+                                    List.of(),
+                                    List.of(),
+                                    null,
+                                    metadataFilter,
+                                    new QueryMemoryRawDataRequest.IncludeOptions(false, true),
+                                    effectiveLimit,
+                                    cursor));
+            entries.addAll(
+                    rawData.rawData().stream().map(MemindMcpToolService::recentRawData).toList());
+        }
+        List<MemindRecentResponse.Entry> sorted =
+                entries.stream()
+                        .sorted(Comparator.comparing(MemindMcpToolService::sortTime).reversed())
+                        .limit(effectiveLimit)
+                        .toList();
+        return new MemindRecentResponse(sorted, null);
+    }
+
+    @McpTool(
             name = "memind_extract_text",
             title = "Extract standalone text into Memind memory",
             description =
@@ -88,6 +230,41 @@ public class MemindMcpToolService {
                 request.userId(),
                 request.agentId());
         return memoryService.extract(request.toApplicationRequest());
+    }
+
+    @McpTool(
+            name = "memind_extract_rawdata",
+            title = "Extract typed rawdata into Memind memory",
+            description =
+                    "Extract memory immediately from a typed rawdata payload using Memind's "
+                            + "registered rawdata content types.")
+    public ExtractMemoryResponse extractRawData(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Rawdata type discriminator, such as conversation.")
+                    String type,
+            @McpToolParam(description = "Rawdata content payload without a type key.")
+                    Map<String, Object> content,
+            @McpToolParam(required = false, description = "Metadata to attach to the rawdata.")
+                    Map<String, Object> metadata,
+            @McpToolParam(required = false, description = "Source marker. Defaults to mcp.")
+                    String sourceClient) {
+        var request =
+                new MemindExtractRawDataToolRequest(
+                        userId, agentId, type, content, metadata, sourceClient);
+        Map<String, Object> rawPayload = new LinkedHashMap<>();
+        rawPayload.putAll(request.requiredContent());
+        rawPayload.put("type", request.requiredType());
+        RawContent rawContent = rawDataObjectMapper.convertValue(rawPayload, RawContent.class);
+        if (!request.effectiveMetadata().isEmpty()) {
+            rawContent = rawContent.withMetadata(request.effectiveMetadata());
+        }
+        return memoryService.extract(
+                new ExtractMemoryRequest(
+                        request.requiredUserId(),
+                        request.requiredAgentId(),
+                        rawContent,
+                        request.effectiveSourceClient()));
     }
 
     @McpTool(
@@ -135,5 +312,176 @@ public class MemindMcpToolService {
                 request.userId(),
                 request.agentId());
         return memoryService.commit(request.toApplicationRequest());
+    }
+
+    @McpTool(
+            name = "memind_items_search",
+            title = "Search Memind memory items",
+            description = "Search persisted memory items by scope, category, source and metadata.")
+    public QueryMemoryItemsResponse itemsSearch(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(required = false, description = "Memory item scope filter.") String scope,
+            @McpToolParam(required = false, description = "Memory item category filters.")
+                    List<String> categories,
+            @McpToolParam(required = false, description = "Source client filters.")
+                    List<String> sourceClients,
+            @McpToolParam(required = false, description = "Rawdata type filters.")
+                    List<String> rawDataTypes,
+            @McpToolParam(required = false, description = "Occurred-at time range.")
+                    QueryMemoryItemsRequest.TimeRange timeRange,
+            @McpToolParam(required = false, description = "Metadata filter.")
+                    MetadataFilter metadataFilter,
+            @McpToolParam(required = false, description = "Maximum results.") Integer limit,
+            @McpToolParam(required = false, description = "Reserved pagination cursor.")
+                    String cursor) {
+        var request =
+                new MemindQueryItemsToolRequest(
+                        userId,
+                        agentId,
+                        scope,
+                        categories,
+                        sourceClients,
+                        rawDataTypes,
+                        timeRange,
+                        metadataFilter,
+                        limit,
+                        cursor);
+        return assetQueryService.queryItems(request.toApplicationRequest(properties));
+    }
+
+    @McpTool(
+            name = "memind_items_get",
+            title = "Get Memind memory items",
+            description = "Fetch memory items by ID after userId and agentId scope filtering.")
+    public MemindItemsGetResponse itemsGet(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Memory item IDs.") List<String> ids) {
+        var request = new MemindGetItemsToolRequest(userId, agentId, ids);
+        return assetQueryService.getItemsByIds(
+                request.requiredUserId(),
+                request.requiredAgentId(),
+                request.requiredLongIds(properties.maxIdsPerRequest()));
+    }
+
+    @McpTool(
+            name = "memind_items_sources",
+            title = "Get Memind memory item sources",
+            description =
+                    "Fetch source rawdata records for memory item IDs with optional segments.")
+    public MemindItemSourcesResponse itemsSources(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Memory item IDs.") List<String> ids,
+            @McpToolParam(required = false, description = "Whether to include rawdata segments.")
+                    Boolean includeSegment) {
+        var request = new MemindItemSourcesToolRequest(userId, agentId, ids, includeSegment);
+        return assetQueryService.getItemSourcesByItemIds(
+                request.requiredUserId(),
+                request.requiredAgentId(),
+                request.requiredLongIds(properties.maxIdsPerRequest()),
+                request.effectiveIncludeSegment(),
+                properties.maxRawSegmentChars());
+    }
+
+    @McpTool(
+            name = "memind_rawdata_search",
+            title = "Search Memind rawdata",
+            description = "Search rawdata records by type, source, time range and metadata.")
+    public QueryMemoryRawDataResponse rawDataSearch(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(required = false, description = "Rawdata type filters.")
+                    List<String> types,
+            @McpToolParam(required = false, description = "Source client filters.")
+                    List<String> sourceClients,
+            @McpToolParam(required = false, description = "Rawdata start time range.")
+                    QueryMemoryRawDataRequest.TimeRange timeRange,
+            @McpToolParam(required = false, description = "Metadata filter.")
+                    MetadataFilter metadataFilter,
+            @McpToolParam(required = false, description = "Whether to include rawdata segments.")
+                    Boolean includeSegment,
+            @McpToolParam(required = false, description = "Whether to include rawdata metadata.")
+                    Boolean includeMetadata,
+            @McpToolParam(required = false, description = "Maximum results.") Integer limit,
+            @McpToolParam(required = false, description = "Reserved pagination cursor.")
+                    String cursor) {
+        var request =
+                new MemindQueryRawDataToolRequest(
+                        userId,
+                        agentId,
+                        types,
+                        sourceClients,
+                        timeRange,
+                        metadataFilter,
+                        includeSegment,
+                        includeMetadata,
+                        limit,
+                        cursor);
+        return assetQueryService.queryRawData(request.toApplicationRequest(properties));
+    }
+
+    @McpTool(
+            name = "memind_rawdata_get",
+            title = "Get Memind rawdata",
+            description = "Fetch rawdata records by ID after userId and agentId scope filtering.")
+    public MemindRawDataGetResponse rawDataGet(
+            @McpToolParam(description = "Memory user scope.") String userId,
+            @McpToolParam(description = "Memory agent scope.") String agentId,
+            @McpToolParam(description = "Rawdata IDs.") List<String> ids,
+            @McpToolParam(required = false, description = "Whether to include rawdata segments.")
+                    Boolean includeSegment) {
+        var request = new MemindGetRawDataToolRequest(userId, agentId, ids, includeSegment);
+        return assetQueryService.getRawDataByIds(
+                request.requiredUserId(),
+                request.requiredAgentId(),
+                request.requiredIds(properties.maxIdsPerRequest()),
+                request.effectiveIncludeSegment(),
+                properties.maxRawSegmentChars());
+    }
+
+    private static MemindRecentResponse.Entry recentItem(
+            QueryMemoryItemsResponse.MemoryItemView item) {
+        return new MemindRecentResponse.Entry(
+                "ITEM",
+                item.id(),
+                item.category(),
+                item.text(),
+                item.sourceClient(),
+                firstNonNull(item.occurredAt(), item.observedAt()),
+                item.createdAt(),
+                item.metadata());
+    }
+
+    private static MemindRecentResponse.Entry recentRawData(
+            QueryMemoryRawDataResponse.MemoryRawDataView rawData) {
+        return new MemindRecentResponse.Entry(
+                "RAWDATA",
+                rawData.id(),
+                rawData.type(),
+                rawData.caption(),
+                rawData.sourceClient(),
+                firstNonNull(rawData.startTime(), rawData.endTime()),
+                rawData.createdAt(),
+                rawData.metadata());
+    }
+
+    private static Instant sortTime(MemindRecentResponse.Entry entry) {
+        return firstNonNull(entry.occurredAt(), entry.createdAt(), Instant.EPOCH);
+    }
+
+    private static Instant firstNonNull(Instant first, Instant second) {
+        return first != null ? first : second;
+    }
+
+    private static Instant firstNonNull(Instant first, Instant second, Instant third) {
+        if (first != null) {
+            return first;
+        }
+        if (second != null) {
+            return second;
+        }
+        return third;
     }
 }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/compiler/MemindMcpContextCompiler.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/compiler/MemindMcpContextCompiler.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.compiler;
+
+import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindCompiledContextResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemindMcpContextCompiler {
+
+    private static final List<String> SECTION_ORDER =
+            List.of(
+                    "Must Follow",
+                    "Resolved Problems",
+                    "Playbooks",
+                    "Tool Notes",
+                    "Insights",
+                    "Recent Context",
+                    "Other Memory");
+
+    public MemindCompiledContextResponse compile(
+            RetrieveMemoryResponse response,
+            int maxItems,
+            int tokenBudget,
+            boolean includeSources) {
+        Map<String, List<String>> grouped = new LinkedHashMap<>();
+        SECTION_ORDER.forEach(section -> grouped.put(section, new ArrayList<>()));
+
+        List<RetrieveMemoryResponse.RetrievedItemView> selectedItems =
+                response.items().stream().limit(Math.max(0, maxItems)).toList();
+        Set<String> selectedItemIds = new LinkedHashSet<>();
+        for (var item : selectedItems) {
+            if (hasText(item.id())) {
+                selectedItemIds.add(item.id());
+            }
+            if (hasText(item.text())) {
+                grouped.get(sectionForCategory(item.category())).add(item.text().trim());
+            }
+        }
+
+        for (var insight : response.insights()) {
+            if (hasText(insight.text())) {
+                grouped.get("Insights").add(insight.text().trim());
+            }
+        }
+
+        for (var rawData : response.rawData()) {
+            if (shouldRenderRawDataCaption(rawData, selectedItemIds)
+                    && hasText(rawData.caption())) {
+                grouped.get("Recent Context").add(rawData.caption().trim());
+            }
+        }
+
+        List<MemindCompiledContextResponse.Section> sections =
+                SECTION_ORDER.stream()
+                        .map(
+                                name ->
+                                        new MemindCompiledContextResponse.Section(
+                                                name, grouped.get(name)))
+                        .filter(section -> !section.items().isEmpty())
+                        .toList();
+        String rendered = render(sections);
+        TruncatedText truncated = applyTokenBudget(rendered, tokenBudget);
+
+        return new MemindCompiledContextResponse(
+                response.status(),
+                response.query(),
+                response.strategy(),
+                truncated.text(),
+                sections,
+                includeSources ? sources(response.rawData()) : List.of(),
+                truncated.truncated());
+    }
+
+    private static boolean shouldRenderRawDataCaption(
+            RetrieveMemoryResponse.RetrievedRawDataView rawData, Set<String> selectedItemIds) {
+        if (rawData.itemIds().isEmpty()) {
+            return true;
+        }
+        return rawData.itemIds().stream().anyMatch(selectedItemIds::contains);
+    }
+
+    private static List<MemindCompiledContextResponse.Source> sources(
+            List<RetrieveMemoryResponse.RetrievedRawDataView> rawData) {
+        return rawData.stream()
+                .map(
+                        source ->
+                                new MemindCompiledContextResponse.Source(
+                                        source.rawDataId(),
+                                        source.type(),
+                                        source.caption(),
+                                        source.sourceClient(),
+                                        source.itemIds(),
+                                        source.metadata()))
+                .toList();
+    }
+
+    private static String render(List<MemindCompiledContextResponse.Section> sections) {
+        StringBuilder builder = new StringBuilder();
+        for (var section : sections) {
+            if (builder.length() > 0) {
+                builder.append("\n\n");
+            }
+            builder.append("## ").append(section.name());
+            for (String item : section.items()) {
+                builder.append("\n- ").append(item);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static TruncatedText applyTokenBudget(String text, int tokenBudget) {
+        int maxChars = Math.max(1, tokenBudget) * 4;
+        if (text.length() <= maxChars) {
+            return new TruncatedText(text, false);
+        }
+        return new TruncatedText(text.substring(0, maxChars) + "\n...[truncated]", true);
+    }
+
+    private static String sectionForCategory(String category) {
+        if (!hasText(category)) {
+            return "Other Memory";
+        }
+        return switch (category.trim().toLowerCase(Locale.ROOT)) {
+            case "directive" -> "Must Follow";
+            case "resolution" -> "Resolved Problems";
+            case "playbook" -> "Playbooks";
+            case "tool" -> "Tool Notes";
+            case "insight" -> "Insights";
+            default -> "Other Memory";
+        };
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private record TruncatedText(String text, boolean truncated) {}
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/config/MemindMcpToolProperties.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/config/MemindMcpToolProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "memind.mcp")
+public record MemindMcpToolProperties(
+        boolean governanceEnabled,
+        int defaultTokenBudget,
+        int maxTokenBudget,
+        int maxItemsPerContext,
+        int maxResultLimit,
+        int maxIdsPerRequest,
+        int maxRawSegmentChars) {
+
+    public MemindMcpToolProperties {
+        if (defaultTokenBudget <= 0) {
+            defaultTokenBudget = 1800;
+        }
+        if (maxTokenBudget <= 0) {
+            maxTokenBudget = 6000;
+        }
+        if (maxItemsPerContext <= 0) {
+            maxItemsPerContext = 50;
+        }
+        if (maxResultLimit <= 0) {
+            maxResultLimit = 100;
+        }
+        if (maxIdsPerRequest <= 0) {
+            maxIdsPerRequest = 50;
+        }
+        if (maxRawSegmentChars <= 0) {
+            maxRawSegmentChars = 12000;
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindCompileContextToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindCompileContextToolRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.server.domain.memory.request.MetadataFilter;
+import com.openmemind.ai.memory.server.domain.memory.request.RetrieveMemoryRequest;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.Locale;
+
+public record MemindCompileContextToolRequest(
+        String userId,
+        String agentId,
+        String query,
+        String strategy,
+        Integer maxItems,
+        Integer tokenBudget,
+        Boolean includeSources,
+        MetadataFilter metadataFilter) {
+
+    private static final int DEFAULT_MAX_ITEMS = 12;
+
+    public RetrieveMemoryRequest toApplicationRequest() {
+        return new RetrieveMemoryRequest(
+                requiredUserId(),
+                requiredAgentId(),
+                requiredQuery(),
+                parseStrategy(strategy),
+                null,
+                null,
+                java.util.List.of(),
+                null,
+                metadataFilter,
+                null);
+    }
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public String requiredQuery() {
+        return MemindMcpToolValidation.requireText(query, "query");
+    }
+
+    public int effectiveMaxItems(MemindMcpToolProperties properties) {
+        return MemindMcpToolValidation.effectivePositiveInt(
+                maxItems, DEFAULT_MAX_ITEMS, properties.maxItemsPerContext(), "maxItems");
+    }
+
+    public int effectiveTokenBudget(MemindMcpToolProperties properties) {
+        return MemindMcpToolValidation.effectivePositiveInt(
+                tokenBudget,
+                properties.defaultTokenBudget(),
+                properties.maxTokenBudget(),
+                "tokenBudget");
+    }
+
+    public boolean effectiveIncludeSources() {
+        return includeSources == null || includeSources;
+    }
+
+    static RetrievalConfig.Strategy parseStrategy(String value) {
+        if (value == null || value.isBlank()) {
+            return RetrievalConfig.Strategy.SIMPLE;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "SIMPLE" -> RetrievalConfig.Strategy.SIMPLE;
+            case "DEEP" -> RetrievalConfig.Strategy.DEEP;
+            default -> throw new IllegalArgumentException("strategy must be one of SIMPLE, DEEP");
+        };
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindExtractRawDataToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindExtractRawDataToolRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.Map;
+
+public record MemindExtractRawDataToolRequest(
+        String userId,
+        String agentId,
+        String type,
+        Map<String, Object> content,
+        Map<String, Object> metadata,
+        String sourceClient) {
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public String requiredType() {
+        return MemindMcpToolValidation.requireText(type, "type");
+    }
+
+    public Map<String, Object> requiredContent() {
+        Map<String, Object> value = MemindMcpToolValidation.requireMap(content, "content");
+        if (value.containsKey("type")) {
+            throw new IllegalArgumentException("content must not contain type");
+        }
+        return value;
+    }
+
+    public Map<String, Object> effectiveMetadata() {
+        return metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public String effectiveSourceClient() {
+        return MemindMcpToolValidation.normalizeSourceClient(sourceClient);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindForgetToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindForgetToolRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+import java.util.Locale;
+
+public record MemindForgetToolRequest(
+        String userId,
+        String agentId,
+        TargetType targetType,
+        List<String> ids,
+        String reason,
+        boolean dryRun) {
+
+    public static MemindForgetToolRequest of(
+            String userId,
+            String agentId,
+            String targetType,
+            List<String> ids,
+            String reason,
+            Boolean dryRun,
+            int maxIdsPerRequest) {
+        return new MemindForgetToolRequest(
+                MemindMcpToolValidation.requireText(userId, "userId"),
+                MemindMcpToolValidation.requireText(agentId, "agentId"),
+                parseTargetType(targetType),
+                MemindMcpToolValidation.requireStringIds(ids, "ids", maxIdsPerRequest),
+                MemindMcpToolValidation.requireText(reason, "reason"),
+                dryRun == null || dryRun);
+    }
+
+    public List<Long> longIds(int maxIdsPerRequest) {
+        return MemindMcpToolValidation.requireLongIds(ids, "ids", maxIdsPerRequest);
+    }
+
+    private static TargetType parseTargetType(String value) {
+        String normalized =
+                MemindMcpToolValidation.requireText(value, "targetType").toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "ITEM" -> TargetType.ITEM;
+            case "RAWDATA" -> TargetType.RAWDATA;
+            default ->
+                    throw new IllegalArgumentException("targetType must be one of ITEM, RAWDATA");
+        };
+    }
+
+    public enum TargetType {
+        ITEM,
+        RAWDATA
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindGetItemsToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindGetItemsToolRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+
+public record MemindGetItemsToolRequest(String userId, String agentId, List<String> ids) {
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public List<Long> requiredLongIds(int maxIdsPerRequest) {
+        return MemindMcpToolValidation.requireLongIds(ids, "ids", maxIdsPerRequest);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindGetRawDataToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindGetRawDataToolRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+
+public record MemindGetRawDataToolRequest(
+        String userId, String agentId, List<String> ids, Boolean includeSegment) {
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public List<String> requiredIds(int maxIdsPerRequest) {
+        return MemindMcpToolValidation.requireStringIds(ids, "ids", maxIdsPerRequest);
+    }
+
+    public boolean effectiveIncludeSegment() {
+        return Boolean.TRUE.equals(includeSegment);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindItemSourcesToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindItemSourcesToolRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+
+public record MemindItemSourcesToolRequest(
+        String userId, String agentId, List<String> ids, Boolean includeSegment) {
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public List<Long> requiredLongIds(int maxIdsPerRequest) {
+        return MemindMcpToolValidation.requireLongIds(ids, "ids", maxIdsPerRequest);
+    }
+
+    public boolean effectiveIncludeSegment() {
+        return Boolean.TRUE.equals(includeSegment);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindQueryItemsToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindQueryItemsToolRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.domain.memory.request.MetadataFilter;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryItemsRequest;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+
+public record MemindQueryItemsToolRequest(
+        String userId,
+        String agentId,
+        String scope,
+        List<String> categories,
+        List<String> sourceClients,
+        List<String> rawDataTypes,
+        QueryMemoryItemsRequest.TimeRange timeRange,
+        MetadataFilter metadataFilter,
+        Integer limit,
+        String cursor) {
+
+    public QueryMemoryItemsRequest toApplicationRequest(MemindMcpToolProperties properties) {
+        return new QueryMemoryItemsRequest(
+                MemindMcpToolValidation.requireText(userId, "userId"),
+                MemindMcpToolValidation.requireText(agentId, "agentId"),
+                trimOptional(scope),
+                safeList(categories),
+                safeList(sourceClients),
+                safeList(rawDataTypes),
+                timeRange,
+                metadataFilter,
+                effectiveLimit(properties),
+                cursor);
+    }
+
+    private int effectiveLimit(MemindMcpToolProperties properties) {
+        return MemindMcpToolValidation.effectivePositiveInt(
+                limit, 20, properties.maxResultLimit(), "limit");
+    }
+
+    private static List<String> safeList(List<String> values) {
+        return values == null
+                ? List.of()
+                : values.stream()
+                        .filter(MemindQueryItemsToolRequest::hasText)
+                        .map(String::trim)
+                        .toList();
+    }
+
+    private static String trimOptional(String value) {
+        return hasText(value) ? value.trim() : null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindQueryRawDataToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindQueryRawDataToolRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.domain.memory.request.MetadataFilter;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryRawDataRequest;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+
+public record MemindQueryRawDataToolRequest(
+        String userId,
+        String agentId,
+        List<String> types,
+        List<String> sourceClients,
+        QueryMemoryRawDataRequest.TimeRange timeRange,
+        MetadataFilter metadataFilter,
+        Boolean includeSegment,
+        Boolean includeMetadata,
+        Integer limit,
+        String cursor) {
+
+    public QueryMemoryRawDataRequest toApplicationRequest(MemindMcpToolProperties properties) {
+        return new QueryMemoryRawDataRequest(
+                MemindMcpToolValidation.requireText(userId, "userId"),
+                MemindMcpToolValidation.requireText(agentId, "agentId"),
+                safeList(types),
+                safeList(sourceClients),
+                timeRange,
+                metadataFilter,
+                new QueryMemoryRawDataRequest.IncludeOptions(
+                        Boolean.TRUE.equals(includeSegment),
+                        includeMetadata == null || includeMetadata),
+                effectiveLimit(properties),
+                cursor);
+    }
+
+    private int effectiveLimit(MemindMcpToolProperties properties) {
+        return MemindMcpToolValidation.effectivePositiveInt(
+                limit, 20, properties.maxResultLimit(), "limit");
+    }
+
+    private static List<String> safeList(List<String> values) {
+        return values == null
+                ? List.of()
+                : values.stream()
+                        .filter(MemindQueryRawDataToolRequest::hasText)
+                        .map(String::trim)
+                        .toList();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindRecentToolRequest.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/request/MemindRecentToolRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.request;
+
+import com.openmemind.ai.memory.server.domain.memory.request.MetadataFilter;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpToolValidation;
+import java.util.List;
+import java.util.Locale;
+
+public record MemindRecentToolRequest(
+        String userId,
+        String agentId,
+        List<String> types,
+        Integer limit,
+        String cursor,
+        MetadataFilter metadataFilter) {
+
+    public String requiredUserId() {
+        return MemindMcpToolValidation.requireText(userId, "userId");
+    }
+
+    public String requiredAgentId() {
+        return MemindMcpToolValidation.requireText(agentId, "agentId");
+    }
+
+    public List<EntryType> effectiveTypes() {
+        if (types == null || types.isEmpty()) {
+            return List.of(EntryType.ITEM, EntryType.RAWDATA);
+        }
+        return types.stream().map(MemindRecentToolRequest::parseType).distinct().toList();
+    }
+
+    public int effectiveLimit(MemindMcpToolProperties properties) {
+        return MemindMcpToolValidation.effectivePositiveInt(
+                limit, 20, properties.maxResultLimit(), "limit");
+    }
+
+    private static EntryType parseType(String value) {
+        String normalized =
+                MemindMcpToolValidation.requireText(value, "types").toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "ITEM" -> EntryType.ITEM;
+            case "RAWDATA" -> EntryType.RAWDATA;
+            default ->
+                    throw new IllegalArgumentException("types must contain only ITEM or RAWDATA");
+        };
+    }
+
+    public enum EntryType {
+        ITEM,
+        RAWDATA
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindCompiledContextResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindCompiledContextResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import java.util.List;
+import java.util.Map;
+
+public record MemindCompiledContextResponse(
+        String status,
+        String query,
+        String strategy,
+        String contextText,
+        List<Section> sections,
+        List<Source> sources,
+        boolean truncated) {
+
+    public MemindCompiledContextResponse {
+        sections = sections == null ? List.of() : List.copyOf(sections);
+        sources = sources == null ? List.of() : List.copyOf(sources);
+    }
+
+    public record Section(String name, List<String> items) {
+        public Section {
+            items = items == null ? List.of() : List.copyOf(items);
+        }
+    }
+
+    public record Source(
+            String rawDataId,
+            String rawDataType,
+            String caption,
+            String sourceClient,
+            List<String> itemIds,
+            Map<String, Object> metadata) {
+        public Source {
+            itemIds = itemIds == null ? List.of() : List.copyOf(itemIds);
+            metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindForgetResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindForgetResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import com.openmemind.ai.memory.server.mcp.request.MemindForgetToolRequest.TargetType;
+import java.util.List;
+
+public record MemindForgetResponse(
+        String status,
+        TargetType targetType,
+        boolean dryRun,
+        List<String> deleted,
+        List<String> notFound,
+        List<String> blocked) {
+
+    public MemindForgetResponse {
+        deleted = deleted == null ? List.of() : List.copyOf(deleted);
+        notFound = notFound == null ? List.of() : List.copyOf(notFound);
+        blocked = blocked == null ? List.of() : List.copyOf(blocked);
+    }
+
+    public static MemindForgetResponse dryRun(
+            TargetType targetType, List<String> wouldDelete, List<String> notFound) {
+        return new MemindForgetResponse(
+                "DRY_RUN",
+                targetType,
+                true,
+                List.of(),
+                List.copyOf(notFound),
+                List.copyOf(wouldDelete));
+    }
+
+    public static MemindForgetResponse deleted(
+            TargetType targetType, List<String> deleted, List<String> notFound) {
+        return new MemindForgetResponse(
+                "DELETED",
+                targetType,
+                false,
+                List.copyOf(deleted),
+                List.copyOf(notFound),
+                List.of());
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindItemSourcesResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindItemSourcesResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import java.util.List;
+import java.util.Map;
+
+public record MemindItemSourcesResponse(List<Source> sources, List<String> missingItemIds) {
+
+    public MemindItemSourcesResponse {
+        sources = sources == null ? List.of() : List.copyOf(sources);
+        missingItemIds = missingItemIds == null ? List.of() : List.copyOf(missingItemIds);
+    }
+
+    public record Source(
+            String itemId,
+            String rawDataId,
+            String rawDataType,
+            String caption,
+            String sourceClient,
+            Map<String, Object> metadata,
+            Map<String, Object> segment) {
+        public Source {
+            metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+            segment = segment == null ? null : Map.copyOf(segment);
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindItemsGetResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindItemsGetResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryItemsResponse;
+import java.util.List;
+
+public record MemindItemsGetResponse(
+        List<QueryMemoryItemsResponse.MemoryItemView> items, List<String> missingItemIds) {
+
+    public MemindItemsGetResponse {
+        items = items == null ? List.of() : List.copyOf(items);
+        missingItemIds = missingItemIds == null ? List.of() : List.copyOf(missingItemIds);
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindRawDataGetResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindRawDataGetResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record MemindRawDataGetResponse(List<RawData> rawData, List<String> missingRawDataIds) {
+
+    public MemindRawDataGetResponse {
+        rawData = rawData == null ? List.of() : List.copyOf(rawData);
+        missingRawDataIds = missingRawDataIds == null ? List.of() : List.copyOf(missingRawDataIds);
+    }
+
+    public record RawData(
+            String id,
+            String type,
+            String sourceClient,
+            String caption,
+            Map<String, Object> metadata,
+            Map<String, Object> segment,
+            Instant startTime,
+            Instant endTime,
+            Instant createdAt) {
+        public RawData {
+            metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+            segment = segment == null ? null : Map.copyOf(segment);
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindRecentResponse.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/response/MemindRecentResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record MemindRecentResponse(List<Entry> entries, String nextCursor) {
+
+    public MemindRecentResponse {
+        entries = entries == null ? List.of() : List.copyOf(entries);
+    }
+
+    public record Entry(
+            String kind,
+            String id,
+            String title,
+            String text,
+            String sourceClient,
+            Instant occurredAt,
+            Instant createdAt,
+            Map<String, Object> metadata) {
+        public Entry {
+            metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpSegmentLimiter.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpSegmentLimiter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.support;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class MemindMcpSegmentLimiter {
+
+    private static final String TRUNCATED_SUFFIX = "...[truncated]";
+
+    private MemindMcpSegmentLimiter() {}
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> limit(Map<String, Object> segment, int maxStringChars) {
+        if (segment == null) {
+            return null;
+        }
+        return (Map<String, Object>) limitValue(segment, maxStringChars);
+    }
+
+    private static Object limitValue(Object value, int maxStringChars) {
+        if (value instanceof String text) {
+            return limitString(text, maxStringChars);
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> limited = new LinkedHashMap<>();
+            map.forEach(
+                    (key, child) ->
+                            limited.put(String.valueOf(key), limitValue(child, maxStringChars)));
+            return Map.copyOf(limited);
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(child -> limitValue(child, maxStringChars)).toList();
+        }
+        return value;
+    }
+
+    private static String limitString(String text, int maxStringChars) {
+        if (maxStringChars <= 0 || text.length() <= maxStringChars) {
+            return text;
+        }
+        return text.substring(0, maxStringChars) + TRUNCATED_SUFFIX;
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpToolValidation.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpToolValidation.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.support;
+
+import java.util.List;
+import java.util.Map;
+
+public final class MemindMcpToolValidation {
+
+    private MemindMcpToolValidation() {}
+
+    public static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    public static String normalizeSourceClient(String value) {
+        if (value == null || value.isBlank()) {
+            return "mcp";
+        }
+        return value.trim();
+    }
+
+    public static List<String> requireStringIds(
+            List<String> values, String fieldName, int maxSize) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
+        if (values.size() > maxSize) {
+            throw new IllegalArgumentException(
+                    fieldName + " must contain at most " + maxSize + " values");
+        }
+        return values.stream().map(value -> requireListValue(value, fieldName)).toList();
+    }
+
+    public static List<Long> requireLongIds(List<String> values, String fieldName, int maxSize) {
+        return requireStringIds(values, fieldName, maxSize).stream()
+                .map(value -> parseLong(value, fieldName))
+                .toList();
+    }
+
+    public static Map<String, Object> requireMap(Map<String, Object> value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + " must not be null");
+        }
+        return Map.copyOf(value);
+    }
+
+    public static int effectivePositiveInt(
+            Integer value, int defaultValue, int maxValue, String fieldName) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value <= 0) {
+            throw new IllegalArgumentException(fieldName + " must be greater than 0");
+        }
+        return Math.min(value, maxValue);
+    }
+
+    private static String requireListValue(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not contain blank values");
+        }
+        return value.trim();
+    }
+
+    private static Long parseLong(String value, String fieldName) {
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(fieldName + " must contain numeric ids", exception);
+        }
+    }
+}

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/item/ItemQueryService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/item/ItemQueryService.java
@@ -43,4 +43,8 @@ public class ItemQueryService {
     public List<AdminItemView> listItemsByRawDataId(String rawDataId) {
         return itemQueryMapper.findByRawDataIds(List.of(rawDataId));
     }
+
+    public List<AdminItemView> listItemsByIds(List<Long> itemIds) {
+        return itemQueryMapper.findByBizIds(itemIds);
+    }
 }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryAssetQueryService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryAssetQueryService.java
@@ -23,11 +23,19 @@ import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryItemsRe
 import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryRawDataResponse;
 import com.openmemind.ai.memory.server.domain.rawdata.query.RawDataPageQuery;
 import com.openmemind.ai.memory.server.domain.rawdata.view.AdminRawDataView;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemSourcesResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemsGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRawDataGetResponse;
+import com.openmemind.ai.memory.server.mcp.support.MemindMcpSegmentLimiter;
 import com.openmemind.ai.memory.server.service.item.ItemQueryService;
 import com.openmemind.ai.memory.server.service.rawdata.RawDataQueryService;
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -65,6 +73,84 @@ public class OpenMemoryAssetQueryService {
         return new QueryMemoryItemsResponse(items, null);
     }
 
+    public MemindItemsGetResponse getItemsByIds(String userId, String agentId, List<Long> itemIds) {
+        List<AdminItemView> scopedItems =
+                itemQueryService.listItemsByIds(itemIds).stream()
+                        .filter(
+                                item ->
+                                        matchesScope(
+                                                item.userId(), item.agentId(), userId, agentId))
+                        .toList();
+        List<String> foundIds =
+                scopedItems.stream().map(AdminItemView::itemId).map(String::valueOf).toList();
+        List<String> requestedIds = itemIds.stream().map(String::valueOf).toList();
+        return new MemindItemsGetResponse(
+                scopedItems.stream().map(OpenMemoryAssetQueryService::toItemView).toList(),
+                missingIds(requestedIds, foundIds));
+    }
+
+    public MemindRawDataGetResponse getRawDataByIds(
+            String userId,
+            String agentId,
+            List<String> rawDataIds,
+            boolean includeSegment,
+            int maxSegmentChars) {
+        List<AdminRawDataView> scopedRawData =
+                rawDataQueryService.listRawDataByIds(rawDataIds).stream()
+                        .filter(raw -> matchesScope(raw.userId(), raw.agentId(), userId, agentId))
+                        .toList();
+        List<String> foundIds = scopedRawData.stream().map(AdminRawDataView::rawDataId).toList();
+        return new MemindRawDataGetResponse(
+                scopedRawData.stream()
+                        .map(raw -> toMcpRawData(raw, includeSegment, maxSegmentChars))
+                        .toList(),
+                missingIds(rawDataIds, foundIds));
+    }
+
+    public MemindItemSourcesResponse getItemSourcesByItemIds(
+            String userId,
+            String agentId,
+            List<Long> itemIds,
+            boolean includeSegment,
+            int maxSegmentChars) {
+        List<AdminItemView> scopedItems =
+                itemQueryService.listItemsByIds(itemIds).stream()
+                        .filter(
+                                item ->
+                                        matchesScope(
+                                                item.userId(), item.agentId(), userId, agentId))
+                        .toList();
+        List<String> foundItemIds =
+                scopedItems.stream().map(AdminItemView::itemId).map(String::valueOf).toList();
+        List<String> rawDataIds =
+                scopedItems.stream()
+                        .map(AdminItemView::rawDataId)
+                        .filter(OpenMemoryAssetQueryService::hasText)
+                        .distinct()
+                        .toList();
+        Map<String, AdminRawDataView> rawDataById =
+                rawDataQueryService.listRawDataByIds(rawDataIds).stream()
+                        .filter(raw -> matchesScope(raw.userId(), raw.agentId(), userId, agentId))
+                        .collect(
+                                Collectors.toMap(
+                                        AdminRawDataView::rawDataId,
+                                        Function.identity(),
+                                        (left, right) -> left));
+        List<MemindItemSourcesResponse.Source> sources =
+                scopedItems.stream()
+                        .map(
+                                item ->
+                                        toItemSource(
+                                                item,
+                                                rawDataById.get(item.rawDataId()),
+                                                includeSegment,
+                                                maxSegmentChars))
+                        .filter(Objects::nonNull)
+                        .toList();
+        List<String> requestedItemIds = itemIds.stream().map(String::valueOf).toList();
+        return new MemindItemSourcesResponse(sources, missingIds(requestedItemIds, foundItemIds));
+    }
+
     public QueryMemoryRawDataResponse queryRawData(QueryMemoryRawDataRequest request) {
         QueryMemoryRawDataRequest.TimeRange timeRange = request.timeRange();
         var page =
@@ -85,6 +171,56 @@ public class OpenMemoryAssetQueryService {
                         .map(raw -> toRawDataView(raw, include))
                         .toList();
         return new QueryMemoryRawDataResponse(rawData, null);
+    }
+
+    private static MemindRawDataGetResponse.RawData toMcpRawData(
+            AdminRawDataView rawData, boolean includeSegment, int maxSegmentChars) {
+        return new MemindRawDataGetResponse.RawData(
+                rawData.rawDataId(),
+                rawData.type(),
+                rawData.sourceClient(),
+                rawData.caption(),
+                rawData.metadata(),
+                includeSegment
+                        ? MemindMcpSegmentLimiter.limit(rawData.segment(), maxSegmentChars)
+                        : null,
+                rawData.startTime(),
+                rawData.endTime(),
+                rawData.createdAt());
+    }
+
+    private static MemindItemSourcesResponse.Source toItemSource(
+            AdminItemView item,
+            AdminRawDataView rawData,
+            boolean includeSegment,
+            int maxSegmentChars) {
+        if (rawData == null) {
+            return null;
+        }
+        return new MemindItemSourcesResponse.Source(
+                String.valueOf(item.itemId()),
+                rawData.rawDataId(),
+                rawData.type(),
+                rawData.caption(),
+                rawData.sourceClient(),
+                rawData.metadata(),
+                includeSegment
+                        ? MemindMcpSegmentLimiter.limit(rawData.segment(), maxSegmentChars)
+                        : null);
+    }
+
+    private static boolean matchesScope(
+            String actualUserId,
+            String actualAgentId,
+            String expectedUserId,
+            String expectedAgentId) {
+        return Objects.equals(actualUserId, expectedUserId)
+                && Objects.equals(actualAgentId, expectedAgentId);
+    }
+
+    private static List<String> missingIds(List<String> requestedIds, List<String> foundIds) {
+        var found = new LinkedHashSet<>(foundIds);
+        return requestedIds.stream().filter(id -> !found.contains(id)).toList();
     }
 
     private static boolean matchesMetadata(Map<String, Object> metadata, MetadataFilter filter) {
@@ -121,6 +257,10 @@ public class OpenMemoryAssetQueryService {
                 rawData.startTime(),
                 rawData.endTime(),
                 rawData.createdAt());
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private static Instant createdAt(AdminItemView item) {

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/rawdata/RawDataQueryService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/rawdata/RawDataQueryService.java
@@ -17,6 +17,7 @@ import com.openmemind.ai.memory.server.domain.common.PageResponse;
 import com.openmemind.ai.memory.server.domain.rawdata.query.RawDataPageQuery;
 import com.openmemind.ai.memory.server.domain.rawdata.view.AdminRawDataView;
 import com.openmemind.ai.memory.server.mapper.rawdata.AdminRawDataQueryMapper;
+import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 
@@ -37,5 +38,9 @@ public class RawDataQueryService {
         return rawDataQueryMapper
                 .findByBizId(rawDataId)
                 .orElseThrow(() -> new NoSuchElementException("Raw data not found: " + rawDataId));
+    }
+
+    public List<AdminRawDataView> listRawDataByIds(List<String> rawDataIds) {
+        return rawDataQueryMapper.findByBizIds(rawDataIds);
     }
 }

--- a/memind-server/src/main/resources/application.yml
+++ b/memind-server/src/main/resources/application.yml
@@ -73,6 +73,14 @@ server:
   port: ${SERVER_PORT:8366}
 
 memind:
+  mcp:
+    governance-enabled: ${MEMIND_MCP_GOVERNANCE_ENABLED:false}
+    default-token-budget: ${MEMIND_MCP_DEFAULT_TOKEN_BUDGET:1800}
+    max-token-budget: ${MEMIND_MCP_MAX_TOKEN_BUDGET:6000}
+    max-items-per-context: ${MEMIND_MCP_MAX_ITEMS_PER_CONTEXT:50}
+    max-result-limit: ${MEMIND_MCP_MAX_RESULT_LIMIT:100}
+    max-ids-per-request: ${MEMIND_MCP_MAX_IDS_PER_REQUEST:50}
+    max-raw-segment-chars: ${MEMIND_MCP_MAX_RAW_SEGMENT_CHARS:12000}
   vector:
     # Used only by the fallback local file vector store.
     # When an external VectorStore bean such as Qdrant is configured, this path is ignored.

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpApplicationTest.java
@@ -13,6 +13,7 @@
  */
 package com.openmemind.ai.memory.server.mcp;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -45,6 +46,37 @@ import org.springframework.web.context.WebApplicationContext;
 
 class MemindMcpApplicationTest {
 
+    private static final List<String> DEFAULT_TOOL_NAMES =
+            List.of(
+                    "memind_add_message",
+                    "memind_commit",
+                    "memind_compile_context",
+                    "memind_extract_rawdata",
+                    "memind_extract_text",
+                    "memind_items_get",
+                    "memind_items_search",
+                    "memind_items_sources",
+                    "memind_rawdata_get",
+                    "memind_rawdata_search",
+                    "memind_recent",
+                    "memind_retrieve");
+
+    private static final List<String> GOVERNANCE_TOOL_NAMES =
+            List.of(
+                    "memind_add_message",
+                    "memind_commit",
+                    "memind_compile_context",
+                    "memind_extract_rawdata",
+                    "memind_extract_text",
+                    "memind_forget",
+                    "memind_items_get",
+                    "memind_items_search",
+                    "memind_items_sources",
+                    "memind_rawdata_get",
+                    "memind_rawdata_search",
+                    "memind_recent",
+                    "memind_retrieve");
+
     @Nested
     @SpringBootTest(classes = {MemindServerApplication.class, NoopRuntimeTestConfiguration.class})
     class Enabled {
@@ -74,34 +106,21 @@ class MemindMcpApplicationTest {
         }
 
         @Test
-        void contextRegistersOnlyMemindMcpTools() {
+        void contextRegistersOnlyDefaultMemindMcpTools() {
             assertThat(applicationContext.getBeanNamesForType(MemindMcpToolService.class))
                     .hasSize(1);
+            assertThat(applicationContext.getBeanNamesForType(MemindMcpGovernanceToolService.class))
+                    .isEmpty();
             assertThat(applicationContext.getBeanNamesForType(McpStatelessSyncServer.class))
                     .hasSize(1);
 
-            assertThat(toolNames())
-                    .containsExactly(
-                            "memind_add_message",
-                            "memind_commit",
-                            "memind_extract_text",
-                            "memind_retrieve");
+            assertThat(toolNames()).containsExactlyElementsOf(DEFAULT_TOOL_NAMES);
         }
 
         @Test
         void toolsExposeFlatInputSchemas() {
-            Map<String, List<String>> requiredFieldsByTool =
-                    Map.of(
-                            "memind_retrieve", List.of("userId", "agentId", "query"),
-                            "memind_extract_text", List.of("userId", "agentId", "text"),
-                            "memind_add_message", List.of("userId", "agentId", "role", "content"),
-                            "memind_commit", List.of("userId", "agentId"));
-            Map<String, List<String>> optionalFieldsByTool =
-                    Map.of(
-                            "memind_retrieve", List.of("strategy", "trace"),
-                            "memind_extract_text", List.of("sourceClient"),
-                            "memind_add_message", List.of("sourceClient"),
-                            "memind_commit", List.of("sourceClient"));
+            Map<String, List<String>> requiredFieldsByTool = requiredFieldsByDefaultTool();
+            Map<String, List<String>> optionalFieldsByTool = optionalFieldsByDefaultTool();
 
             toolSpecifications()
                     .forEach(
@@ -116,15 +135,19 @@ class MemindMcpApplicationTest {
                                 assertThat(inputSchema.properties())
                                         .containsKeys(
                                                 expectedRequiredFields.toArray(String[]::new));
-                                assertThat(inputSchema.properties())
-                                        .containsKeys(
-                                                expectedOptionalFields.toArray(String[]::new));
+                                if (!expectedOptionalFields.isEmpty()) {
+                                    assertThat(inputSchema.properties())
+                                            .containsKeys(
+                                                    expectedOptionalFields.toArray(String[]::new));
+                                }
                                 assertThat(inputSchema.properties()).doesNotContainKey("request");
                                 assertThat(inputSchema.required())
                                         .containsExactlyInAnyOrderElementsOf(
                                                 expectedRequiredFields);
-                                assertThat(inputSchema.required())
-                                        .doesNotContainAnyElementsOf(expectedOptionalFields);
+                                if (!expectedOptionalFields.isEmpty()) {
+                                    assertThat(inputSchema.required())
+                                            .doesNotContainAnyElementsOf(expectedOptionalFields);
+                                }
                             });
         }
 
@@ -150,14 +173,82 @@ class MemindMcpApplicationTest {
                             jsonPath("$.result.tools[*].name")
                                     .value(
                                             containsInAnyOrder(
-                                                    "memind_add_message",
-                                                    "memind_commit",
-                                                    "memind_extract_text",
-                                                    "memind_retrieve")));
+                                                    DEFAULT_TOOL_NAMES.toArray(String[]::new))));
         }
 
         private MockMvc mcpClient() {
             return MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        }
+
+        private List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications() {
+            return syncToolSpecifications.stream().flatMap(List::stream).toList();
+        }
+
+        private List<String> toolNames() {
+            return toolSpecifications().stream().map(spec -> spec.tool().name()).sorted().toList();
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = {MemindServerApplication.class, NoopRuntimeTestConfiguration.class})
+    class GovernanceEnabled {
+
+        private static final Path DB_PATH =
+                Path.of("target", "memind-mcp-governance-" + UUID.randomUUID() + ".db")
+                        .toAbsolutePath();
+
+        @Autowired private ApplicationContext applicationContext;
+        @Autowired private WebApplicationContext webApplicationContext;
+
+        @Autowired
+        private ObjectProvider<List<McpStatelessServerFeatures.SyncToolSpecification>>
+                syncToolSpecifications;
+
+        @DynamicPropertySource
+        static void registerProperties(DynamicPropertyRegistry registry) {
+            prepareDatabasePath(DB_PATH);
+            registry.add("spring.main.web-application-type", () -> "servlet");
+            registry.add("spring.datasource.url", () -> "jdbc:sqlite:" + DB_PATH);
+            registry.add("spring.datasource.driver-class-name", () -> "org.sqlite.JDBC");
+            registry.add("memind.store.init-schema", () -> "true");
+            registry.add("spring.ai.mcp.server.enabled", () -> "true");
+            registry.add("memind.mcp.governance-enabled", () -> "true");
+            registry.add(
+                    "spring.autoconfigure.exclude",
+                    () -> NoopRuntimeTestConfiguration.SPRING_AI_AUTOCONFIG_EXCLUDES);
+        }
+
+        @Test
+        void contextRegistersGovernanceToolWhenEnabled() {
+            assertThat(applicationContext.getBeanNamesForType(MemindMcpGovernanceToolService.class))
+                    .hasSize(1);
+            assertThat(toolNames()).containsExactlyElementsOf(GOVERNANCE_TOOL_NAMES);
+        }
+
+        @Test
+        void mcpEndpointListsGovernanceToolWhenEnabled() throws Exception {
+            MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                    .build()
+                    .perform(
+                            post("/mcp")
+                                    .contentType(APPLICATION_JSON)
+                                    .accept(APPLICATION_JSON, TEXT_EVENT_STREAM)
+                                    .content(
+                                            """
+                                            {
+                                              "jsonrpc": "2.0",
+                                              "id": 1,
+                                              "method": "tools/list",
+                                              "params": {}
+                                            }
+                                            """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.error").doesNotExist())
+                    .andExpect(
+                            jsonPath("$.result.tools[*].name")
+                                    .value(
+                                            containsInAnyOrder(
+                                                    GOVERNANCE_TOOL_NAMES.toArray(String[]::new))));
         }
 
         private List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications() {
@@ -225,6 +316,65 @@ class MemindMcpApplicationTest {
                                             """))
                     .andExpect(status().is4xxClientError());
         }
+    }
+
+    private static Map<String, List<String>> requiredFieldsByDefaultTool() {
+        return Map.ofEntries(
+                entry("memind_add_message", List.of("userId", "agentId", "role", "content")),
+                entry("memind_commit", List.of("userId", "agentId")),
+                entry("memind_compile_context", List.of("userId", "agentId", "query")),
+                entry("memind_extract_rawdata", List.of("userId", "agentId", "type", "content")),
+                entry("memind_extract_text", List.of("userId", "agentId", "text")),
+                entry("memind_items_get", List.of("userId", "agentId", "ids")),
+                entry("memind_items_search", List.of("userId", "agentId")),
+                entry("memind_items_sources", List.of("userId", "agentId", "ids")),
+                entry("memind_rawdata_get", List.of("userId", "agentId", "ids")),
+                entry("memind_rawdata_search", List.of("userId", "agentId")),
+                entry("memind_recent", List.of("userId", "agentId")),
+                entry("memind_retrieve", List.of("userId", "agentId", "query")));
+    }
+
+    private static Map<String, List<String>> optionalFieldsByDefaultTool() {
+        return Map.ofEntries(
+                entry("memind_add_message", List.of("sourceClient")),
+                entry("memind_commit", List.of("sourceClient")),
+                entry(
+                        "memind_compile_context",
+                        List.of(
+                                "strategy",
+                                "maxItems",
+                                "tokenBudget",
+                                "includeSources",
+                                "metadataFilter")),
+                entry("memind_extract_rawdata", List.of("metadata", "sourceClient")),
+                entry("memind_extract_text", List.of("sourceClient")),
+                entry("memind_items_get", List.of()),
+                entry(
+                        "memind_items_search",
+                        List.of(
+                                "scope",
+                                "categories",
+                                "sourceClients",
+                                "rawDataTypes",
+                                "timeRange",
+                                "metadataFilter",
+                                "limit",
+                                "cursor")),
+                entry("memind_items_sources", List.of("includeSegment")),
+                entry("memind_rawdata_get", List.of("includeSegment")),
+                entry(
+                        "memind_rawdata_search",
+                        List.of(
+                                "types",
+                                "sourceClients",
+                                "timeRange",
+                                "metadataFilter",
+                                "includeSegment",
+                                "includeMetadata",
+                                "limit",
+                                "cursor")),
+                entry("memind_recent", List.of("types", "limit", "cursor", "metadataFilter")),
+                entry("memind_retrieve", List.of("strategy", "trace")));
     }
 
     private static void prepareDatabasePath(Path dbPath) {

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpGovernanceToolServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpGovernanceToolServiceTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.openmemind.ai.memory.server.domain.common.BatchDeleteResult;
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryItemsResponse;
+import com.openmemind.ai.memory.server.domain.rawdata.response.RawDataDeleteResult;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemsGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRawDataGetResponse;
+import com.openmemind.ai.memory.server.service.item.ItemDeleteService;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryAssetQueryService;
+import com.openmemind.ai.memory.server.service.rawdata.RawDataDeleteService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MemindMcpGovernanceToolServiceTest {
+
+    private final RecordingOpenMemoryAssetQueryService assetQueryService =
+            new RecordingOpenMemoryAssetQueryService();
+    private final RecordingItemDeleteService itemDeleteService = new RecordingItemDeleteService();
+    private final RecordingRawDataDeleteService rawDataDeleteService =
+            new RecordingRawDataDeleteService();
+    private final MemindMcpGovernanceToolService toolService =
+            new MemindMcpGovernanceToolService(
+                    assetQueryService,
+                    itemDeleteService,
+                    rawDataDeleteService,
+                    new MemindMcpToolProperties(true, 1800, 6000, 50, 100, 50, 12000));
+
+    @Test
+    void forgetDefaultsToDryRunAndDoesNotDeleteItems() {
+        assetQueryService.itemsResponse =
+                new MemindItemsGetResponse(List.of(item("101")), List.of("999"));
+
+        var response =
+                toolService.forget(
+                        "user-1", "agent-1", "ITEM", List.of("101", "999"), "obsolete", null);
+
+        assertThat(response.status()).isEqualTo("DRY_RUN");
+        assertThat(response.dryRun()).isTrue();
+        assertThat(response.blocked()).containsExactly("101");
+        assertThat(response.notFound()).containsExactly("999");
+        assertThat(response.deleted()).isEmpty();
+        assertThat(itemDeleteService.deletedIds).isNull();
+    }
+
+    @Test
+    void forgetDeletesOnlyScopedFoundItemsWhenDryRunIsFalse() {
+        assetQueryService.itemsResponse =
+                new MemindItemsGetResponse(List.of(item("101"), item("102")), List.of("999"));
+
+        var response =
+                toolService.forget(
+                        "user-1",
+                        "agent-1",
+                        "ITEM",
+                        List.of("101", "102", "999"),
+                        "user request",
+                        false);
+
+        assertThat(response.status()).isEqualTo("DELETED");
+        assertThat(response.dryRun()).isFalse();
+        assertThat(response.deleted()).containsExactly("101", "102");
+        assertThat(response.notFound()).containsExactly("999");
+        assertThat(response.blocked()).isEmpty();
+        assertThat(itemDeleteService.deletedIds).containsExactly(101L, 102L);
+    }
+
+    @Test
+    void forgetDeletesOnlyScopedFoundRawDataWhenDryRunIsFalse() {
+        assetQueryService.rawDataResponse =
+                new MemindRawDataGetResponse(List.of(rawData("rd-1")), List.of("rd-404"));
+
+        var response =
+                toolService.forget(
+                        "user-1",
+                        "agent-1",
+                        "RAWDATA",
+                        List.of("rd-1", "rd-404"),
+                        "cleanup",
+                        false);
+
+        assertThat(response.status()).isEqualTo("DELETED");
+        assertThat(response.deleted()).containsExactly("rd-1");
+        assertThat(response.notFound()).containsExactly("rd-404");
+        assertThat(rawDataDeleteService.deletedIds).containsExactly("rd-1");
+    }
+
+    @Test
+    void forgetRejectsInsightTargetType() {
+        assertThatThrownBy(
+                        () ->
+                                toolService.forget(
+                                        "user-1",
+                                        "agent-1",
+                                        "INSIGHT",
+                                        List.of("1"),
+                                        "cleanup",
+                                        true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("targetType must be one of ITEM, RAWDATA");
+    }
+
+    private static QueryMemoryItemsResponse.MemoryItemView item(String id) {
+        return new QueryMemoryItemsResponse.MemoryItemView(
+                id,
+                "content " + id,
+                "ALL",
+                "fact",
+                "FACT",
+                "rd-" + id,
+                "conversation",
+                "mcp",
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Map.of());
+    }
+
+    private static MemindRawDataGetResponse.RawData rawData(String id) {
+        return new MemindRawDataGetResponse.RawData(
+                id,
+                "conversation",
+                "mcp",
+                "caption",
+                Map.of(),
+                null,
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"));
+    }
+
+    private static final class RecordingOpenMemoryAssetQueryService
+            extends OpenMemoryAssetQueryService {
+
+        private MemindItemsGetResponse itemsResponse =
+                new MemindItemsGetResponse(List.of(), List.of());
+        private MemindRawDataGetResponse rawDataResponse =
+                new MemindRawDataGetResponse(List.of(), List.of());
+
+        private RecordingOpenMemoryAssetQueryService() {
+            super(null, null);
+        }
+
+        @Override
+        public MemindItemsGetResponse getItemsByIds(
+                String userId, String agentId, List<Long> itemIds) {
+            return itemsResponse;
+        }
+
+        @Override
+        public MemindRawDataGetResponse getRawDataByIds(
+                String userId,
+                String agentId,
+                List<String> rawDataIds,
+                boolean includeSegment,
+                int maxSegmentChars) {
+            return rawDataResponse;
+        }
+    }
+
+    private static final class RecordingItemDeleteService extends ItemDeleteService {
+
+        private List<Long> deletedIds;
+
+        private RecordingItemDeleteService() {
+            super(null, null);
+        }
+
+        @Override
+        public BatchDeleteResult deleteItems(List<Long> itemIds) {
+            this.deletedIds = List.copyOf(itemIds);
+            return new BatchDeleteResult(itemIds.size(), List.of("user-1:agent-1"));
+        }
+    }
+
+    private static final class RecordingRawDataDeleteService extends RawDataDeleteService {
+
+        private List<String> deletedIds;
+
+        private RecordingRawDataDeleteService() {
+            super(null, null, null, null);
+        }
+
+        @Override
+        public RawDataDeleteResult deleteRawData(List<String> rawDataIds) {
+            this.deletedIds = List.copyOf(rawDataIds);
+            return new RawDataDeleteResult(rawDataIds.size(), 0, List.of("user-1:agent-1"), true);
+        }
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolServiceTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/MemindMcpToolServiceTest.java
@@ -19,22 +19,43 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.ConversationContent;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
 import com.openmemind.ai.memory.core.retrieval.RetrievalConfig;
+import com.openmemind.ai.memory.core.utils.JsonUtils;
 import com.openmemind.ai.memory.server.domain.memory.request.AddMessageRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.CommitMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.ExtractMemoryRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryItemsRequest;
+import com.openmemind.ai.memory.server.domain.memory.request.QueryMemoryRawDataRequest;
 import com.openmemind.ai.memory.server.domain.memory.request.RetrieveMemoryRequest;
 import com.openmemind.ai.memory.server.domain.memory.response.AddMessageResponse;
 import com.openmemind.ai.memory.server.domain.memory.response.ExtractMemoryResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryItemsResponse;
+import com.openmemind.ai.memory.server.domain.memory.response.QueryMemoryRawDataResponse;
 import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.mcp.compiler.MemindMcpContextCompiler;
+import com.openmemind.ai.memory.server.mcp.config.MemindMcpToolProperties;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemSourcesResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindItemsGetResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindRawDataGetResponse;
 import com.openmemind.ai.memory.server.service.memory.OpenMemoryApplicationService;
+import com.openmemind.ai.memory.server.service.memory.OpenMemoryAssetQueryService;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class MemindMcpToolServiceTest {
 
     private final RecordingOpenMemoryApplicationService applicationService =
             new RecordingOpenMemoryApplicationService();
-    private final MemindMcpToolService toolService = new MemindMcpToolService(applicationService);
+    private final RecordingOpenMemoryAssetQueryService assetQueryService =
+            new RecordingOpenMemoryAssetQueryService();
+    private final MemindMcpToolService toolService =
+            new MemindMcpToolService(
+                    applicationService,
+                    assetQueryService,
+                    new MemindMcpContextCompiler(),
+                    new MemindMcpToolProperties(false, 1800, 6000, 50, 100, 50, 12000),
+                    JsonUtils.mapper());
 
     @Test
     void retrieveDefaultsToSimpleStrategy() {
@@ -73,6 +94,44 @@ class MemindMcpToolServiceTest {
     }
 
     @Test
+    void compileContextDelegatesToRetrieveHonorsMaxItemsAndIncludesSourcesByDefault() {
+        applicationService.retrieveResponse =
+                new RetrieveMemoryResponse(
+                        "success",
+                        List.of(
+                                item("1", "Always run tests", "directive"),
+                                item("2", "Second item", "tool")),
+                        List.of(),
+                        List.of(
+                                new RetrieveMemoryResponse.RetrievedRawDataView(
+                                        "rd-1",
+                                        "Test turn",
+                                        0.9,
+                                        List.of("1"),
+                                        "agent_timeline",
+                                        "claude-code",
+                                        Map.of(),
+                                        Instant.parse("2026-05-01T00:00:00Z"),
+                                        Instant.parse("2026-05-01T00:01:00Z"),
+                                        Instant.parse("2026-05-01T00:02:00Z"))),
+                        List.of(),
+                        "SIMPLE",
+                        "tests");
+
+        var response =
+                toolService.compileContext(
+                        "user-1", "agent-1", " tests ", null, 1, 1200, null, null);
+
+        assertThat(applicationService.lastRetrieveRequest.query()).isEqualTo("tests");
+        assertThat(response.contextText())
+                .contains("Always run tests")
+                .doesNotContain("Second item");
+        assertThat(response.sources())
+                .singleElement()
+                .satisfies(source -> assertThat(source.rawDataId()).isEqualTo("rd-1"));
+    }
+
+    @Test
     void extractTextCreatesConversationContentAndDefaultsSourceClient() {
         applicationService.extractResponse =
                 new ExtractMemoryResponse(
@@ -92,6 +151,32 @@ class MemindMcpToolServiceTest {
                             assertThat(message.role()).isEqualTo(Message.Role.USER);
                             assertThat(message.textContent()).isEqualTo("remember this");
                         });
+    }
+
+    @Test
+    void extractRawDataUsesRawContentMapperAndRejectsNestedType() {
+        applicationService.extractResponse =
+                new ExtractMemoryResponse(
+                        "SUCCESS", List.of("rd-1"), List.of(), List.of(), false, 1L, null);
+
+        toolService.extractRawData(
+                "user-1", "agent-1", "conversation", Map.of("messages", List.of()), null, null);
+
+        assertThat(applicationService.lastExtractRequest.rawContent())
+                .isInstanceOf(ConversationContent.class);
+        assertThat(applicationService.lastExtractRequest.sourceClient()).isEqualTo("mcp");
+
+        assertThatThrownBy(
+                        () ->
+                                toolService.extractRawData(
+                                        "user-1",
+                                        "agent-1",
+                                        "conversation",
+                                        Map.of("type", "tool_call"),
+                                        null,
+                                        null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("content must not contain type");
     }
 
     @Test
@@ -148,6 +233,87 @@ class MemindMcpToolServiceTest {
         assertThat(applicationService.lastCommitRequest).isNull();
     }
 
+    @Test
+    void itemsSearchDelegatesToAssetQueryServiceWithFilters() {
+        toolService.itemsSearch(
+                "user-1",
+                "agent-1",
+                "AGENT",
+                List.of("tool"),
+                List.of("claude-code"),
+                List.of("agent_timeline"),
+                null,
+                null,
+                10,
+                null);
+
+        QueryMemoryItemsRequest request = assetQueryService.lastItemsRequest;
+        assertThat(request.userId()).isEqualTo("user-1");
+        assertThat(request.agentId()).isEqualTo("agent-1");
+        assertThat(request.scope()).isEqualTo("AGENT");
+        assertThat(request.categories()).containsExactly("tool");
+        assertThat(request.sourceClients()).containsExactly("claude-code");
+        assertThat(request.rawDataTypes()).containsExactly("agent_timeline");
+        assertThat(request.limit()).isEqualTo(10);
+    }
+
+    @Test
+    void itemsGetParsesIdsAndDelegatesToScopedLookup() {
+        toolService.itemsGet("user-1", "agent-1", List.of(" 101 ", "102"));
+
+        assertThat(assetQueryService.lastItemIds).containsExactly(101L, 102L);
+    }
+
+    @Test
+    void itemsSourcesDefaultsIncludeSegmentFalse() {
+        toolService.itemsSources("user-1", "agent-1", List.of("101"), null);
+
+        assertThat(assetQueryService.lastIncludeSegment).isFalse();
+    }
+
+    @Test
+    void rawDataSearchDefaultsIncludeSegmentFalseAndMetadataTrue() {
+        toolService.rawDataSearch(
+                "user-1",
+                "agent-1",
+                List.of("agent_timeline"),
+                List.of("codex"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        QueryMemoryRawDataRequest request = assetQueryService.lastRawDataRequest;
+        assertThat(request.effectiveInclude().includeSegment()).isFalse();
+        assertThat(request.effectiveInclude().includeMetadata()).isTrue();
+    }
+
+    @Test
+    void rawDataGetDefaultsIncludeSegmentFalse() {
+        toolService.rawDataGet("user-1", "agent-1", List.of("rd-1"), null);
+
+        assertThat(assetQueryService.lastRawDataIds).containsExactly("rd-1");
+        assertThat(assetQueryService.lastIncludeSegment).isFalse();
+    }
+
+    @Test
+    void recentMergesItemsAndRawDataByTime() {
+        var response =
+                toolService.recent("user-1", "agent-1", List.of("ITEM", "RAWDATA"), 2, null, null);
+
+        assertThat(response.entries()).hasSize(2);
+        assertThat(response.entries().get(0).kind()).isEqualTo("RAWDATA");
+        assertThat(response.entries().get(1).kind()).isEqualTo("ITEM");
+    }
+
+    private static RetrieveMemoryResponse.RetrievedItemView item(
+            String id, String text, String category) {
+        return new RetrieveMemoryResponse.RetrievedItemView(
+                id, text, 1.0f, 1.0, Instant.parse("2026-05-01T00:00:00Z"), category, Map.of());
+    }
+
     private static final class RecordingOpenMemoryApplicationService
             extends OpenMemoryApplicationService {
 
@@ -192,6 +358,90 @@ class MemindMcpToolServiceTest {
         public ExtractMemoryResponse commit(CommitMemoryRequest request) {
             this.lastCommitRequest = request;
             return commitResponse;
+        }
+    }
+
+    private static final class RecordingOpenMemoryAssetQueryService
+            extends OpenMemoryAssetQueryService {
+
+        private QueryMemoryItemsRequest lastItemsRequest;
+        private QueryMemoryRawDataRequest lastRawDataRequest;
+        private List<Long> lastItemIds;
+        private List<String> lastRawDataIds;
+        private boolean lastIncludeSegment;
+
+        private RecordingOpenMemoryAssetQueryService() {
+            super(null, null);
+        }
+
+        @Override
+        public QueryMemoryItemsResponse queryItems(QueryMemoryItemsRequest request) {
+            this.lastItemsRequest = request;
+            return new QueryMemoryItemsResponse(
+                    List.of(
+                            new QueryMemoryItemsResponse.MemoryItemView(
+                                    "101",
+                                    "Run mvn test",
+                                    "AGENT",
+                                    "tool",
+                                    "FACT",
+                                    "rd-1",
+                                    "agent_timeline",
+                                    "claude-code",
+                                    Instant.parse("2026-05-01T00:00:00Z"),
+                                    Instant.parse("2026-05-01T00:01:00Z"),
+                                    Instant.parse("2026-05-01T00:02:00Z"),
+                                    Map.of())),
+                    null);
+        }
+
+        @Override
+        public QueryMemoryRawDataResponse queryRawData(QueryMemoryRawDataRequest request) {
+            this.lastRawDataRequest = request;
+            return new QueryMemoryRawDataResponse(
+                    List.of(
+                            new QueryMemoryRawDataResponse.MemoryRawDataView(
+                                    "rd-1",
+                                    "agent_timeline",
+                                    "claude-code",
+                                    "Fixed build",
+                                    Map.of(),
+                                    null,
+                                    Instant.parse("2026-05-01T00:03:00Z"),
+                                    Instant.parse("2026-05-01T00:04:00Z"),
+                                    Instant.parse("2026-05-01T00:05:00Z"))),
+                    null);
+        }
+
+        @Override
+        public MemindItemsGetResponse getItemsByIds(
+                String userId, String agentId, List<Long> itemIds) {
+            this.lastItemIds = itemIds;
+            return new MemindItemsGetResponse(List.of(), List.of());
+        }
+
+        @Override
+        public MemindItemSourcesResponse getItemSourcesByItemIds(
+                String userId,
+                String agentId,
+                List<Long> itemIds,
+                boolean includeSegment,
+                int maxSegmentChars) {
+            this.lastItemIds = itemIds;
+            this.lastIncludeSegment = includeSegment;
+            return new MemindItemSourcesResponse(List.of(), List.of());
+        }
+
+        @Override
+        public MemindRawDataGetResponse getRawDataByIds(
+                String userId,
+                String agentId,
+                List<String> rawDataIds,
+                boolean includeSegment,
+                int maxSegmentChars) {
+            this.lastRawDataIds = rawDataIds;
+            this.lastIncludeSegment = includeSegment;
+            return new MemindRawDataGetResponse(List.of(), List.of());
         }
     }
 }

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/compiler/MemindMcpContextCompilerTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/compiler/MemindMcpContextCompilerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.compiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.server.domain.memory.response.RetrieveMemoryResponse;
+import com.openmemind.ai.memory.server.mcp.response.MemindCompiledContextResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MemindMcpContextCompilerTest {
+
+    @Test
+    void groupsItemsInsightsAndSourcesWhileHonoringMaxItems() {
+        var response =
+                new RetrieveMemoryResponse(
+                        "success",
+                        List.of(
+                                new RetrieveMemoryResponse.RetrievedItemView(
+                                        "101",
+                                        "Always run mvn test",
+                                        0.9f,
+                                        0.95,
+                                        Instant.parse("2026-05-01T00:00:00Z"),
+                                        "directive",
+                                        Map.of()),
+                                new RetrieveMemoryResponse.RetrievedItemView(
+                                        "102",
+                                        "Fixed flaky auth test",
+                                        0.8f,
+                                        0.9,
+                                        Instant.parse("2026-05-02T00:00:00Z"),
+                                        "resolution",
+                                        Map.of())),
+                        List.of(
+                                new RetrieveMemoryResponse.RetrievedInsightView(
+                                        "i1", "Prefer SQLite WAL", "PROJECT")),
+                        List.of(
+                                new RetrieveMemoryResponse.RetrievedRawDataView(
+                                        "raw-1",
+                                        "Auth fix turn",
+                                        0.91,
+                                        List.of("101"),
+                                        "agent_timeline",
+                                        "claude-code",
+                                        Map.of("project", "memind"),
+                                        Instant.parse("2026-05-02T00:00:00Z"),
+                                        Instant.parse("2026-05-02T00:10:00Z"),
+                                        Instant.parse("2026-05-02T00:11:00Z"))),
+                        List.of(),
+                        "SIMPLE",
+                        "auth");
+
+        MemindCompiledContextResponse compiled =
+                new MemindMcpContextCompiler().compile(response, 1, 1200, true);
+
+        assertThat(compiled.contextText())
+                .contains("## Must Follow")
+                .contains("Always run mvn test")
+                .contains("## Insights")
+                .contains("Prefer SQLite WAL")
+                .contains("## Recent Context")
+                .contains("Auth fix turn")
+                .doesNotContain("Fixed flaky auth test");
+        assertThat(compiled.sections())
+                .extracting(MemindCompiledContextResponse.Section::name)
+                .containsExactly("Must Follow", "Insights", "Recent Context");
+        assertThat(compiled.sources())
+                .singleElement()
+                .satisfies(
+                        source -> {
+                            assertThat(source.itemIds()).contains("101");
+                            assertThat(source.rawDataId()).isEqualTo("raw-1");
+                            assertThat(source.sourceClient()).isEqualTo("claude-code");
+                        });
+    }
+
+    @Test
+    void marksTruncatedWhenTokenBudgetCutsContextText() {
+        var response =
+                new RetrieveMemoryResponse(
+                        "success",
+                        List.of(
+                                new RetrieveMemoryResponse.RetrievedItemView(
+                                        "1",
+                                        "abcdefghijklmnopqrstuvwxyz",
+                                        1.0f,
+                                        1.0,
+                                        null,
+                                        "fact",
+                                        Map.of())),
+                        List.of(),
+                        List.of(),
+                        List.of(),
+                        "SIMPLE",
+                        "letters");
+
+        var compiled = new MemindMcpContextCompiler().compile(response, 10, 2, false);
+
+        assertThat(compiled.truncated()).isTrue();
+        assertThat(compiled.contextText()).contains("[truncated]");
+        assertThat(compiled.sources()).isEmpty();
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpSegmentLimiterTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpSegmentLimiterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MemindMcpSegmentLimiterTest {
+
+    @Test
+    void truncatesLongStringValuesRecursively() {
+        var limited =
+                MemindMcpSegmentLimiter.limit(
+                        Map.of("nested", Map.of("list", List.of("abcdef"))), 4);
+
+        assertThat(limited).containsEntry("nested", Map.of("list", List.of("abcd...[truncated]")));
+    }
+
+    @Test
+    void leavesNullSegmentNull() {
+        assertThat(MemindMcpSegmentLimiter.limit(null, 4)).isNull();
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpToolValidationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/mcp/support/MemindMcpToolValidationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.mcp.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MemindMcpToolValidationTest {
+
+    @Test
+    void requireTextTrimsAndRejectsBlank() {
+        assertThat(MemindMcpToolValidation.requireText(" value ", "field")).isEqualTo("value");
+
+        assertThatThrownBy(() -> MemindMcpToolValidation.requireText(" ", "field"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("field must not be blank");
+    }
+
+    @Test
+    void normalizeSourceClientDefaultsToMcp() {
+        assertThat(MemindMcpToolValidation.normalizeSourceClient(null)).isEqualTo("mcp");
+        assertThat(MemindMcpToolValidation.normalizeSourceClient(" cli ")).isEqualTo("cli");
+    }
+
+    @Test
+    void requireIdListTrimsRejectsBlankAndCapsSize() {
+        assertThat(MemindMcpToolValidation.requireStringIds(List.of(" a ", "b"), "ids", 3))
+                .containsExactly("a", "b");
+
+        assertThatThrownBy(
+                        () -> MemindMcpToolValidation.requireStringIds(List.of("a", " "), "ids", 3))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids must not contain blank values");
+
+        assertThatThrownBy(
+                        () -> MemindMcpToolValidation.requireStringIds(List.of("a", "b"), "ids", 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids must contain at most 1 values");
+    }
+
+    @Test
+    void requireMapRejectsNullAndReturnsCopy() {
+        assertThat(MemindMcpToolValidation.requireMap(Map.of("text", "hello"), "content"))
+                .containsEntry("text", "hello");
+
+        assertThatThrownBy(() -> MemindMcpToolValidation.requireMap(null, "content"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("content must not be null");
+    }
+
+    @Test
+    void effectivePositiveIntAppliesDefaultAndMax() {
+        assertThat(MemindMcpToolValidation.effectivePositiveInt(null, 20, 100, "limit"))
+                .isEqualTo(20);
+        assertThat(MemindMcpToolValidation.effectivePositiveInt(200, 20, 100, "limit"))
+                .isEqualTo(100);
+
+        assertThatThrownBy(() -> MemindMcpToolValidation.effectivePositiveInt(0, 20, 100, "limit"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("limit must be greater than 0");
+    }
+}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryAssetQueryServiceMcpTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/service/memory/OpenMemoryAssetQueryServiceMcpTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.server.service.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.openmemind.ai.memory.server.domain.item.view.AdminItemView;
+import com.openmemind.ai.memory.server.domain.rawdata.view.AdminRawDataView;
+import com.openmemind.ai.memory.server.service.item.ItemQueryService;
+import com.openmemind.ai.memory.server.service.rawdata.RawDataQueryService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenMemoryAssetQueryServiceMcpTest {
+
+    private final ItemQueryService itemQueryService = mock(ItemQueryService.class);
+    private final RawDataQueryService rawDataQueryService = mock(RawDataQueryService.class);
+    private final OpenMemoryAssetQueryService service =
+            new OpenMemoryAssetQueryService(itemQueryService, rawDataQueryService);
+
+    @Test
+    void getItemsByIdsFiltersByUserAndAgentScope() {
+        when(itemQueryService.listItemsByIds(List.of(1L, 2L)))
+                .thenReturn(List.of(item("u1", "a1", 1L, "raw-1"), item("u2", "a1", 2L, "raw-2")));
+
+        var result = service.getItemsByIds("u1", "a1", List.of(1L, 2L));
+
+        assertThat(result.items())
+                .singleElement()
+                .satisfies(item -> assertThat(item.id()).isEqualTo("1"));
+        assertThat(result.missingItemIds()).containsExactly("2");
+    }
+
+    @Test
+    void getRawDataByIdsFiltersByUserAndAgentScopeAndHidesSegmentByDefault() {
+        when(rawDataQueryService.listRawDataByIds(List.of("raw-1", "raw-2")))
+                .thenReturn(List.of(raw("u1", "a1", "raw-1"), raw("u2", "a1", "raw-2")));
+
+        var result = service.getRawDataByIds("u1", "a1", List.of("raw-1", "raw-2"), false, 100);
+
+        assertThat(result.rawData())
+                .singleElement()
+                .satisfies(raw -> assertThat(raw.id()).isEqualTo("raw-1"));
+        assertThat(result.rawData().get(0).segment()).isNull();
+        assertThat(result.missingRawDataIds()).containsExactly("raw-2");
+    }
+
+    @Test
+    void getItemSourcesReturnsScopedRawDataForScopedItemsOnly() {
+        when(itemQueryService.listItemsByIds(List.of(1L, 2L)))
+                .thenReturn(List.of(item("u1", "a1", 1L, "raw-1"), item("u2", "a1", 2L, "raw-2")));
+        when(rawDataQueryService.listRawDataByIds(List.of("raw-1")))
+                .thenReturn(List.of(raw("u1", "a1", "raw-1")));
+
+        var result = service.getItemSourcesByItemIds("u1", "a1", List.of(1L, 2L), true, 100);
+
+        assertThat(result.sources())
+                .singleElement()
+                .satisfies(
+                        source -> {
+                            assertThat(source.itemId()).isEqualTo("1");
+                            assertThat(source.rawDataId()).isEqualTo("raw-1");
+                            assertThat(source.segment()).containsEntry("text", "segment");
+                        });
+        assertThat(result.missingItemIds()).containsExactly("2");
+    }
+
+    private static AdminItemView item(
+            String userId, String agentId, Long itemId, String rawDataId) {
+        return new AdminItemView(
+                itemId,
+                userId,
+                agentId,
+                userId + ":" + agentId,
+                "content " + itemId,
+                "ALL",
+                "fact",
+                "vector-" + itemId,
+                rawDataId,
+                "hash-" + itemId,
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Map.of(),
+                "FACT",
+                "conversation",
+                "mcp",
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"));
+    }
+
+    private static AdminRawDataView raw(String userId, String agentId, String rawDataId) {
+        return new AdminRawDataView(
+                rawDataId,
+                userId,
+                agentId,
+                userId + ":" + agentId,
+                "conversation",
+                "mcp",
+                "content-id",
+                Map.of("text", "segment"),
+                "caption",
+                "caption-vector",
+                Map.of("key", "value"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a broader default MCP memory tool surface for context compilation, recent activity, typed rawdata ingestion, item/rawdata search, and provenance lookup.
- Add optional scoped governance deletion via memind_forget behind MEMIND_MCP_GOVERNANCE_ENABLED.
- Add MCP validation, response shaping, segment limiting, scoped asset lookup services, and documentation.

## Tests
- mvn -pl memind-server -am test
- mvn -pl memind-server spotless:check checkstyle:check