### PR TITLE
Polish README hero and benchmark badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,22 @@
 
 <h1 align="center">Memind</h1>
 
+<h3 align="center">
+  <em>Memory that thinks. Context that evolves.</em>
+</h3>
+
 <p align="center">
-  <strong>Memory that thinks. Context that evolves.</strong>
+  <strong>The memory layer that lets AI systems learn from every conversation,<br>
+  tool call, document, and resolved task.</strong>
 </p>
 
 <p align="center">
-  The memory layer that lets AI systems learn from every conversation,
-  tool call, document, and resolved task.
-</p>
-
-<p align="center">
-  Memind turns raw context into structured memory and reusable experience,
-  continuously organizes it into memory graphs, threads, and evolving Insight Trees,
-  then recalls the right context through REST, MCP, SDKs, and first-party plugins
-  for popular agents.
+  <sub>
+    Memind turns raw context into <strong>structured memory</strong> and <strong>reusable experience</strong>,
+    continuously organizes it into <strong>memory graphs</strong>, <strong>threads</strong>, and evolving
+    <strong>Insight Trees</strong>, then recalls the right context through <strong>REST</strong>,
+    <strong>MCP</strong>, <strong>SDKs</strong>, and first-party plugins for popular agents.
+  </sub>
 </p>
 
 <p align="center">
@@ -29,9 +31,9 @@
 </p>
 
 <p align="center">
-  <a href="#benchmark"><img src="./docs/images/badges/locomo.svg" alt="LoCoMo 86.88%" height="38"></a>
-  <a href="#benchmark"><img src="./docs/images/badges/longmemeval.svg" alt="LongMemEval 84.20%" height="38"></a>
-  <a href="#benchmark"><img src="./docs/images/badges/personamem.svg" alt="PersonaMem 67.91%" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/locomo.svg" alt="LoCoMo rank #1 among listed baselines" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/longmemeval.svg" alt="LongMemEval rank #1 among listed baselines" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/personamem.svg" alt="PersonaMem rank #1 among listed baselines" height="38"></a>
   <a href="#mcp-server"><img src="./docs/images/badges/mcp-tools.svg" alt="11+ MCP tools" height="38"></a>
   <a href="#official-api-clients"><img src="./docs/images/badges/sdks.svg" alt="5 SDKs" height="38"></a>
   <a href="#agent-integrations"><img src="./docs/images/badges/agent-plugins.svg" alt="4 agent plugins" height="38"></a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,19 +4,21 @@
 
 <h1 align="center">Memind</h1>
 
+<h3 align="center">
+  <em>让记忆形成理解，让上下文持续进化。</em>
+</h3>
+
 <p align="center">
-  <strong>能思考的记忆，能进化的上下文。</strong>
+  <strong>让 AI 系统从每一次对话、工具调用、文档和已解决任务中持续学习的记忆层。</strong>
 </p>
 
 <p align="center">
-  让 AI 系统从每一次对话、工具调用、文档和已解决任务中持续学习的记忆层。
-</p>
-
-<p align="center">
-  Memind 将原始上下文沉淀为结构化记忆和可复用经验，
-  持续组织成 Memory Graph、Memory Thread 和不断演化的 Insight Tree，
-  再通过 REST、MCP、多语言 SDK，以及面向主流 Agent 的官方插件，
-  召回正确上下文。
+  <sub>
+    Memind 将原始上下文沉淀为 <strong>结构化记忆</strong> 和 <strong>可复用经验</strong>，
+    持续组织成 <strong>Memory Graph</strong>、<strong>Memory Thread</strong> 和不断演化的
+    <strong>Insight Tree</strong>，再通过 <strong>REST</strong>、<strong>MCP</strong>、
+    <strong>多语言 SDK</strong> 以及面向主流 Agent 的官方插件召回正确上下文。
+  </sub>
 </p>
 
 <p align="center">
@@ -28,9 +30,9 @@
 </p>
 
 <p align="center">
-  <a href="#benchmark"><img src="./docs/images/badges/locomo.svg" alt="LoCoMo 86.88%" height="38"></a>
-  <a href="#benchmark"><img src="./docs/images/badges/longmemeval.svg" alt="LongMemEval 84.20%" height="38"></a>
-  <a href="#benchmark"><img src="./docs/images/badges/personamem.svg" alt="PersonaMem 67.91%" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/locomo.svg" alt="LoCoMo rank #1 among listed baselines" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/longmemeval.svg" alt="LongMemEval rank #1 among listed baselines" height="38"></a>
+  <a href="#benchmark"><img src="./docs/images/badges/personamem.svg" alt="PersonaMem rank #1 among listed baselines" height="38"></a>
   <a href="#mcp-server"><img src="./docs/images/badges/mcp-tools.svg" alt="11+ MCP tools" height="38"></a>
   <a href="#official-api-clients"><img src="./docs/images/badges/sdks.svg" alt="5 SDKs" height="38"></a>
   <a href="#agent-integrations"><img src="./docs/images/badges/agent-plugins.svg" alt="4 agent plugins" height="38"></a>

