### PR TITLE
Restore README hero body text size

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,15 @@
 </h3>
 
 <p align="center">
-  <strong>The memory layer that lets AI systems learn from every conversation,<br>
-  tool call, document, and resolved task.</strong>
+  The memory layer that lets AI systems learn from every conversation,
+  tool call, document, and resolved task.
 </p>
 
 <p align="center">
-  <sub>
-    Memind turns raw context into <strong>structured memory</strong> and <strong>reusable experience</strong>,
-    continuously organizes it into <strong>memory graphs</strong>, <strong>threads</strong>, and evolving
-    <strong>Insight Trees</strong>, then recalls the right context through <strong>REST</strong>,
-    <strong>MCP</strong>, <strong>SDKs</strong>, and first-party plugins for popular agents.
-  </sub>
+  Memind turns raw context into structured memory and reusable experience,
+  continuously organizes it into memory graphs, threads, and evolving Insight Trees,
+  then recalls the right context through REST, MCP, SDKs, and first-party plugins
+  for popular agents.
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,16 +9,14 @@
 </h3>
 
 <p align="center">
-  <strong>让 AI 系统从每一次对话、工具调用、文档和已解决任务中持续学习的记忆层。</strong>
+  让 AI 系统从每一次对话、工具调用、文档和已解决任务中持续学习的记忆层。
 </p>
 
 <p align="center">
-  <sub>
-    Memind 将原始上下文沉淀为 <strong>结构化记忆</strong> 和 <strong>可复用经验</strong>，
-    持续组织成 <strong>Memory Graph</strong>、<strong>Memory Thread</strong> 和不断演化的
-    <strong>Insight Tree</strong>，再通过 <strong>REST</strong>、<strong>MCP</strong>、
-    <strong>多语言 SDK</strong> 以及面向主流 Agent 的官方插件召回正确上下文。
-  </sub>
+  Memind 将原始上下文沉淀为结构化记忆和可复用经验，
+  持续组织成 Memory Graph、Memory Thread 和不断演化的 Insight Tree，
+  再通过 REST、MCP、多语言 SDK，以及面向主流 Agent 的官方插件，
+  召回正确上下文。
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Restore the README hero positioning copy to normal paragraph text size in both English and Chinese.
- Remove the small-text sub treatment and full-line bolding introduced in the previous hero polish.
- Keep the updated tagline and benchmark rank badges unchanged.

## Verification
- git diff --check origin/main..HEAD
- xmllint --noout docs/images/badges/*.svg