--- a/docs/images/badges/locomo.svg
+++ b/docs/images/badges/locomo.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="LoCoMo: 86.88%">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="LoCoMo: rank #1 among listed baselines">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#111827"/>
   <rect x="0.5" y="0.5" width="139" height="47" rx="9.5" stroke="url(#border)" stroke-opacity="0.92"/>
   <rect x="1" y="1" width="138" height="46" rx="9" fill="url(#shine)" opacity="0.62"/>
-  <text x="70" y="24" fill="#22C55E" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.2">86.88%</text>
-  <text x="70" y="38" fill="#CBD5E1" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="9" font-weight="700" text-anchor="middle" letter-spacing="1.45">LOCOMO</text>
+  <text x="70" y="20" fill="#22C55E" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="21" font-weight="900" text-anchor="middle" letter-spacing="-0.2">#1</text>
+  <text x="70" y="33" fill="#E5E7EB" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="8.8" font-weight="800" text-anchor="middle" letter-spacing="1.45">LOCOMO</text>
+  <text x="70" y="42" fill="#94A3B8" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="6.4" font-weight="700" text-anchor="middle" letter-spacing="0.75">LISTED BASELINES</text>
   <defs>
     <linearGradient id="border" x1="0" y1="0" x2="140" y2="48">
       <stop stop-color="#22C55E"/>

--- a/docs/images/badges/longmemeval.svg
+++ b/docs/images/badges/longmemeval.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="LongMemEval: 84.20%">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="LongMemEval: rank #1 among listed baselines">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#111827"/>
   <rect x="0.5" y="0.5" width="139" height="47" rx="9.5" stroke="url(#border)" stroke-opacity="0.92"/>
   <rect x="1" y="1" width="138" height="46" rx="9" fill="url(#shine)" opacity="0.62"/>
-  <text x="70" y="24" fill="#10B981" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.2">84.20%</text>
-  <text x="70" y="38" fill="#CBD5E1" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="8.2" font-weight="700" text-anchor="middle" letter-spacing="0.9">LONGMEMEVAL</text>
+  <text x="70" y="20" fill="#10B981" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="21" font-weight="900" text-anchor="middle" letter-spacing="-0.2">#1</text>
+  <text x="70" y="33" fill="#E5E7EB" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="8" font-weight="800" text-anchor="middle" letter-spacing="0.9">LONGMEMEVAL</text>
+  <text x="70" y="42" fill="#94A3B8" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="6.4" font-weight="700" text-anchor="middle" letter-spacing="0.75">LISTED BASELINES</text>
   <defs>
     <linearGradient id="border" x1="0" y1="0" x2="140" y2="48">
       <stop stop-color="#10B981"/>

--- a/docs/images/badges/personamem.svg
+++ b/docs/images/badges/personamem.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="PersonaMem: 67.91%">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" fill="none" role="img" aria-label="PersonaMem: rank #1 among listed baselines">
   <rect x="0" y="0" width="140" height="48" rx="10" fill="#111827"/>
   <rect x="0.5" y="0.5" width="139" height="47" rx="9.5" stroke="url(#border)" stroke-opacity="0.92"/>
   <rect x="1" y="1" width="138" height="46" rx="9" fill="url(#shine)" opacity="0.62"/>
-  <text x="70" y="24" fill="#A3E635" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle" letter-spacing="-0.2">67.91%</text>
-  <text x="70" y="38" fill="#CBD5E1" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="8.4" font-weight="700" text-anchor="middle" letter-spacing="0.95">PERSONAMEM</text>
+  <text x="70" y="20" fill="#A3E635" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="21" font-weight="900" text-anchor="middle" letter-spacing="-0.2">#1</text>
+  <text x="70" y="33" fill="#E5E7EB" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="8.2" font-weight="800" text-anchor="middle" letter-spacing="0.95">PERSONAMEM</text>
+  <text x="70" y="42" fill="#94A3B8" font-family="ui-sans-serif, -apple-system, Segoe UI, Inter, system-ui, Arial, sans-serif" font-size="6.4" font-weight="700" text-anchor="middle" letter-spacing="0.75">LISTED BASELINES</text>
   <defs>
     <linearGradient id="border" x1="0" y1="0" x2="140" y2="48">
       <stop stop-color="#A3E635"/>


### PR DESCRIPTION
## Summary
- Restyle the README hero tagline and positioning copy for clearer visual hierarchy in English and Chinese.
- Update the Chinese tagline to better express Memind's structured understanding and evolving context.
- Change the three benchmark badges from raw scores to rank-focused #1 badges scoped to the listed baselines.

## Verification
- xmllint --noout docs/images/badges/*.svg
- git diff --check origin/main...HEAD