### PR TITLE
Add configurable AI client routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy this file to .env for Docker Compose.
+# The default placeholder starts the service, but real memory extraction,
+# retrieval, and embedding calls require valid provider credentials.
+
+# Default OpenAI-compatible provider used by spring.ai.openai and the
+# memind.ai "openai" routing client.
+OPENAI_API_KEY=your-api-key
+OPENAI_BASE_URL=https://openrouter.ai/api
+OPENAI_CHAT_MODEL=openai/gpt-4o-mini
+OPENAI_CHAT_TEMPERATURE=0.2
+
+# Optional embedding override. When left blank, the server uses OPENAI_API_KEY
+# and OPENAI_BASE_URL through application.yml fallbacks.
+EMBEDDING_API_KEY=
+EMBEDDING_BASE_URL=
+OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small
+
+# Optional keys for additional memind.ai chat or embedding clients that you
+# configure in memind-server/src/main/resources/application.yml.
+DEEPSEEK_API_KEY=
+GLM_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+SILICONFLOW_API_KEY=
+
+# Optional reranker for deep retrieval. Leave MEMIND_RERANK_API_KEY blank to
+# keep the default no-op reranker.
+MEMIND_RERANK_BASE_URL=https://aihubmix.com
+MEMIND_RERANK_API_KEY=
+MEMIND_RERANK_MODEL=jina-reranker-v3

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ target/
 .worktrees/
 .corepack/
 
+### Local environment ###
+.env
+.env.*
+!.env.example
+
 ### Mac OS ###
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -106,38 +106,49 @@ Maven, Node.js, or pnpm on the host.
 ### Prerequisites
 
 - Docker with the Compose plugin
-- A chat model key and an embedding model key. The default config uses the same `OPENAI_API_KEY`
-  for an OpenAI-compatible chat and embedding endpoint.
+- Provider credentials for the chat and embedding models you want to use. The default
+  configuration uses one OpenAI-compatible provider for both chat and embeddings.
 
 ### Configure credentials
 
-Create a local `.env` file in the repository root. `docker-compose.yml` reads these values
-automatically:
+Create a local `.env` file from the example. Docker Compose reads it automatically:
 
 ```bash
-# Required by the default application.yml.
-OPENAI_API_KEY=your-key
-
-# Optional. Add only the keys referenced by your application.yml clients.
-DEEPSEEK_API_KEY=
-GLM_API_KEY=
-ANTHROPIC_API_KEY=
-GEMINI_API_KEY=
-SILICONFLOW_API_KEY=
-
-# Optional. Required only when you want an external rerank provider for deep retrieval.
-MEMIND_RERANK_API_KEY=
+cp .env.example .env
 ```
 
-Model providers, base URLs, models, and slot routing are configured in
-[`memind-server/src/main/resources/application.yml`](./memind-server/src/main/resources/application.yml).
-The default config uses one OpenAI-compatible client for all chat slots and one embedding client.
-Unconfigured slots automatically fall back to `default-client`.
+The example uses `OPENAI_API_KEY=your-api-key` as a startup-safe placeholder. Replace it with a
+real key before running memory extraction, retrieval, or embedding calls.
+
+AI configuration has two layers:
+
+- `spring.ai.*` defines provider defaults and model options, using Spring AI's native property
+  structure where available.
+- `memind.ai.*` defines Memind's named clients, embedding client, and chat-client slot routing.
+
+The default [`application.yml`](./memind-server/src/main/resources/application.yml) defines one
+`openai` chat client and one `openai` embedding client. Both inherit base URL, API key, model, and
+common options from `spring.ai.openai.*`. Unconfigured chat slots automatically fall back to
+`default-client`.
 
 Example: route most stages to DeepSeek, Insight generation to DeepSeek Reasoner, group
 classification to GLM, and thread enrichment to Claude:
 
 ```yaml
+spring:
+  ai:
+    openai:
+      base-url: ${OPENAI_BASE_URL:https://openrouter.ai/api}
+      api-key: ${OPENAI_API_KEY:your-api-key}
+      chat:
+        options:
+          model: ${OPENAI_CHAT_MODEL:openai/gpt-4o-mini}
+      embedding:
+        base-url: ${EMBEDDING_BASE_URL:${OPENAI_BASE_URL:https://openrouter.ai/api}}
+        api-key: ${EMBEDDING_API_KEY:${OPENAI_API_KEY:your-api-key}}
+        options:
+          model: ${OPENAI_EMBEDDING_MODEL:openai/text-embedding-3-small}
+
 memind:
   ai:
     chat:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Maven, Node.js, or pnpm on the host.
 ### Prerequisites
 
 - Docker with the Compose plugin
-- An OpenAI-compatible chat and embedding provider key
+- A chat model key and an embedding model key. The default config uses the same `OPENAI_API_KEY`
+  for an OpenAI-compatible chat and embedding endpoint.
 
 ### Configure credentials
 
@@ -114,28 +115,71 @@ Create a local `.env` file in the repository root. `docker-compose.yml` reads th
 automatically:
 
 ```bash
-# Required.
+# Required by the default application.yml.
 OPENAI_API_KEY=your-key
 
-# Optional provider and model overrides.
-OPENAI_BASE_URL=https://openrouter.ai/api
-OPENAI_CHAT_MODEL=openai/gpt-4o-mini
-OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small
+# Optional. Add only the keys referenced by your application.yml clients.
+DEEPSEEK_API_KEY=
+GLM_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+SILICONFLOW_API_KEY=
 
 # Optional. Required only when you want an external rerank provider for deep retrieval.
-MEMIND_RERANK_BASE_URL=https://aihubmix.com
 MEMIND_RERANK_API_KEY=
-MEMIND_RERANK_MODEL=jina-reranker-v3
-
-# Optional host ports.
-MEMIND_SERVER_PORT=8366
-MEMIND_UI_PORT=8080
 ```
 
-`OPENAI_BASE_URL`, `OPENAI_CHAT_MODEL`, and `OPENAI_EMBEDDING_MODEL` are optional.
-The chat and embedding model choices directly affect memory extraction, insight quality,
-and retrieval quality. If your embedding provider uses a different endpoint or key from chat,
-also set `EMBEDDING_BASE_URL` and `EMBEDDING_API_KEY`.
+Model providers, base URLs, models, and slot routing are configured in
+[`memind-server/src/main/resources/application.yml`](./memind-server/src/main/resources/application.yml).
+The default config uses one OpenAI-compatible client for all chat slots and one embedding client.
+Unconfigured slots automatically fall back to `default-client`.
+
+Example: route most stages to DeepSeek, Insight generation to DeepSeek Reasoner, group
+classification to GLM, and thread enrichment to Claude:
+
+```yaml
+memind:
+  ai:
+    chat:
+      default-client: ds
+      clients:
+        ds:
+          provider: openai
+          base-url: https://api.deepseek.com
+          api-key: ${DEEPSEEK_API_KEY}
+          model: deepseek-chat
+        ds_reasoner:
+          provider: openai
+          base-url: https://api.deepseek.com
+          api-key: ${DEEPSEEK_API_KEY}
+          model: deepseek-reasoner
+        glm:
+          provider: openai
+          base-url: https://open.bigmodel.cn/api/paas/v4
+          api-key: ${GLM_API_KEY}
+          model: glm-4.5
+        claude:
+          provider: anthropic
+          api-key: ${ANTHROPIC_API_KEY}
+          model: claude-sonnet-4-5
+      slots:
+        ITEM_EXTRACTION: ds
+        INSIGHT_GENERATOR: ds_reasoner
+        INSIGHT_GROUP_CLASSIFIER: glm
+        THREAD_ENRICHMENT: claude
+    embedding:
+      client: embedding
+      clients:
+        embedding:
+          provider: openai
+          base-url: https://api.siliconflow.cn/v1
+          api-key: ${SILICONFLOW_API_KEY}
+          model: BAAI/bge-m3
+```
+
+Supported chat providers are `openai` for OpenAI-compatible endpoints, `anthropic`,
+`gemini`, and `ollama`. Supported embedding providers are `openai`, `gemini`, and `ollama`.
+For full configuration guidance, see [docs.openmemind.com](https://docs.openmemind.com).
 
 ### Start the stack
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -108,35 +108,79 @@ React 管理 UI，不需要在宿主机安装 Java、Maven、Node.js 或 pnpm。
 ### 前置要求
 
 - Docker，并已启用 Compose 插件
-- 一个兼容 OpenAI 协议的 chat 和 embedding 服务密钥
+- 一个 chat model 密钥和一个 embedding model 密钥。默认配置会把同一个 `OPENAI_API_KEY`
+  用于兼容 OpenAI 协议的 chat 和 embedding endpoint。
 
 ### 配置凭据
 
 在仓库根目录创建本地 `.env` 文件。`docker-compose.yml` 会自动读取这些变量：
 
 ```bash
-# 必填。
+# 默认 application.yml 必填。
 OPENAI_API_KEY=your-key
 
-# 可选的服务地址和模型覆盖项。
-OPENAI_BASE_URL=https://openrouter.ai/api
-OPENAI_CHAT_MODEL=openai/gpt-4o-mini
-OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small
+# 可选。只需要填写 application.yml 中实际引用的 client key。
+DEEPSEEK_API_KEY=
+GLM_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+SILICONFLOW_API_KEY=
 
-# 可选。只有 deep retrieval 需要外部 rerank 服务时才需要配置。
-MEMIND_RERANK_BASE_URL=https://aihubmix.com
+# 可选。只有 Deep Retrieval 需要外部 rerank 服务时才需要配置。
 MEMIND_RERANK_API_KEY=
-MEMIND_RERANK_MODEL=jina-reranker-v3
-
-# 可选的宿主机端口。
-MEMIND_SERVER_PORT=8366
-MEMIND_UI_PORT=8080
 ```
 
-`OPENAI_BASE_URL`、`OPENAI_CHAT_MODEL` 和 `OPENAI_EMBEDDING_MODEL` 都是可选项。
-其中 chat model 和 embedding model 的选择会直接影响 Memory 的提取质量、洞察质量和检索质量。
-如果你的 embedding 服务使用了和 chat 不同的地址或密钥，请额外设置
-`EMBEDDING_BASE_URL` 和 `EMBEDDING_API_KEY`。
+模型 provider、base URL、具体模型和 chat-client slot routing 都在
+[`memind-server/src/main/resources/application.yml`](./memind-server/src/main/resources/application.yml)
+里配置。默认配置使用一个兼容 OpenAI 协议的 chat client 处理所有 chat slot，并使用一个
+embedding client。没有单独配置的 slot 会自动回退到 `default-client`。
+
+示例：大多数阶段使用 DeepSeek，Insight 生成使用 DeepSeek Reasoner，分组分类使用 GLM，
+线程 enrichment 使用 Claude：
+
+```yaml
+memind:
+  ai:
+    chat:
+      default-client: ds
+      clients:
+        ds:
+          provider: openai
+          base-url: https://api.deepseek.com
+          api-key: ${DEEPSEEK_API_KEY}
+          model: deepseek-chat
+        ds_reasoner:
+          provider: openai
+          base-url: https://api.deepseek.com
+          api-key: ${DEEPSEEK_API_KEY}
+          model: deepseek-reasoner
+        glm:
+          provider: openai
+          base-url: https://open.bigmodel.cn/api/paas/v4
+          api-key: ${GLM_API_KEY}
+          model: glm-4.5
+        claude:
+          provider: anthropic
+          api-key: ${ANTHROPIC_API_KEY}
+          model: claude-sonnet-4-5
+      slots:
+        ITEM_EXTRACTION: ds
+        INSIGHT_GENERATOR: ds_reasoner
+        INSIGHT_GROUP_CLASSIFIER: glm
+        THREAD_ENRICHMENT: claude
+    embedding:
+      client: embedding
+      clients:
+        embedding:
+          provider: openai
+          base-url: https://api.siliconflow.cn/v1
+          api-key: ${SILICONFLOW_API_KEY}
+          model: BAAI/bge-m3
+```
+
+chat provider 支持 `openai`（兼容 OpenAI 协议的 endpoint）、`anthropic`、`gemini`
+和 `ollama`。embedding provider 支持 `openai`、`gemini` 和 `ollama`。完整配置说明见
+[docs.openmemind.com](https://docs.openmemind.com)。
 
 ### 启动服务
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -108,37 +108,47 @@ React 管理 UI，不需要在宿主机安装 Java、Maven、Node.js 或 pnpm。
 ### 前置要求
 
 - Docker，并已启用 Compose 插件
-- 一个 chat model 密钥和一个 embedding model 密钥。默认配置会把同一个 `OPENAI_API_KEY`
-  用于兼容 OpenAI 协议的 chat 和 embedding endpoint。
+- 你准备使用的 chat 和 embedding 模型凭据。默认配置使用一个兼容 OpenAI 协议的 provider
+  同时处理 chat 和 embedding。
 
 ### 配置凭据
 
-在仓库根目录创建本地 `.env` 文件。`docker-compose.yml` 会自动读取这些变量：
+从示例文件创建本地 `.env`。Docker Compose 会自动读取这个文件：
 
 ```bash
-# 默认 application.yml 必填。
-OPENAI_API_KEY=your-key
-
-# 可选。只需要填写 application.yml 中实际引用的 client key。
-DEEPSEEK_API_KEY=
-GLM_API_KEY=
-ANTHROPIC_API_KEY=
-GEMINI_API_KEY=
-SILICONFLOW_API_KEY=
-
-# 可选。只有 Deep Retrieval 需要外部 rerank 服务时才需要配置。
-MEMIND_RERANK_API_KEY=
+cp .env.example .env
 ```
 
-模型 provider、base URL、具体模型和 chat-client slot routing 都在
-[`memind-server/src/main/resources/application.yml`](./memind-server/src/main/resources/application.yml)
-里配置。默认配置使用一个兼容 OpenAI 协议的 chat client 处理所有 chat slot，并使用一个
-embedding client。没有单独配置的 slot 会自动回退到 `default-client`。
+示例文件里的 `OPENAI_API_KEY=your-api-key` 是为了保证服务可以启动的占位值。真正执行 memory
+extraction、retrieval 或 embedding 调用前，需要替换成真实 key。
+
+AI 配置分成两层：
+
+- `spring.ai.*` 定义 provider 默认参数和模型 options，尽量沿用 Spring AI 原生配置结构。
+- `memind.ai.*` 定义 Memind 的 named client、embedding client 和 chat-client slot routing。
+
+默认 [`application.yml`](./memind-server/src/main/resources/application.yml) 定义了一个 `openai`
+chat client 和一个 `openai` embedding client。它们会从 `spring.ai.openai.*` 继承 base URL、
+API key、模型和常用 options。没有单独配置的 chat slot 会自动回退到 `default-client`。
 
 示例：大多数阶段使用 DeepSeek，Insight 生成使用 DeepSeek Reasoner，分组分类使用 GLM，
 线程 enrichment 使用 Claude：
 
 ```yaml
+spring:
+  ai:
+    openai:
+      base-url: ${OPENAI_BASE_URL:https://openrouter.ai/api}
+      api-key: ${OPENAI_API_KEY:your-api-key}
+      chat:
+        options:
+          model: ${OPENAI_CHAT_MODEL:openai/gpt-4o-mini}
+      embedding:
+        base-url: ${EMBEDDING_BASE_URL:${OPENAI_BASE_URL:https://openrouter.ai/api}}
+        api-key: ${EMBEDDING_API_KEY:${OPENAI_API_KEY:your-api-key}}
+        options:
+          model: ${OPENAI_EMBEDDING_MODEL:openai/text-embedding-3-small}
+
 memind:
   ai:
     chat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,12 @@ services:
     container_name: memind-server
     environment:
       SERVER_PORT: 8366
-      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://openrouter.ai/api}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-123}
-      OPENAI_CHAT_MODEL: ${OPENAI_CHAT_MODEL:-openai/gpt-4o-mini}
-      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-openai/text-embedding-3-small}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      GLM_API_KEY: ${GLM_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      SILICONFLOW_API_KEY: ${SILICONFLOW_API_KEY:-}
       MEMIND_DATASOURCE_URL: jdbc:sqlite:/app/data/memind-server.db
       MEMIND_VECTOR_STORE_PATH: /app/data/vector-store.json
       MEMIND_RERANK_BASE_URL: ${MEMIND_RERANK_BASE_URL:-https://aihubmix.com}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,13 @@ services:
     container_name: memind-server
     environment:
       SERVER_PORT: 8366
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://openrouter.ai/api}
+      OPENAI_CHAT_MODEL: ${OPENAI_CHAT_MODEL:-openai/gpt-4o-mini}
+      OPENAI_CHAT_TEMPERATURE: ${OPENAI_CHAT_TEMPERATURE:-0.2}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-openai/text-embedding-3-small}
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-${OPENAI_API_KEY:-your-api-key}}
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-${OPENAI_BASE_URL:-https://openrouter.ai/api}}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       GLM_API_KEY: ${GLM_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/pom.xml
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/pom.xml
@@ -49,6 +49,22 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-anthropic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-google-genai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-google-genai-embedding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-ollama</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-vector-store</artifactId>
         </dependency>
         <dependency>

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/ConfiguredChatClientsCondition.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/ConfiguredChatClientsCondition.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+final class ConfiguredChatClientsCondition extends SpringBootCondition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(
+            ConditionContext context, AnnotatedTypeMetadata metadata) {
+        boolean configured =
+                Binder.get(context.getEnvironment())
+                        .bind("memind.ai.chat.clients", Bindable.mapOf(String.class, Object.class))
+                        .map(clients -> !clients.isEmpty())
+                        .orElse(false);
+        ConditionMessage message =
+                ConditionMessage.forCondition("configured memind AI chat clients")
+                        .because(
+                                configured
+                                        ? "memind.ai.chat.clients is configured"
+                                        : "memind.ai.chat.clients is not configured");
+        return configured ? ConditionOutcome.match(message) : ConditionOutcome.noMatch(message);
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/ConfiguredEmbeddingClientsCondition.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/ConfiguredEmbeddingClientsCondition.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+final class ConfiguredEmbeddingClientsCondition extends SpringBootCondition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(
+            ConditionContext context, AnnotatedTypeMetadata metadata) {
+        boolean configured =
+                Binder.get(context.getEnvironment())
+                        .bind(
+                                "memind.ai.embedding.clients",
+                                Bindable.mapOf(String.class, Object.class))
+                        .map(clients -> !clients.isEmpty())
+                        .orElse(false);
+        ConditionMessage message =
+                ConditionMessage.forCondition("configured memind AI embedding clients")
+                        .because(
+                                configured
+                                        ? "memind.ai.embedding.clients is configured"
+                                        : "memind.ai.embedding.clients is not configured");
+        return configured ? ConditionOutcome.match(message) : ConditionOutcome.noMatch(message);
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
@@ -15,12 +15,18 @@ package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.core.retry.RetryTemplate;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @AutoConfiguration
 @AutoConfigureBefore({SpringAiLlmAutoConfiguration.class, SpringAiVectorAutoConfiguration.class})
@@ -30,11 +36,15 @@ public class MemindAiClientAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public MemindAiClientFactory memindAiClientFactory(
-            org.springframework.beans.factory.ObjectProvider<RetryTemplate> retryTemplateProvider,
-            org.springframework.beans.factory.ObjectProvider<ObservationRegistry>
-                    observationRegistryProvider,
-            org.springframework.beans.factory.ObjectProvider<ToolCallingManager>
-                    toolCallingManagerProvider) {
+            ObjectProvider<RetryTemplate> retryTemplateProvider,
+            ObjectProvider<ObservationRegistry> observationRegistryProvider,
+            ObjectProvider<ToolCallingManager> toolCallingManagerProvider,
+            ObjectProvider<ToolExecutionEligibilityPredicate>
+                    toolExecutionEligibilityPredicateProvider,
+            ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+            ObjectProvider<WebClient.Builder> webClientBuilderProvider,
+            ObjectProvider<ResponseErrorHandler> responseErrorHandlerProvider,
+            Environment environment) {
         ObservationRegistry observationRegistry =
                 observationRegistryProvider.getIfAvailable(
                         MemindAiClientFactory::defaultObservationRegistry);
@@ -42,8 +52,14 @@ public class MemindAiClientAutoConfiguration {
                 retryTemplateProvider.getIfAvailable(MemindAiClientFactory::defaultRetryTemplate),
                 observationRegistry,
                 toolCallingManagerProvider.getIfAvailable(
-                        () ->
-                                MemindAiClientFactory.defaultToolCallingManager(
-                                        observationRegistry)));
+                        () -> MemindAiClientFactory.defaultToolCallingManager(observationRegistry)),
+                toolExecutionEligibilityPredicateProvider.getIfUnique(),
+                restClientBuilderProvider.getIfAvailable(
+                        MemindAiClientFactory::defaultRestClientBuilder),
+                webClientBuilderProvider.getIfAvailable(
+                        MemindAiClientFactory::defaultWebClientBuilder),
+                responseErrorHandlerProvider.getIfAvailable(
+                        MemindAiClientFactory::defaultResponseErrorHandler),
+                environment);
     }
 }

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.retry.RetryTemplate;
+
+@AutoConfiguration
+@AutoConfigureBefore({SpringAiLlmAutoConfiguration.class, SpringAiVectorAutoConfiguration.class})
+@EnableConfigurationProperties(MemindAiProperties.class)
+public class MemindAiClientAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MemindAiClientFactory memindAiClientFactory(
+            org.springframework.beans.factory.ObjectProvider<RetryTemplate> retryTemplateProvider,
+            org.springframework.beans.factory.ObjectProvider<ObservationRegistry>
+                    observationRegistryProvider,
+            org.springframework.beans.factory.ObjectProvider<ToolCallingManager>
+                    toolCallingManagerProvider) {
+        ObservationRegistry observationRegistry =
+                observationRegistryProvider.getIfAvailable(
+                        MemindAiClientFactory::defaultObservationRegistry);
+        return new MemindAiClientFactory(
+                retryTemplateProvider.getIfAvailable(MemindAiClientFactory::defaultRetryTemplate),
+                observationRegistry,
+                toolCallingManagerProvider.getIfAvailable(
+                        () ->
+                                MemindAiClientFactory.defaultToolCallingManager(
+                                        observationRegistry)));
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
@@ -20,8 +20,10 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.env.Environment;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
@@ -32,6 +34,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 @AutoConfigureBefore({SpringAiLlmAutoConfiguration.class, SpringAiVectorAutoConfiguration.class})
 @EnableConfigurationProperties(MemindAiProperties.class)
 public class MemindAiClientAutoConfiguration {
+
+    @Bean
+    @ConfigurationPropertiesBinding
+    public Converter<String, MemindAiProperties.AiProvider> memindAiProviderConverter() {
+        return new MemindAiProperties.AiProviderConverter();
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientAutoConfiguration.java
@@ -20,10 +20,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.env.Environment;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
@@ -34,12 +32,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @AutoConfigureBefore({SpringAiLlmAutoConfiguration.class, SpringAiVectorAutoConfiguration.class})
 @EnableConfigurationProperties(MemindAiProperties.class)
 public class MemindAiClientAutoConfiguration {
-
-    @Bean
-    @ConfigurationPropertiesBinding
-    public Converter<String, MemindAiProperties.AiProvider> memindAiProviderConverter() {
-        return new MemindAiProperties.AiProviderConverter();
-    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
@@ -36,7 +36,11 @@ import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails;
 import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel;
 import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiConnectionProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingProperties;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.OllamaEmbeddingModel;
 import org.springframework.ai.ollama.api.OllamaApi;
@@ -48,9 +52,18 @@ import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiEmbeddingOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 public final class MemindAiClientFactory {
 
@@ -66,15 +79,33 @@ public final class MemindAiClientFactory {
     private final RetryTemplate retryTemplate;
     private final ObservationRegistry observationRegistry;
     private final ToolCallingManager toolCallingManager;
+    private final ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate;
+    private final RestClient.Builder restClientBuilder;
+    private final WebClient.Builder webClientBuilder;
+    private final ResponseErrorHandler responseErrorHandler;
+    private final Binder binder;
+    private final Environment environment;
 
     public MemindAiClientFactory(
             RetryTemplate retryTemplate,
             ObservationRegistry observationRegistry,
-            ToolCallingManager toolCallingManager) {
+            ToolCallingManager toolCallingManager,
+            ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate,
+            RestClient.Builder restClientBuilder,
+            WebClient.Builder webClientBuilder,
+            ResponseErrorHandler responseErrorHandler,
+            Environment environment) {
         this.retryTemplate = Objects.requireNonNull(retryTemplate, "retryTemplate");
         this.observationRegistry =
                 Objects.requireNonNull(observationRegistry, "observationRegistry");
         this.toolCallingManager = Objects.requireNonNull(toolCallingManager, "toolCallingManager");
+        this.toolExecutionEligibilityPredicate = toolExecutionEligibilityPredicate;
+        this.restClientBuilder = Objects.requireNonNull(restClientBuilder, "restClientBuilder");
+        this.webClientBuilder = Objects.requireNonNull(webClientBuilder, "webClientBuilder");
+        this.responseErrorHandler =
+                Objects.requireNonNull(responseErrorHandler, "responseErrorHandler");
+        this.environment = Objects.requireNonNull(environment, "environment");
+        this.binder = Binder.get(environment);
     }
 
     public MemindChatClients createChatClients(MemindAiProperties.ChatProperties properties) {
@@ -88,8 +119,39 @@ public final class MemindAiClientFactory {
                         properties.getDefaultClient(),
                         "memind.ai.chat.default-client must not be blank");
 
+        if (!configuredClients.containsKey(defaultClientId)) {
+            throw new MemindAiConfigurationException(
+                    "memind.ai.chat.default-client '"
+                            + defaultClientId
+                            + "' does not match any configured client");
+        }
+
+        Map<ChatClientSlot, String> slotClientIds = new EnumMap<>(ChatClientSlot.class);
+        Map<String, MemindAiProperties.ClientProperties> referencedClients = new LinkedHashMap<>();
+        referencedClients.put(defaultClientId, configuredClients.get(defaultClientId));
+        emptySafe(properties.getSlots())
+                .forEach(
+                        (slot, clientId) -> {
+                            String resolvedClientId =
+                                    requireText(
+                                            clientId,
+                                            "memind.ai.chat.slots." + slot + " must not be blank");
+                            MemindAiProperties.ClientProperties clientProperties =
+                                    configuredClients.get(resolvedClientId);
+                            if (clientProperties == null) {
+                                throw new MemindAiConfigurationException(
+                                        "memind.ai.chat.slots."
+                                                + slot
+                                                + " references unknown client '"
+                                                + resolvedClientId
+                                                + "'");
+                            }
+                            slotClientIds.put(slot, resolvedClientId);
+                            referencedClients.putIfAbsent(resolvedClientId, clientProperties);
+                        });
+
         Map<String, StructuredChatClient> clients = new LinkedHashMap<>();
-        configuredClients.forEach(
+        referencedClients.forEach(
                 (clientId, clientProperties) ->
                         clients.put(
                                 clientId,
@@ -100,34 +162,8 @@ public final class MemindAiClientFactory {
                                                         clientProperties)))));
 
         StructuredChatClient defaultClient = clients.get(defaultClientId);
-        if (defaultClient == null) {
-            throw new MemindAiConfigurationException(
-                    "memind.ai.chat.default-client '"
-                            + defaultClientId
-                            + "' does not match any configured client");
-        }
-
-        Map<ChatClientSlot, String> slotClientIds = new EnumMap<>(ChatClientSlot.class);
         Map<ChatClientSlot, StructuredChatClient> slotClients = new EnumMap<>(ChatClientSlot.class);
-        emptySafe(properties.getSlots())
-                .forEach(
-                        (slot, clientId) -> {
-                            String resolvedClientId =
-                                    requireText(
-                                            clientId,
-                                            "memind.ai.chat.slots." + slot + " must not be blank");
-                            StructuredChatClient client = clients.get(resolvedClientId);
-                            if (client == null) {
-                                throw new MemindAiConfigurationException(
-                                        "memind.ai.chat.slots."
-                                                + slot
-                                                + " references unknown client '"
-                                                + resolvedClientId
-                                                + "'");
-                            }
-                            slotClientIds.put(slot, resolvedClientId);
-                            slotClients.put(slot, client);
-                        });
+        slotClientIds.forEach((slot, clientId) -> slotClients.put(slot, clients.get(clientId)));
 
         return new MemindChatClients(
                 defaultClientId, defaultClient, clients, slotClientIds, slotClients);
@@ -195,189 +231,285 @@ public final class MemindAiClientFactory {
 
     private ChatModel openAiChatModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OpenAiConnectionProperties connectionProperties =
+                bind("spring.ai.openai", OpenAiConnectionProperties.class)
+                        .orElseGet(OpenAiConnectionProperties::new);
+        OpenAiChatProperties chatProperties =
+                bind("spring.ai.openai.chat", OpenAiChatProperties.class)
+                        .orElseGet(OpenAiChatProperties::new);
+        String baseUrl =
+                firstText(
+                        properties.getBaseUrl(),
+                        chatProperties.getBaseUrl(),
+                        connectionProperties.getBaseUrl());
+        String apiKey =
+                firstText(
+                        properties.getApiKey(),
+                        chatProperties.getApiKey(),
+                        connectionProperties.getApiKey());
+        OpenAiChatOptions options = OpenAiChatOptions.fromOptions(chatProperties.getOptions());
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
+        applyCommonChatOverrides(properties, options);
         OpenAiApi api =
                 OpenAiApi.builder()
-                        .baseUrl(requireText(properties.getBaseUrl(), propertyPath + ".base-url"))
-                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
+                        .baseUrl(requireText(baseUrl, propertyPath + ".base-url"))
+                        .apiKey(requireText(apiKey, propertyPath + ".api-key"))
+                        .headers(
+                                openAiHeaders(
+                                        chatProperties.getProjectId(),
+                                        chatProperties.getOrganizationId(),
+                                        connectionProperties))
+                        .completionsPath(chatProperties.getCompletionsPath())
+                        .restClientBuilder(restClientBuilder)
+                        .webClientBuilder(webClientBuilder)
+                        .responseErrorHandler(responseErrorHandler)
                         .build();
-        OpenAiChatOptions.Builder options =
-                OpenAiChatOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
-        if (properties.getTemperature() != null) {
-            options.temperature(properties.getTemperature());
+        OpenAiChatModel.Builder builder =
+                OpenAiChatModel.builder()
+                        .openAiApi(api)
+                        .defaultOptions(options)
+                        .toolCallingManager(toolCallingManager)
+                        .retryTemplate(retryTemplate)
+                        .observationRegistry(observationRegistry);
+        if (toolExecutionEligibilityPredicate != null) {
+            builder.toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate);
         }
-        if (properties.getTopP() != null) {
-            options.topP(properties.getTopP());
-        }
-        if (properties.getMaxTokens() != null) {
-            options.maxTokens(properties.getMaxTokens());
-        }
-        if (properties.getMaxCompletionTokens() != null) {
-            options.maxCompletionTokens(properties.getMaxCompletionTokens());
-        }
-        return OpenAiChatModel.builder()
-                .openAiApi(api)
-                .defaultOptions(options.build())
-                .toolCallingManager(toolCallingManager)
-                .retryTemplate(retryTemplate)
-                .observationRegistry(observationRegistry)
-                .build();
+        return builder.build();
     }
 
     private EmbeddingModel openAiEmbeddingModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OpenAiConnectionProperties connectionProperties =
+                bind("spring.ai.openai", OpenAiConnectionProperties.class)
+                        .orElseGet(OpenAiConnectionProperties::new);
+        OpenAiEmbeddingProperties embeddingProperties =
+                bind("spring.ai.openai.embedding", OpenAiEmbeddingProperties.class)
+                        .orElseGet(OpenAiEmbeddingProperties::new);
+        String baseUrl =
+                firstText(
+                        properties.getBaseUrl(),
+                        embeddingProperties.getBaseUrl(),
+                        connectionProperties.getBaseUrl());
+        String apiKey =
+                firstText(
+                        properties.getApiKey(),
+                        embeddingProperties.getApiKey(),
+                        connectionProperties.getApiKey());
+        OpenAiEmbeddingOptions options =
+                copyOpenAiEmbeddingOptions(embeddingProperties.getOptions());
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
+        if (properties.getDimensions() != null) {
+            options.setDimensions(properties.getDimensions());
+        }
         OpenAiApi api =
                 OpenAiApi.builder()
-                        .baseUrl(requireText(properties.getBaseUrl(), propertyPath + ".base-url"))
-                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
+                        .baseUrl(requireText(baseUrl, propertyPath + ".base-url"))
+                        .apiKey(requireText(apiKey, propertyPath + ".api-key"))
+                        .headers(
+                                openAiHeaders(
+                                        embeddingProperties.getProjectId(),
+                                        embeddingProperties.getOrganizationId(),
+                                        connectionProperties))
+                        .embeddingsPath(embeddingProperties.getEmbeddingsPath())
+                        .restClientBuilder(restClientBuilder)
+                        .webClientBuilder(webClientBuilder)
+                        .responseErrorHandler(responseErrorHandler)
                         .build();
-        OpenAiEmbeddingOptions.Builder options =
-                OpenAiEmbeddingOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
-        if (properties.getDimensions() != null) {
-            options.dimensions(properties.getDimensions());
-        }
         return new OpenAiEmbeddingModel(
-                api, MetadataMode.EMBED, options.build(), retryTemplate, observationRegistry);
+                api,
+                embeddingProperties.getMetadataMode() == null
+                        ? MetadataMode.EMBED
+                        : embeddingProperties.getMetadataMode(),
+                options,
+                retryTemplate,
+                observationRegistry);
     }
 
     private ChatModel anthropicChatModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
+        AnthropicChatOptions options =
+                bind("spring.ai.anthropic.chat.options", AnthropicChatOptions.class)
+                        .orElseGet(AnthropicChatOptions::new);
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
+        applyCommonChatOverrides(properties, options);
         AnthropicApi.Builder api =
                 AnthropicApi.builder()
-                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"));
-        if (StringUtils.hasText(properties.getBaseUrl())) {
-            api.baseUrl(properties.getBaseUrl());
+                        .apiKey(
+                                requireText(
+                                        firstText(
+                                                properties.getApiKey(),
+                                                property("spring.ai.anthropic.api-key")),
+                                        propertyPath + ".api-key"))
+                        .restClientBuilder(restClientBuilder)
+                        .webClientBuilder(webClientBuilder)
+                        .responseErrorHandler(responseErrorHandler);
+        String baseUrl =
+                firstText(properties.getBaseUrl(), property("spring.ai.anthropic.base-url"));
+        if (StringUtils.hasText(baseUrl)) {
+            api.baseUrl(baseUrl);
         }
-        AnthropicChatOptions.Builder options =
-                AnthropicChatOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
-        if (properties.getTemperature() != null) {
-            options.temperature(properties.getTemperature());
+        String completionsPath = property("spring.ai.anthropic.completions-path");
+        if (StringUtils.hasText(completionsPath)) {
+            api.completionsPath(completionsPath);
         }
-        if (properties.getTopP() != null) {
-            options.topP(properties.getTopP());
+        String version = property("spring.ai.anthropic.version");
+        if (StringUtils.hasText(version)) {
+            api.anthropicVersion(version);
         }
-        if (properties.getTopK() != null) {
-            options.topK(properties.getTopK());
+        String betaVersion = property("spring.ai.anthropic.beta-version");
+        if (StringUtils.hasText(betaVersion)) {
+            api.anthropicBetaFeatures(betaVersion);
         }
-        if (properties.getMaxTokens() != null) {
-            options.maxTokens(properties.getMaxTokens());
+        AnthropicChatModel.Builder builder =
+                AnthropicChatModel.builder()
+                        .anthropicApi(api.build())
+                        .defaultOptions(options)
+                        .toolCallingManager(toolCallingManager)
+                        .retryTemplate(retryTemplate)
+                        .observationRegistry(observationRegistry);
+        if (toolExecutionEligibilityPredicate != null) {
+            builder.toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate);
         }
-        return AnthropicChatModel.builder()
-                .anthropicApi(api.build())
-                .defaultOptions(options.build())
-                .toolCallingManager(toolCallingManager)
-                .retryTemplate(retryTemplate)
-                .observationRegistry(observationRegistry)
-                .build();
+        return builder.build();
     }
 
     private ChatModel googleGenAiChatModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        GoogleGenAiChatOptions.Builder options =
-                GoogleGenAiChatOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
-        if (properties.getTemperature() != null) {
-            options.temperature(properties.getTemperature());
+        GoogleGenAiChatOptions options =
+                bind("spring.ai.google.genai.chat.options", GoogleGenAiChatOptions.class)
+                        .orElseGet(GoogleGenAiChatOptions::new);
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
+        applyCommonChatOverrides(properties, options);
+        GoogleGenAiChatModel.Builder builder =
+                GoogleGenAiChatModel.builder()
+                        .genAiClient(
+                                googleClient(propertyPath, properties, "spring.ai.google.genai"))
+                        .defaultOptions(options)
+                        .toolCallingManager(toolCallingManager)
+                        .retryTemplate(retryTemplate)
+                        .observationRegistry(observationRegistry);
+        if (toolExecutionEligibilityPredicate != null) {
+            builder.toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate);
         }
-        if (properties.getTopP() != null) {
-            options.topP(properties.getTopP());
-        }
-        if (properties.getTopK() != null) {
-            options.topK(properties.getTopK());
-        }
-        if (properties.getMaxTokens() != null) {
-            options.maxOutputTokens(properties.getMaxTokens());
-        }
-        return GoogleGenAiChatModel.builder()
-                .genAiClient(googleClient(propertyPath, properties))
-                .defaultOptions(options.build())
-                .toolCallingManager(toolCallingManager)
-                .retryTemplate(retryTemplate)
-                .observationRegistry(observationRegistry)
-                .build();
+        return builder.build();
     }
 
     private EmbeddingModel googleGenAiEmbeddingModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        GoogleGenAiTextEmbeddingOptions.Builder options =
-                GoogleGenAiTextEmbeddingOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        GoogleGenAiTextEmbeddingOptions options =
+                bind(
+                                "spring.ai.google.genai.embedding.options",
+                                GoogleGenAiTextEmbeddingOptions.class)
+                        .orElseGet(GoogleGenAiTextEmbeddingOptions::new);
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
         if (properties.getDimensions() != null) {
-            options.dimensions(properties.getDimensions());
+            options.setDimensions(properties.getDimensions());
         }
         GoogleGenAiEmbeddingConnectionDetails.Builder connectionDetailsBuilder =
                 GoogleGenAiEmbeddingConnectionDetails.builder()
-                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
-                        .genAiClient(googleClient(propertyPath, properties));
-        if (StringUtils.hasText(properties.getProjectId())) {
-            connectionDetailsBuilder.projectId(properties.getProjectId());
+                        .apiKey(
+                                requireText(
+                                        firstText(
+                                                properties.getApiKey(),
+                                                property("spring.ai.google.genai.api-key")),
+                                        propertyPath + ".api-key"))
+                        .genAiClient(
+                                googleClient(propertyPath, properties, "spring.ai.google.genai"));
+        String projectId =
+                firstText(properties.getProjectId(), property("spring.ai.google.genai.project-id"));
+        if (StringUtils.hasText(projectId)) {
+            connectionDetailsBuilder.projectId(projectId);
         }
-        if (StringUtils.hasText(properties.getLocation())) {
-            connectionDetailsBuilder.location(properties.getLocation());
+        String location =
+                firstText(properties.getLocation(), property("spring.ai.google.genai.location"));
+        if (StringUtils.hasText(location)) {
+            connectionDetailsBuilder.location(location);
         }
         GoogleGenAiEmbeddingConnectionDetails connectionDetails = connectionDetailsBuilder.build();
         return new GoogleGenAiTextEmbeddingModel(
-                connectionDetails, options.build(), retryTemplate, observationRegistry);
+                connectionDetails, options, retryTemplate, observationRegistry);
     }
 
     private ChatModel ollamaChatModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        OllamaChatOptions.Builder options =
-                OllamaChatOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
-        if (properties.getTemperature() != null) {
-            options.temperature(properties.getTemperature());
+        OllamaChatOptions options =
+                bind("spring.ai.ollama.chat.options", OllamaChatOptions.class)
+                        .orElseGet(OllamaChatOptions::new);
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
+        applyCommonChatOverrides(properties, options);
+        OllamaChatModel.Builder builder =
+                OllamaChatModel.builder()
+                        .ollamaApi(ollamaApi(propertyPath, properties))
+                        .defaultOptions(options)
+                        .toolCallingManager(toolCallingManager)
+                        .retryTemplate(retryTemplate)
+                        .observationRegistry(observationRegistry)
+                        .modelManagementOptions(ModelManagementOptions.defaults());
+        if (toolExecutionEligibilityPredicate != null) {
+            builder.toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate);
         }
-        if (properties.getTopP() != null) {
-            options.topP(properties.getTopP());
-        }
-        if (properties.getTopK() != null) {
-            options.topK(properties.getTopK());
-        }
-        if (properties.getMaxTokens() != null) {
-            options.numPredict(properties.getMaxTokens());
-        }
-        return OllamaChatModel.builder()
-                .ollamaApi(ollamaApi(propertyPath, properties))
-                .defaultOptions(options.build())
-                .toolCallingManager(toolCallingManager)
-                .retryTemplate(retryTemplate)
-                .observationRegistry(observationRegistry)
-                .modelManagementOptions(ModelManagementOptions.defaults())
-                .build();
+        return builder.build();
     }
 
     private EmbeddingModel ollamaEmbeddingModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        OllamaEmbeddingOptions.Builder options =
-                OllamaEmbeddingOptions.builder()
-                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        OllamaEmbeddingOptions options =
+                bind("spring.ai.ollama.embedding.options", OllamaEmbeddingOptions.class)
+                        .orElseGet(OllamaEmbeddingOptions::new);
+        options.setModel(
+                requireText(
+                        firstText(properties.getModel(), options.getModel()),
+                        propertyPath + ".model"));
         if (properties.getDimensions() != null) {
-            options.dimensions(properties.getDimensions());
+            options.setDimensions(properties.getDimensions());
         }
         return OllamaEmbeddingModel.builder()
                 .ollamaApi(ollamaApi(propertyPath, properties))
-                .defaultOptions(options.build())
+                .defaultOptions(options)
                 .observationRegistry(observationRegistry)
                 .modelManagementOptions(ModelManagementOptions.defaults())
                 .build();
     }
 
     private Client googleClient(
-            String propertyPath, MemindAiProperties.ClientProperties properties) {
+            String propertyPath, MemindAiProperties.ClientProperties properties, String prefix) {
         Client.Builder builder =
                 Client.builder()
-                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"));
-        if (StringUtils.hasText(properties.getBaseUrl())) {
-            builder.httpOptions(HttpOptions.builder().baseUrl(properties.getBaseUrl()).build());
+                        .apiKey(
+                                requireText(
+                                        firstText(
+                                                properties.getApiKey(),
+                                                property(prefix + ".api-key")),
+                                        propertyPath + ".api-key"));
+        String baseUrl = firstText(properties.getBaseUrl(), property(prefix + ".base-url"));
+        if (StringUtils.hasText(baseUrl)) {
+            builder.httpOptions(HttpOptions.builder().baseUrl(baseUrl).build());
         }
-        if (StringUtils.hasText(properties.getProjectId())) {
-            builder.project(properties.getProjectId());
+        String projectId = firstText(properties.getProjectId(), property(prefix + ".project-id"));
+        if (StringUtils.hasText(projectId)) {
+            builder.project(projectId);
         }
-        if (StringUtils.hasText(properties.getLocation())) {
-            builder.location(properties.getLocation());
+        String location = firstText(properties.getLocation(), property(prefix + ".location"));
+        if (StringUtils.hasText(location)) {
+            builder.location(location);
         }
         return builder.build();
     }
@@ -385,8 +517,9 @@ public final class MemindAiClientFactory {
     private OllamaApi ollamaApi(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
         OllamaApi.Builder builder = OllamaApi.builder();
-        if (StringUtils.hasText(properties.getBaseUrl())) {
-            builder.baseUrl(properties.getBaseUrl());
+        String baseUrl = firstText(properties.getBaseUrl(), property("spring.ai.ollama.base-url"));
+        if (StringUtils.hasText(baseUrl)) {
+            builder.baseUrl(baseUrl);
         } else {
             throw new MemindAiConfigurationException(propertyPath + ".base-url is required");
         }
@@ -403,6 +536,126 @@ public final class MemindAiClientFactory {
 
     static ToolCallingManager defaultToolCallingManager(ObservationRegistry observationRegistry) {
         return ToolCallingManager.builder().observationRegistry(observationRegistry).build();
+    }
+
+    static RestClient.Builder defaultRestClientBuilder() {
+        return RestClient.builder();
+    }
+
+    static WebClient.Builder defaultWebClientBuilder() {
+        return WebClient.builder();
+    }
+
+    static ResponseErrorHandler defaultResponseErrorHandler() {
+        return RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER;
+    }
+
+    private <T> BindResult<T> bind(String name, Class<T> type) {
+        return binder.bind(name, Bindable.of(type));
+    }
+
+    private String property(String name) {
+        return environment.getProperty(name);
+    }
+
+    private static String firstText(String... values) {
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static HttpHeaders openAiHeaders(
+            String modelProjectId,
+            String modelOrganizationId,
+            OpenAiConnectionProperties connectionProperties) {
+        String projectId = firstText(modelProjectId, connectionProperties.getProjectId());
+        String organizationId =
+                firstText(modelOrganizationId, connectionProperties.getOrganizationId());
+        HttpHeaders headers = new HttpHeaders();
+        if (StringUtils.hasText(projectId)) {
+            headers.add("OpenAI-Project", projectId);
+        }
+        if (StringUtils.hasText(organizationId)) {
+            headers.add("OpenAI-Organization", organizationId);
+        }
+        return headers;
+    }
+
+    private static OpenAiEmbeddingOptions copyOpenAiEmbeddingOptions(
+            OpenAiEmbeddingOptions source) {
+        OpenAiEmbeddingOptions target = new OpenAiEmbeddingOptions();
+        target.setModel(source.getModel());
+        target.setEncodingFormat(source.getEncodingFormat());
+        target.setDimensions(source.getDimensions());
+        target.setUser(source.getUser());
+        return target;
+    }
+
+    private static void applyCommonChatOverrides(
+            MemindAiProperties.ClientProperties properties, OpenAiChatOptions options) {
+        if (properties.getTemperature() != null) {
+            options.setTemperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.setTopP(properties.getTopP());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.setMaxTokens(properties.getMaxTokens());
+        }
+        if (properties.getMaxCompletionTokens() != null) {
+            options.setMaxCompletionTokens(properties.getMaxCompletionTokens());
+        }
+    }
+
+    private static void applyCommonChatOverrides(
+            MemindAiProperties.ClientProperties properties, AnthropicChatOptions options) {
+        if (properties.getTemperature() != null) {
+            options.setTemperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.setTopP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.setTopK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.setMaxTokens(properties.getMaxTokens());
+        }
+    }
+
+    private static void applyCommonChatOverrides(
+            MemindAiProperties.ClientProperties properties, GoogleGenAiChatOptions options) {
+        if (properties.getTemperature() != null) {
+            options.setTemperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.setTopP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.setTopK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.setMaxOutputTokens(properties.getMaxTokens());
+        }
+    }
+
+    private static void applyCommonChatOverrides(
+            MemindAiProperties.ClientProperties properties, OllamaChatOptions options) {
+        if (properties.getTemperature() != null) {
+            options.setTemperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.setTopP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.setTopK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.setNumPredict(properties.getMaxTokens());
+        }
     }
 
     private static String normalizeProvider(String provider) {

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
@@ -18,10 +18,10 @@ import com.google.genai.types.HttpOptions;
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
+import com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindAiProperties.AiProvider;
 import io.micrometer.observation.ObservationRegistry;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import org.springframework.ai.anthropic.AnthropicChatModel;
@@ -66,15 +66,6 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 
 public final class MemindAiClientFactory {
-
-    private static final String PROVIDER_OPENAI = "openai";
-    private static final String PROVIDER_OPENAI_COMPATIBLE = "openai-compatible";
-    private static final String PROVIDER_ANTHROPIC = "anthropic";
-    private static final String PROVIDER_CLAUDE = "claude";
-    private static final String PROVIDER_GEMINI = "gemini";
-    private static final String PROVIDER_GOOGLE = "google";
-    private static final String PROVIDER_GOOGLE_GENAI = "google-genai";
-    private static final String PROVIDER_OLLAMA = "ollama";
 
     private final RetryTemplate retryTemplate;
     private final ObservationRegistry observationRegistry;
@@ -190,41 +181,27 @@ public final class MemindAiClientFactory {
 
     private ChatModel createChatModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        String provider =
-                normalizeProvider(
-                        requireText(
-                                properties.getProvider(), propertyPath + ".provider is required"));
+        AiProvider provider = requireProvider(properties.getProvider(), propertyPath + ".provider");
         return switch (provider) {
-            case PROVIDER_OPENAI, PROVIDER_OPENAI_COMPATIBLE ->
-                    openAiChatModel(propertyPath, properties);
-            case PROVIDER_ANTHROPIC, PROVIDER_CLAUDE ->
-                    anthropicChatModel(propertyPath, properties);
-            case PROVIDER_GEMINI, PROVIDER_GOOGLE, PROVIDER_GOOGLE_GENAI ->
-                    googleGenAiChatModel(propertyPath, properties);
-            case PROVIDER_OLLAMA -> ollamaChatModel(propertyPath, properties);
-            default ->
-                    throw new MemindAiConfigurationException(
-                            propertyPath + ".provider '" + provider + "' is not supported");
+            case OPENAI -> openAiChatModel(propertyPath, properties);
+            case ANTHROPIC -> anthropicChatModel(propertyPath, properties);
+            case GOOGLE -> googleGenAiChatModel(propertyPath, properties);
+            case OLLAMA -> ollamaChatModel(propertyPath, properties);
         };
     }
 
     private EmbeddingModel createEmbeddingModel(
             String propertyPath, MemindAiProperties.ClientProperties properties) {
-        String provider =
-                normalizeProvider(
-                        requireText(
-                                properties.getProvider(), propertyPath + ".provider is required"));
+        AiProvider provider = requireProvider(properties.getProvider(), propertyPath + ".provider");
         return switch (provider) {
-            case PROVIDER_OPENAI, PROVIDER_OPENAI_COMPATIBLE ->
-                    openAiEmbeddingModel(propertyPath, properties);
-            case PROVIDER_GEMINI, PROVIDER_GOOGLE, PROVIDER_GOOGLE_GENAI ->
-                    googleGenAiEmbeddingModel(propertyPath, properties);
-            case PROVIDER_OLLAMA -> ollamaEmbeddingModel(propertyPath, properties);
-            default ->
+            case OPENAI -> openAiEmbeddingModel(propertyPath, properties);
+            case GOOGLE -> googleGenAiEmbeddingModel(propertyPath, properties);
+            case OLLAMA -> ollamaEmbeddingModel(propertyPath, properties);
+            case ANTHROPIC ->
                     throw new MemindAiConfigurationException(
                             propertyPath
                                     + ".provider '"
-                                    + provider
+                                    + provider.propertyValue()
                                     + "' does not support embeddings");
         };
     }
@@ -658,8 +635,11 @@ public final class MemindAiClientFactory {
         }
     }
 
-    private static String normalizeProvider(String provider) {
-        return provider.trim().toLowerCase(Locale.ROOT);
+    private static AiProvider requireProvider(AiProvider provider, String propertyPath) {
+        if (provider == null) {
+            throw new MemindAiConfigurationException(propertyPath + " is required");
+        }
+        return provider;
     }
 
     private static String requireText(String value, String propertyPath) {

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiClientFactory.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import com.google.genai.Client;
+import com.google.genai.types.HttpOptions;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.plugin.ai.spring.SpringAiStructuredChatClient;
+import io.micrometer.observation.ObservationRegistry;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails;
+import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel;
+import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.ollama.OllamaEmbeddingModel;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaChatOptions;
+import org.springframework.ai.ollama.api.OllamaEmbeddingOptions;
+import org.springframework.ai.ollama.management.ModelManagementOptions;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.StringUtils;
+
+public final class MemindAiClientFactory {
+
+    private static final String PROVIDER_OPENAI = "openai";
+    private static final String PROVIDER_OPENAI_COMPATIBLE = "openai-compatible";
+    private static final String PROVIDER_ANTHROPIC = "anthropic";
+    private static final String PROVIDER_CLAUDE = "claude";
+    private static final String PROVIDER_GEMINI = "gemini";
+    private static final String PROVIDER_GOOGLE = "google";
+    private static final String PROVIDER_GOOGLE_GENAI = "google-genai";
+    private static final String PROVIDER_OLLAMA = "ollama";
+
+    private final RetryTemplate retryTemplate;
+    private final ObservationRegistry observationRegistry;
+    private final ToolCallingManager toolCallingManager;
+
+    public MemindAiClientFactory(
+            RetryTemplate retryTemplate,
+            ObservationRegistry observationRegistry,
+            ToolCallingManager toolCallingManager) {
+        this.retryTemplate = Objects.requireNonNull(retryTemplate, "retryTemplate");
+        this.observationRegistry =
+                Objects.requireNonNull(observationRegistry, "observationRegistry");
+        this.toolCallingManager = Objects.requireNonNull(toolCallingManager, "toolCallingManager");
+    }
+
+    public MemindChatClients createChatClients(MemindAiProperties.ChatProperties properties) {
+        Map<String, MemindAiProperties.ClientProperties> configuredClients =
+                emptySafe(properties.getClients());
+        if (configuredClients.isEmpty()) {
+            throw new MemindAiConfigurationException("memind.ai.chat.clients must not be empty");
+        }
+        String defaultClientId =
+                requireText(
+                        properties.getDefaultClient(),
+                        "memind.ai.chat.default-client must not be blank");
+
+        Map<String, StructuredChatClient> clients = new LinkedHashMap<>();
+        configuredClients.forEach(
+                (clientId, clientProperties) ->
+                        clients.put(
+                                clientId,
+                                new SpringAiStructuredChatClient(
+                                        ChatClient.create(
+                                                createChatModel(
+                                                        "memind.ai.chat.clients." + clientId,
+                                                        clientProperties)))));
+
+        StructuredChatClient defaultClient = clients.get(defaultClientId);
+        if (defaultClient == null) {
+            throw new MemindAiConfigurationException(
+                    "memind.ai.chat.default-client '"
+                            + defaultClientId
+                            + "' does not match any configured client");
+        }
+
+        Map<ChatClientSlot, String> slotClientIds = new EnumMap<>(ChatClientSlot.class);
+        Map<ChatClientSlot, StructuredChatClient> slotClients = new EnumMap<>(ChatClientSlot.class);
+        emptySafe(properties.getSlots())
+                .forEach(
+                        (slot, clientId) -> {
+                            String resolvedClientId =
+                                    requireText(
+                                            clientId,
+                                            "memind.ai.chat.slots." + slot + " must not be blank");
+                            StructuredChatClient client = clients.get(resolvedClientId);
+                            if (client == null) {
+                                throw new MemindAiConfigurationException(
+                                        "memind.ai.chat.slots."
+                                                + slot
+                                                + " references unknown client '"
+                                                + resolvedClientId
+                                                + "'");
+                            }
+                            slotClientIds.put(slot, resolvedClientId);
+                            slotClients.put(slot, client);
+                        });
+
+        return new MemindChatClients(
+                defaultClientId, defaultClient, clients, slotClientIds, slotClients);
+    }
+
+    public EmbeddingModel createEmbeddingModel(MemindAiProperties.EmbeddingProperties properties) {
+        Map<String, MemindAiProperties.ClientProperties> configuredClients =
+                emptySafe(properties.getClients());
+        if (configuredClients.isEmpty()) {
+            throw new MemindAiConfigurationException(
+                    "memind.ai.embedding.clients must not be empty");
+        }
+        String clientId =
+                requireText(properties.getClient(), "memind.ai.embedding.client must not be blank");
+        MemindAiProperties.ClientProperties clientProperties = configuredClients.get(clientId);
+        if (clientProperties == null) {
+            throw new MemindAiConfigurationException(
+                    "memind.ai.embedding.client '"
+                            + clientId
+                            + "' does not match any configured client");
+        }
+        return createEmbeddingModel("memind.ai.embedding.clients." + clientId, clientProperties);
+    }
+
+    private ChatModel createChatModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        String provider =
+                normalizeProvider(
+                        requireText(
+                                properties.getProvider(), propertyPath + ".provider is required"));
+        return switch (provider) {
+            case PROVIDER_OPENAI, PROVIDER_OPENAI_COMPATIBLE ->
+                    openAiChatModel(propertyPath, properties);
+            case PROVIDER_ANTHROPIC, PROVIDER_CLAUDE ->
+                    anthropicChatModel(propertyPath, properties);
+            case PROVIDER_GEMINI, PROVIDER_GOOGLE, PROVIDER_GOOGLE_GENAI ->
+                    googleGenAiChatModel(propertyPath, properties);
+            case PROVIDER_OLLAMA -> ollamaChatModel(propertyPath, properties);
+            default ->
+                    throw new MemindAiConfigurationException(
+                            propertyPath + ".provider '" + provider + "' is not supported");
+        };
+    }
+
+    private EmbeddingModel createEmbeddingModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        String provider =
+                normalizeProvider(
+                        requireText(
+                                properties.getProvider(), propertyPath + ".provider is required"));
+        return switch (provider) {
+            case PROVIDER_OPENAI, PROVIDER_OPENAI_COMPATIBLE ->
+                    openAiEmbeddingModel(propertyPath, properties);
+            case PROVIDER_GEMINI, PROVIDER_GOOGLE, PROVIDER_GOOGLE_GENAI ->
+                    googleGenAiEmbeddingModel(propertyPath, properties);
+            case PROVIDER_OLLAMA -> ollamaEmbeddingModel(propertyPath, properties);
+            default ->
+                    throw new MemindAiConfigurationException(
+                            propertyPath
+                                    + ".provider '"
+                                    + provider
+                                    + "' does not support embeddings");
+        };
+    }
+
+    private ChatModel openAiChatModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OpenAiApi api =
+                OpenAiApi.builder()
+                        .baseUrl(requireText(properties.getBaseUrl(), propertyPath + ".base-url"))
+                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
+                        .build();
+        OpenAiChatOptions.Builder options =
+                OpenAiChatOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getTemperature() != null) {
+            options.temperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.topP(properties.getTopP());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.maxTokens(properties.getMaxTokens());
+        }
+        if (properties.getMaxCompletionTokens() != null) {
+            options.maxCompletionTokens(properties.getMaxCompletionTokens());
+        }
+        return OpenAiChatModel.builder()
+                .openAiApi(api)
+                .defaultOptions(options.build())
+                .toolCallingManager(toolCallingManager)
+                .retryTemplate(retryTemplate)
+                .observationRegistry(observationRegistry)
+                .build();
+    }
+
+    private EmbeddingModel openAiEmbeddingModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OpenAiApi api =
+                OpenAiApi.builder()
+                        .baseUrl(requireText(properties.getBaseUrl(), propertyPath + ".base-url"))
+                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
+                        .build();
+        OpenAiEmbeddingOptions.Builder options =
+                OpenAiEmbeddingOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getDimensions() != null) {
+            options.dimensions(properties.getDimensions());
+        }
+        return new OpenAiEmbeddingModel(
+                api, MetadataMode.EMBED, options.build(), retryTemplate, observationRegistry);
+    }
+
+    private ChatModel anthropicChatModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        AnthropicApi.Builder api =
+                AnthropicApi.builder()
+                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"));
+        if (StringUtils.hasText(properties.getBaseUrl())) {
+            api.baseUrl(properties.getBaseUrl());
+        }
+        AnthropicChatOptions.Builder options =
+                AnthropicChatOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getTemperature() != null) {
+            options.temperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.topP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.topK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.maxTokens(properties.getMaxTokens());
+        }
+        return AnthropicChatModel.builder()
+                .anthropicApi(api.build())
+                .defaultOptions(options.build())
+                .toolCallingManager(toolCallingManager)
+                .retryTemplate(retryTemplate)
+                .observationRegistry(observationRegistry)
+                .build();
+    }
+
+    private ChatModel googleGenAiChatModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        GoogleGenAiChatOptions.Builder options =
+                GoogleGenAiChatOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getTemperature() != null) {
+            options.temperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.topP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.topK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.maxOutputTokens(properties.getMaxTokens());
+        }
+        return GoogleGenAiChatModel.builder()
+                .genAiClient(googleClient(propertyPath, properties))
+                .defaultOptions(options.build())
+                .toolCallingManager(toolCallingManager)
+                .retryTemplate(retryTemplate)
+                .observationRegistry(observationRegistry)
+                .build();
+    }
+
+    private EmbeddingModel googleGenAiEmbeddingModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        GoogleGenAiTextEmbeddingOptions.Builder options =
+                GoogleGenAiTextEmbeddingOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getDimensions() != null) {
+            options.dimensions(properties.getDimensions());
+        }
+        GoogleGenAiEmbeddingConnectionDetails.Builder connectionDetailsBuilder =
+                GoogleGenAiEmbeddingConnectionDetails.builder()
+                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"))
+                        .genAiClient(googleClient(propertyPath, properties));
+        if (StringUtils.hasText(properties.getProjectId())) {
+            connectionDetailsBuilder.projectId(properties.getProjectId());
+        }
+        if (StringUtils.hasText(properties.getLocation())) {
+            connectionDetailsBuilder.location(properties.getLocation());
+        }
+        GoogleGenAiEmbeddingConnectionDetails connectionDetails = connectionDetailsBuilder.build();
+        return new GoogleGenAiTextEmbeddingModel(
+                connectionDetails, options.build(), retryTemplate, observationRegistry);
+    }
+
+    private ChatModel ollamaChatModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OllamaChatOptions.Builder options =
+                OllamaChatOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getTemperature() != null) {
+            options.temperature(properties.getTemperature());
+        }
+        if (properties.getTopP() != null) {
+            options.topP(properties.getTopP());
+        }
+        if (properties.getTopK() != null) {
+            options.topK(properties.getTopK());
+        }
+        if (properties.getMaxTokens() != null) {
+            options.numPredict(properties.getMaxTokens());
+        }
+        return OllamaChatModel.builder()
+                .ollamaApi(ollamaApi(propertyPath, properties))
+                .defaultOptions(options.build())
+                .toolCallingManager(toolCallingManager)
+                .retryTemplate(retryTemplate)
+                .observationRegistry(observationRegistry)
+                .modelManagementOptions(ModelManagementOptions.defaults())
+                .build();
+    }
+
+    private EmbeddingModel ollamaEmbeddingModel(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OllamaEmbeddingOptions.Builder options =
+                OllamaEmbeddingOptions.builder()
+                        .model(requireText(properties.getModel(), propertyPath + ".model"));
+        if (properties.getDimensions() != null) {
+            options.dimensions(properties.getDimensions());
+        }
+        return OllamaEmbeddingModel.builder()
+                .ollamaApi(ollamaApi(propertyPath, properties))
+                .defaultOptions(options.build())
+                .observationRegistry(observationRegistry)
+                .modelManagementOptions(ModelManagementOptions.defaults())
+                .build();
+    }
+
+    private Client googleClient(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        Client.Builder builder =
+                Client.builder()
+                        .apiKey(requireText(properties.getApiKey(), propertyPath + ".api-key"));
+        if (StringUtils.hasText(properties.getBaseUrl())) {
+            builder.httpOptions(HttpOptions.builder().baseUrl(properties.getBaseUrl()).build());
+        }
+        if (StringUtils.hasText(properties.getProjectId())) {
+            builder.project(properties.getProjectId());
+        }
+        if (StringUtils.hasText(properties.getLocation())) {
+            builder.location(properties.getLocation());
+        }
+        return builder.build();
+    }
+
+    private OllamaApi ollamaApi(
+            String propertyPath, MemindAiProperties.ClientProperties properties) {
+        OllamaApi.Builder builder = OllamaApi.builder();
+        if (StringUtils.hasText(properties.getBaseUrl())) {
+            builder.baseUrl(properties.getBaseUrl());
+        } else {
+            throw new MemindAiConfigurationException(propertyPath + ".base-url is required");
+        }
+        return builder.build();
+    }
+
+    static RetryTemplate defaultRetryTemplate() {
+        return new RetryTemplate(RetryPolicy.withDefaults());
+    }
+
+    static ObservationRegistry defaultObservationRegistry() {
+        return ObservationRegistry.NOOP;
+    }
+
+    static ToolCallingManager defaultToolCallingManager(ObservationRegistry observationRegistry) {
+        return ToolCallingManager.builder().observationRegistry(observationRegistry).build();
+    }
+
+    private static String normalizeProvider(String provider) {
+        return provider.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String requireText(String value, String propertyPath) {
+        if (!StringUtils.hasText(value)) {
+            throw new MemindAiConfigurationException(propertyPath + " must not be blank");
+        }
+        return value;
+    }
+
+    private static <K, V> Map<K, V> emptySafe(Map<K, V> map) {
+        return map == null ? Map.of() : map;
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationException.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationException.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+public class MemindAiConfigurationException extends IllegalStateException {
+
+    public MemindAiConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
@@ -16,11 +16,48 @@ package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
 
 @ConfigurationProperties(prefix = "memind.ai")
 public class MemindAiProperties {
+
+    public enum AiProvider {
+        OPENAI,
+        ANTHROPIC,
+        GOOGLE,
+        OLLAMA;
+
+        String propertyValue() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    static final class AiProviderConverter implements Converter<String, AiProvider> {
+
+        @Override
+        public AiProvider convert(String source) {
+            if (!StringUtils.hasText(source)) {
+                return null;
+            }
+            String normalized = source.trim().toLowerCase(Locale.ROOT).replace("_", "-");
+            return switch (normalized) {
+                case "openai", "openai-compatible" -> AiProvider.OPENAI;
+                case "anthropic", "claude" -> AiProvider.ANTHROPIC;
+                case "google", "google-genai", "gemini" -> AiProvider.GOOGLE;
+                case "ollama" -> AiProvider.OLLAMA;
+                default ->
+                        throw new IllegalArgumentException(
+                                "Unsupported memind AI provider '"
+                                        + source
+                                        + "'. Supported providers are openai, anthropic, google,"
+                                        + " and ollama.");
+            };
+        }
+    }
 
     private ChatProperties chat = new ChatProperties();
     private EmbeddingProperties embedding = new EmbeddingProperties();
@@ -96,7 +133,7 @@ public class MemindAiProperties {
 
     public static class ClientProperties {
 
-        private String provider;
+        private AiProvider provider;
         private String baseUrl;
         private String apiKey;
         private String model;
@@ -109,11 +146,11 @@ public class MemindAiProperties {
         private String projectId;
         private String location;
 
-        public String getProvider() {
+        public AiProvider getProvider() {
             return provider;
         }
 
-        public void setProvider(String provider) {
+        public void setProvider(AiProvider provider) {
             this.provider = provider;
         }
 

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
@@ -19,8 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.util.StringUtils;
 
 @ConfigurationProperties(prefix = "memind.ai")
 public class MemindAiProperties {
@@ -33,29 +31,6 @@ public class MemindAiProperties {
 
         String propertyValue() {
             return name().toLowerCase(Locale.ROOT);
-        }
-    }
-
-    static final class AiProviderConverter implements Converter<String, AiProvider> {
-
-        @Override
-        public AiProvider convert(String source) {
-            if (!StringUtils.hasText(source)) {
-                return null;
-            }
-            String normalized = source.trim().toLowerCase(Locale.ROOT).replace("_", "-");
-            return switch (normalized) {
-                case "openai", "openai-compatible" -> AiProvider.OPENAI;
-                case "anthropic", "claude" -> AiProvider.ANTHROPIC;
-                case "google", "google-genai", "gemini" -> AiProvider.GOOGLE;
-                case "ollama" -> AiProvider.OLLAMA;
-                default ->
-                        throw new IllegalArgumentException(
-                                "Unsupported memind AI provider '"
-                                        + source
-                                        + "'. Supported providers are openai, anthropic, google,"
-                                        + " and ollama.");
-            };
         }
     }
 

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiProperties.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "memind.ai")
+public class MemindAiProperties {
+
+    private ChatProperties chat = new ChatProperties();
+    private EmbeddingProperties embedding = new EmbeddingProperties();
+
+    public ChatProperties getChat() {
+        return chat;
+    }
+
+    public void setChat(ChatProperties chat) {
+        this.chat = chat;
+    }
+
+    public EmbeddingProperties getEmbedding() {
+        return embedding;
+    }
+
+    public void setEmbedding(EmbeddingProperties embedding) {
+        this.embedding = embedding;
+    }
+
+    public static class ChatProperties {
+
+        private String defaultClient;
+        private Map<String, ClientProperties> clients = new LinkedHashMap<>();
+        private Map<ChatClientSlot, String> slots = new EnumMap<>(ChatClientSlot.class);
+
+        public String getDefaultClient() {
+            return defaultClient;
+        }
+
+        public void setDefaultClient(String defaultClient) {
+            this.defaultClient = defaultClient;
+        }
+
+        public Map<String, ClientProperties> getClients() {
+            return clients;
+        }
+
+        public void setClients(Map<String, ClientProperties> clients) {
+            this.clients = clients;
+        }
+
+        public Map<ChatClientSlot, String> getSlots() {
+            return slots;
+        }
+
+        public void setSlots(Map<ChatClientSlot, String> slots) {
+            this.slots = slots;
+        }
+    }
+
+    public static class EmbeddingProperties {
+
+        private String client;
+        private Map<String, ClientProperties> clients = new LinkedHashMap<>();
+
+        public String getClient() {
+            return client;
+        }
+
+        public void setClient(String client) {
+            this.client = client;
+        }
+
+        public Map<String, ClientProperties> getClients() {
+            return clients;
+        }
+
+        public void setClients(Map<String, ClientProperties> clients) {
+            this.clients = clients;
+        }
+    }
+
+    public static class ClientProperties {
+
+        private String provider;
+        private String baseUrl;
+        private String apiKey;
+        private String model;
+        private Double temperature;
+        private Double topP;
+        private Integer topK;
+        private Integer maxTokens;
+        private Integer maxCompletionTokens;
+        private Integer dimensions;
+        private String projectId;
+        private String location;
+
+        public String getProvider() {
+            return provider;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        public String getApiKey() {
+            return apiKey;
+        }
+
+        public void setApiKey(String apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+
+        public Double getTemperature() {
+            return temperature;
+        }
+
+        public void setTemperature(Double temperature) {
+            this.temperature = temperature;
+        }
+
+        public Double getTopP() {
+            return topP;
+        }
+
+        public void setTopP(Double topP) {
+            this.topP = topP;
+        }
+
+        public Integer getTopK() {
+            return topK;
+        }
+
+        public void setTopK(Integer topK) {
+            this.topK = topK;
+        }
+
+        public Integer getMaxTokens() {
+            return maxTokens;
+        }
+
+        public void setMaxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+        }
+
+        public Integer getMaxCompletionTokens() {
+            return maxCompletionTokens;
+        }
+
+        public void setMaxCompletionTokens(Integer maxCompletionTokens) {
+            this.maxCompletionTokens = maxCompletionTokens;
+        }
+
+        public Integer getDimensions() {
+            return dimensions;
+        }
+
+        public void setDimensions(Integer dimensions) {
+            this.dimensions = dimensions;
+        }
+
+        public String getProjectId() {
+            return projectId;
+        }
+
+        public void setProjectId(String projectId) {
+            this.projectId = projectId;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindChatClients.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindChatClients.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class MemindChatClients {
+
+    private final String defaultClientId;
+    private final StructuredChatClient defaultClient;
+    private final Map<String, StructuredChatClient> clients;
+    private final Map<ChatClientSlot, String> slotClientIds;
+    private final Map<ChatClientSlot, StructuredChatClient> slotClients;
+
+    public MemindChatClients(
+            String defaultClientId,
+            StructuredChatClient defaultClient,
+            Map<String, StructuredChatClient> clients,
+            Map<ChatClientSlot, String> slotClientIds,
+            Map<ChatClientSlot, StructuredChatClient> slotClients) {
+        this.defaultClientId = requireText(defaultClientId, "defaultClientId");
+        this.defaultClient = Objects.requireNonNull(defaultClient, "defaultClient");
+        this.clients = Map.copyOf(Objects.requireNonNull(clients, "clients"));
+        this.slotClientIds = Map.copyOf(Objects.requireNonNull(slotClientIds, "slotClientIds"));
+        this.slotClients = Map.copyOf(Objects.requireNonNull(slotClients, "slotClients"));
+    }
+
+    public String defaultClientId() {
+        return defaultClientId;
+    }
+
+    public StructuredChatClient defaultClient() {
+        return defaultClient;
+    }
+
+    public Map<String, StructuredChatClient> clients() {
+        return clients;
+    }
+
+    public Set<String> clientIds() {
+        return clients.keySet();
+    }
+
+    public Map<ChatClientSlot, String> slotClientIds() {
+        return slotClientIds;
+    }
+
+    public Map<ChatClientSlot, StructuredChatClient> slotClients() {
+        return slotClients;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiLlmAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiLlmAutoConfiguration.java
@@ -21,16 +21,37 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 
 @AutoConfiguration
 @AutoConfigureAfter(
-        name = "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration")
+        name = {
+            "com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindAiClientAutoConfiguration",
+            "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration"
+        })
 @ConditionalOnClass(ChatClient.class)
-@ConditionalOnBean(ChatClient.Builder.class)
+@EnableConfigurationProperties(MemindAiProperties.class)
 public class SpringAiLlmAutoConfiguration {
 
     @Bean
+    @Conditional(ConfiguredChatClientsCondition.class)
+    @ConditionalOnMissingBean
+    public MemindChatClients memindChatClients(
+            MemindAiProperties properties, MemindAiClientFactory clientFactory) {
+        return clientFactory.createChatClients(properties.getChat());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(StructuredChatClient.class)
+    @ConditionalOnBean(MemindChatClients.class)
+    public StructuredChatClient memindConfiguredStructuredLlmClient(MemindChatClients clients) {
+        return clients.defaultClient();
+    }
+
+    @Bean
+    @ConditionalOnBean(ChatClient.Builder.class)
     @ConditionalOnMissingBean(StructuredChatClient.class)
     public StructuredChatClient structuredLlmClient(ChatClient.Builder chatClientBuilder) {
         return new SpringAiStructuredChatClient(chatClientBuilder.build());

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiVectorAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiVectorAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 
 @AutoConfiguration
 @AutoConfigureAfter(
@@ -36,11 +37,19 @@ import org.springframework.context.annotation.Bean;
             "org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiMultiModalEmbeddingAutoConfiguration"
         })
 @ConditionalOnClass(EmbeddingModel.class)
-@ConditionalOnBean(EmbeddingModel.class)
-@EnableConfigurationProperties(SpringAiVectorProperties.class)
+@EnableConfigurationProperties({SpringAiVectorProperties.class, MemindAiProperties.class})
 public class SpringAiVectorAutoConfiguration {
 
+    @Bean
+    @Conditional(ConfiguredEmbeddingClientsCondition.class)
+    @ConditionalOnMissingBean(EmbeddingModel.class)
+    public EmbeddingModel memindEmbeddingModel(
+            MemindAiProperties properties, MemindAiClientFactory clientFactory) {
+        return clientFactory.createEmbeddingModel(properties.getEmbedding());
+    }
+
     @Bean(destroyMethod = "")
+    @ConditionalOnBean(EmbeddingModel.class)
     @ConditionalOnMissingBean({VectorStore.class, MemoryVector.class})
     public VectorStore vectorStore(
             EmbeddingModel embeddingModel, SpringAiVectorProperties properties) {
@@ -48,6 +57,7 @@ public class SpringAiVectorAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(EmbeddingModel.class)
     @ConditionalOnMissingBean(MemoryVector.class)
     public MemoryVector memoryVector(VectorStore vectorStore, EmbeddingModel embeddingModel) {
         return new SpringAiMemoryVector(vectorStore, embeddingModel);

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiVectorAutoConfiguration.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/SpringAiVectorAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Primary;
 
 @AutoConfiguration
 @AutoConfigureAfter(
@@ -42,7 +43,7 @@ public class SpringAiVectorAutoConfiguration {
 
     @Bean
     @Conditional(ConfiguredEmbeddingClientsCondition.class)
-    @ConditionalOnMissingBean(EmbeddingModel.class)
+    @Primary
     public EmbeddingModel memindEmbeddingModel(
             MemindAiProperties properties, MemindAiClientFactory clientFactory) {
         return clientFactory.createEmbeddingModel(properties.getEmbedding());

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
+com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindAiClientAutoConfiguration
 com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.SpringAiLlmAutoConfiguration
 com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.SpringAiVectorAutoConfiguration

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
@@ -93,38 +93,51 @@ class MemindAiConfigurationTest {
     }
 
     @Test
-    @DisplayName("binds provider aliases to canonical providers")
-    void bindsProviderAliasesToCanonicalProviders() {
+    @DisplayName("binds canonical providers to enum values")
+    void bindsCanonicalProvidersToEnumValues() {
         contextRunner
                 .withPropertyValues(
-                        "memind.ai.chat.default-client=ds",
-                        "memind.ai.chat.clients.ds.provider=openai-compatible",
-                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
-                        "memind.ai.chat.clients.ds.api-key=test-key",
-                        "memind.ai.chat.clients.ds.model=deepseek-chat",
-                        "memind.ai.chat.clients.claude.provider=claude",
-                        "memind.ai.chat.clients.gemini.provider=gemini")
+                        "memind.ai.chat.default-client=openai",
+                        "memind.ai.chat.clients.openai.provider=openai",
+                        "memind.ai.chat.clients.openai.base-url=https://api.openai.com",
+                        "memind.ai.chat.clients.openai.api-key=test-key",
+                        "memind.ai.chat.clients.openai.model=gpt-4o-mini",
+                        "memind.ai.chat.clients.anthropic.provider=anthropic",
+                        "memind.ai.chat.clients.google.provider=google",
+                        "memind.ai.chat.clients.ollama.provider=ollama")
                 .run(
                         context -> {
                             assertThat(context).hasNotFailed();
                             MemindAiProperties properties =
                                     context.getBean(MemindAiProperties.class);
-                            assertThat(properties.getChat().getClients().get("ds").getProvider())
+                            assertThat(
+                                            properties
+                                                    .getChat()
+                                                    .getClients()
+                                                    .get("openai")
+                                                    .getProvider())
                                     .isEqualTo(AiProvider.OPENAI);
                             assertThat(
                                             properties
                                                     .getChat()
                                                     .getClients()
-                                                    .get("claude")
+                                                    .get("anthropic")
                                                     .getProvider())
                                     .isEqualTo(AiProvider.ANTHROPIC);
                             assertThat(
                                             properties
                                                     .getChat()
                                                     .getClients()
-                                                    .get("gemini")
+                                                    .get("google")
                                                     .getProvider())
                                     .isEqualTo(AiProvider.GOOGLE);
+                            assertThat(
+                                            properties
+                                                    .getChat()
+                                                    .getClients()
+                                                    .get("ollama")
+                                                    .getProvider())
+                                    .isEqualTo(AiProvider.OLLAMA);
                         });
     }
 

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
@@ -73,6 +73,44 @@ class MemindAiConfigurationTest {
     }
 
     @Test
+    @DisplayName("creates OpenAI chat client from Spring AI defaults")
+    void createsOpenAiChatClientFromSpringAiDefaults() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.ai.openai.base-url=https://openrouter.ai/api",
+                        "spring.ai.openai.api-key=test-key",
+                        "spring.ai.openai.chat.options.model=openai/gpt-4o-mini",
+                        "memind.ai.chat.default-client=openai",
+                        "memind.ai.chat.clients.openai.provider=openai")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context).hasSingleBean(MemindChatClients.class);
+                            assertThat(context.getBean(MemindChatClients.class).defaultClientId())
+                                    .isEqualTo("openai");
+                        });
+    }
+
+    @Test
+    @DisplayName("does not create or validate unreferenced chat clients")
+    void doesNotCreateOrValidateUnreferencedChatClients() {
+        contextRunner
+                .withPropertyValues(
+                        "memind.ai.chat.default-client=ds",
+                        "memind.ai.chat.clients.ds.provider=openai",
+                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds.api-key=test-key",
+                        "memind.ai.chat.clients.ds.model=deepseek-chat",
+                        "memind.ai.chat.clients.unused.provider=openai")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context.getBean(MemindChatClients.class).clientIds())
+                                    .containsExactly("ds");
+                        });
+    }
+
+    @Test
     @DisplayName("fails fast when default client is not configured")
     void failsWhenDefaultClientIsMissing() {
         contextRunner
@@ -122,6 +160,23 @@ class MemindAiConfigurationTest {
                         "memind.ai.embedding.clients.embedding.api-key=test-key",
                         "memind.ai.embedding.clients.embedding.model=BAAI/bge-m3",
                         "memind.ai.embedding.clients.embedding.dimensions=1024")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context).hasSingleBean(EmbeddingModel.class);
+                        });
+    }
+
+    @Test
+    @DisplayName("creates OpenAI embedding model from Spring AI defaults")
+    void createsOpenAiEmbeddingModelFromSpringAiDefaults() {
+        vectorContextRunner
+                .withPropertyValues(
+                        "spring.ai.openai.base-url=https://openrouter.ai/api",
+                        "spring.ai.openai.api-key=test-key",
+                        "spring.ai.openai.embedding.options.model=openai/text-embedding-3-small",
+                        "memind.ai.embedding.client=openai",
+                        "memind.ai.embedding.clients.openai.provider=openai")
                 .run(
                         context -> {
                             assertThat(context).hasNotFailed();

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindAiProperties.AiProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -88,6 +89,42 @@ class MemindAiConfigurationTest {
                             assertThat(context).hasSingleBean(MemindChatClients.class);
                             assertThat(context.getBean(MemindChatClients.class).defaultClientId())
                                     .isEqualTo("openai");
+                        });
+    }
+
+    @Test
+    @DisplayName("binds provider aliases to canonical providers")
+    void bindsProviderAliasesToCanonicalProviders() {
+        contextRunner
+                .withPropertyValues(
+                        "memind.ai.chat.default-client=ds",
+                        "memind.ai.chat.clients.ds.provider=openai-compatible",
+                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds.api-key=test-key",
+                        "memind.ai.chat.clients.ds.model=deepseek-chat",
+                        "memind.ai.chat.clients.claude.provider=claude",
+                        "memind.ai.chat.clients.gemini.provider=gemini")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            MemindAiProperties properties =
+                                    context.getBean(MemindAiProperties.class);
+                            assertThat(properties.getChat().getClients().get("ds").getProvider())
+                                    .isEqualTo(AiProvider.OPENAI);
+                            assertThat(
+                                            properties
+                                                    .getChat()
+                                                    .getClients()
+                                                    .get("claude")
+                                                    .getProvider())
+                                    .isEqualTo(AiProvider.ANTHROPIC);
+                            assertThat(
+                                            properties
+                                                    .getChat()
+                                                    .getClients()
+                                                    .get("gemini")
+                                                    .getProvider())
+                                    .isEqualTo(AiProvider.GOOGLE);
                         });
     }
 

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemindAiConfigurationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.memory.plugin.ai.spring.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
+import com.openmemind.ai.memory.core.llm.StructuredChatClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("Memind AI configuration")
+class MemindAiConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    MemindAiClientAutoConfiguration.class,
+                                    SpringAiLlmAutoConfiguration.class));
+
+    private final ApplicationContextRunner vectorContextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    MemindAiClientAutoConfiguration.class,
+                                    SpringAiVectorAutoConfiguration.class));
+
+    @Test
+    @DisplayName("creates configured chat clients and slot routing")
+    void createsConfiguredChatClientsAndSlotRouting() {
+        contextRunner
+                .withPropertyValues(
+                        "memind.ai.chat.default-client=ds",
+                        "memind.ai.chat.clients.ds.provider=openai",
+                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds.api-key=test-key",
+                        "memind.ai.chat.clients.ds.model=deepseek-chat",
+                        "memind.ai.chat.clients.ds-reasoner.provider=openai",
+                        "memind.ai.chat.clients.ds-reasoner.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds-reasoner.api-key=test-key",
+                        "memind.ai.chat.clients.ds-reasoner.model=deepseek-reasoner",
+                        "memind.ai.chat.slots.INSIGHT_GENERATOR=ds-reasoner")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context).hasSingleBean(MemindChatClients.class);
+                            assertThat(context).hasSingleBean(StructuredChatClient.class);
+
+                            MemindChatClients clients = context.getBean(MemindChatClients.class);
+                            assertThat(clients.defaultClientId()).isEqualTo("ds");
+                            assertThat(clients.clientIds())
+                                    .containsExactlyInAnyOrder("ds", "ds-reasoner");
+                            assertThat(clients.slotClientIds())
+                                    .containsEntry(ChatClientSlot.INSIGHT_GENERATOR, "ds-reasoner");
+                            assertThat(clients.slotClients())
+                                    .containsKey(ChatClientSlot.INSIGHT_GENERATOR);
+                        });
+    }
+
+    @Test
+    @DisplayName("fails fast when default client is not configured")
+    void failsWhenDefaultClientIsMissing() {
+        contextRunner
+                .withPropertyValues(
+                        "memind.ai.chat.default-client=missing",
+                        "memind.ai.chat.clients.ds.provider=openai",
+                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds.api-key=test-key",
+                        "memind.ai.chat.clients.ds.model=deepseek-chat")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasFailed()
+                                        .getFailure()
+                                        .hasMessageContaining(
+                                                "memind.ai.chat.default-client 'missing'"));
+    }
+
+    @Test
+    @DisplayName("fails fast when a slot references an unknown client")
+    void failsWhenSlotReferencesUnknownClient() {
+        contextRunner
+                .withPropertyValues(
+                        "memind.ai.chat.default-client=ds",
+                        "memind.ai.chat.clients.ds.provider=openai",
+                        "memind.ai.chat.clients.ds.base-url=https://api.deepseek.com",
+                        "memind.ai.chat.clients.ds.api-key=test-key",
+                        "memind.ai.chat.clients.ds.model=deepseek-chat",
+                        "memind.ai.chat.slots.INSIGHT_GENERATOR=missing")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasFailed()
+                                        .getFailure()
+                                        .hasMessageContaining(
+                                                "memind.ai.chat.slots.INSIGHT_GENERATOR"));
+    }
+
+    @Test
+    @DisplayName("creates configured embedding model")
+    void createsConfiguredEmbeddingModel() {
+        vectorContextRunner
+                .withPropertyValues(
+                        "memind.ai.embedding.client=embedding",
+                        "memind.ai.embedding.clients.embedding.provider=openai",
+                        "memind.ai.embedding.clients.embedding.base-url=https://api.siliconflow.cn/v1",
+                        "memind.ai.embedding.clients.embedding.api-key=test-key",
+                        "memind.ai.embedding.clients.embedding.model=BAAI/bge-m3",
+                        "memind.ai.embedding.clients.embedding.dimensions=1024")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context).hasSingleBean(EmbeddingModel.class);
+                        });
+    }
+}

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemoryVectorAutoConfigurationTest.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter/src/test/java/com/openmemind/ai/memory/plugin/ai/spring/autoconfigure/MemoryVectorAutoConfigurationTest.java
@@ -35,7 +35,9 @@ class MemoryVectorAutoConfigurationTest {
     private final ApplicationContextRunner contextRunner =
             new ApplicationContextRunner()
                     .withConfiguration(
-                            AutoConfigurations.of(SpringAiVectorAutoConfiguration.class));
+                            AutoConfigurations.of(
+                                    MemindAiClientAutoConfiguration.class,
+                                    SpringAiVectorAutoConfiguration.class));
 
     @Nested
     @DisplayName("Default Configuration")
@@ -67,6 +69,28 @@ class MemoryVectorAutoConfigurationTest {
                                         .isInstanceOf(FileSimpleVectorStore.class);
                                 assertThat(context.getBean(MemoryVector.class))
                                         .isInstanceOf(SpringAiMemoryVector.class);
+                            });
+        }
+
+        @Test
+        @DisplayName("Memind configured EmbeddingModel is primary when another one exists")
+        void memindConfiguredEmbeddingModelIsPrimaryWhenAnotherOneExists() {
+            contextRunner
+                    .withUserConfiguration(EmbeddingModelConfig.class)
+                    .withPropertyValues(
+                            "memind.ai.embedding.client=memind",
+                            "memind.ai.embedding.clients.memind.provider=openai",
+                            "memind.ai.embedding.clients.memind.base-url=https://api.siliconflow.cn/v1",
+                            "memind.ai.embedding.clients.memind.api-key=test-key",
+                            "memind.ai.embedding.clients.memind.model=BAAI/bge-m3")
+                    .run(
+                            context -> {
+                                assertThat(context).hasNotFailed();
+                                assertThat(context).hasBean("memindEmbeddingModel");
+                                assertThat(context.getBeanNamesForType(EmbeddingModel.class))
+                                        .hasSize(2);
+                                assertThat(context.getBean(EmbeddingModel.class))
+                                        .isSameAs(context.getBean("memindEmbeddingModel"));
                             });
         }
     }

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfiguration.java
@@ -31,6 +31,7 @@ import com.openmemind.ai.memory.core.textsearch.MemoryTextSearch;
 import com.openmemind.ai.memory.core.tracing.MemoryObserver;
 import com.openmemind.ai.memory.core.utils.JsonUtils;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
+import com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindChatClients;
 import com.openmemind.ai.memory.server.domain.config.model.ServerRuntimeConfigDO;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeFactory;
 import com.openmemind.ai.memory.server.runtime.MemoryRuntimeManager;
@@ -70,6 +71,7 @@ public class MemindServerRuntimeConfiguration {
 
     @Bean
     MemoryRuntimeFactory memoryRuntimeFactory(
+            ObjectProvider<MemindChatClients> memindChatClientsProvider,
             ObjectProvider<StructuredChatClient> structuredChatClientProvider,
             ObjectProvider<MemoryStore> memoryStoreProvider,
             ObjectProvider<MemoryBuffer> memoryBufferProvider,
@@ -83,8 +85,11 @@ public class MemindServerRuntimeConfiguration {
             ObjectProvider<MemoryObserver> memoryObserverProvider,
             ObjectProvider<MemoryMetricsRecorder> memoryMetricsRecorderProvider) {
         return options -> {
+            MemindChatClients memindChatClients = memindChatClientsProvider.getIfAvailable();
             StructuredChatClient structuredChatClient =
-                    requireRuntimeDependency(structuredChatClientProvider);
+                    memindChatClients == null
+                            ? requireRuntimeDependency(structuredChatClientProvider)
+                            : memindChatClients.defaultClient();
             MemoryStore memoryStore = requireRuntimeDependency(memoryStoreProvider);
             MemoryBuffer memoryBuffer = requireRuntimeDependency(memoryBufferProvider);
             MemoryVector memoryVector = requireRuntimeDependency(memoryVectorProvider);
@@ -108,6 +113,9 @@ public class MemindServerRuntimeConfiguration {
                             .vector(memoryVector)
                             .options(effectiveOptions)
                             .externallyManaged(true);
+            if (memindChatClients != null) {
+                memindChatClients.slotClients().forEach(builder::chatClient);
+            }
             if (bubbleTrackerStore != null) {
                 builder.bubbleTrackerStore(bubbleTrackerStore);
             }
@@ -149,6 +157,7 @@ public class MemindServerRuntimeConfiguration {
             ObjectProvider<BubbleTrackerStore> bubbleTrackerStoreProvider,
             ObjectProvider<MemoryObserver> memoryObserverProvider) {
         return memoryRuntimeFactory(
+                emptyProvider(MemindChatClients.class),
                 structuredChatClientProvider,
                 memoryStoreProvider,
                 memoryBufferProvider,
@@ -161,6 +170,11 @@ public class MemindServerRuntimeConfiguration {
                 bubbleTrackerStoreProvider,
                 memoryObserverProvider,
                 null);
+    }
+
+    private static <T> ObjectProvider<T> emptyProvider(Class<T> type) {
+        return new org.springframework.beans.factory.support.StaticListableBeanFactory()
+                .getBeanProvider(type);
     }
 
     private static List<ContentParser> resolveContentParsers(

--- a/memind-server/src/main/resources/application.yml
+++ b/memind-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@
 # Local development defaults:
 # - SQLite is used by default and can be overridden through MEMIND_DATASOURCE_* env vars.
 # - The fallback vector store is a local JSON file.
-# - Spring AI OpenAI-compatible settings are read from OPENAI_* env vars.
+# - Memind AI chat and embedding clients are configured under memind.ai.
 # - Optional rerank provider settings are read from MEMIND_RERANK_* env vars.
 # - To switch to MySQL or Qdrant, replace/merge the commented examples at the bottom of this file.
 
@@ -57,22 +57,45 @@ spring:
           resource: false
           prompt: false
           completion: false
-    openai:
-      base-url: ${OPENAI_BASE_URL:https://openrouter.ai/api}
-      api-key: ${OPENAI_API_KEY:}
-      chat:
-        options:
-          model: ${OPENAI_CHAT_MODEL:openai/gpt-4o-mini}
-      embedding:
-        base-url: ${EMBEDDING_BASE_URL:${OPENAI_BASE_URL:}}
-        api-key: ${EMBEDDING_API_KEY:${OPENAI_API_KEY:}}
-        options:
-          model: ${OPENAI_EMBEDDING_MODEL:openai/text-embedding-3-small}
 
 server:
   port: ${SERVER_PORT:8366}
 
 memind:
+  ai:
+    chat:
+      # Client ids are local names. Each client can target OpenAI-compatible endpoints
+      # such as OpenAI, DeepSeek, GLM, OpenRouter, SiliconFlow, or any compatible gateway.
+      default-client: openai
+      clients:
+        openai:
+          provider: openai
+          base-url: https://openrouter.ai/api
+          api-key: ${OPENAI_API_KEY:}
+          model: openai/gpt-4o-mini
+          temperature: 0.2
+      # Optional slot routing. Unconfigured slots use default-client.
+      # Add or change entries when some memory pipeline stages should use another client.
+      slots:
+        ITEM_EXTRACTION: openai
+        CONVERSATION_CHUNKER: openai
+        CAPTION_GENERATOR: openai
+        CONTEXT_COMMIT_DETECTOR: openai
+        INSIGHT_GENERATOR: openai
+        INSIGHT_GROUP_CLASSIFIER: openai
+        QUERY_EXPANDER: openai
+        LONG_QUERY_CONDENSER: openai
+        SUFFICIENCY_GATE: openai
+        INSIGHT_TYPE_ROUTER: openai
+        THREAD_ENRICHMENT: openai
+    embedding:
+      client: openai
+      clients:
+        openai:
+          provider: openai
+          base-url: https://openrouter.ai/api
+          api-key: ${OPENAI_API_KEY:}
+          model: openai/text-embedding-3-small
   mcp:
     governance-enabled: ${MEMIND_MCP_GOVERNANCE_ENABLED:false}
     default-token-budget: ${MEMIND_MCP_DEFAULT_TOKEN_BUDGET:1800}

--- a/memind-server/src/main/resources/application.yml
+++ b/memind-server/src/main/resources/application.yml
@@ -15,7 +15,8 @@
 # Local development defaults:
 # - SQLite is used by default and can be overridden through MEMIND_DATASOURCE_* env vars.
 # - The fallback vector store is a local JSON file.
-# - Memind AI chat and embedding clients are configured under memind.ai.
+# - Spring AI provider defaults are configured under spring.ai.
+# - Memind AI client routing is configured under memind.ai.
 # - Optional rerank provider settings are read from MEMIND_RERANK_* env vars.
 # - To switch to MySQL or Qdrant, replace/merge the commented examples at the bottom of this file.
 
@@ -36,6 +37,21 @@ spring:
   jackson:
     default-property-inclusion: non_null
   ai:
+    model:
+      chat: openai
+      embedding: openai
+    openai:
+      base-url: ${OPENAI_BASE_URL:https://openrouter.ai/api}
+      api-key: ${OPENAI_API_KEY:your-api-key}
+      chat:
+        options:
+          model: ${OPENAI_CHAT_MODEL:openai/gpt-4o-mini}
+          temperature: ${OPENAI_CHAT_TEMPERATURE:0.2}
+      embedding:
+        base-url: ${EMBEDDING_BASE_URL:${OPENAI_BASE_URL:https://openrouter.ai/api}}
+        api-key: ${EMBEDDING_API_KEY:${OPENAI_API_KEY:your-api-key}}
+        options:
+          model: ${OPENAI_EMBEDDING_MODEL:openai/text-embedding-3-small}
     # Keeps external Spring AI vector stores dormant by default.
     # Switch this to qdrant in the commented example below when enabling Qdrant.
     vectorstore:
@@ -64,38 +80,21 @@ server:
 memind:
   ai:
     chat:
-      # Client ids are local names. Each client can target OpenAI-compatible endpoints
-      # such as OpenAI, DeepSeek, GLM, OpenRouter, SiliconFlow, or any compatible gateway.
+      # Client ids are local routing names. This default client inherits provider defaults
+      # from spring.ai.openai above. Add more clients here to route individual slots to
+      # different providers, endpoints, or models.
       default-client: openai
       clients:
         openai:
           provider: openai
-          base-url: https://openrouter.ai/api
-          api-key: ${OPENAI_API_KEY:}
-          model: openai/gpt-4o-mini
-          temperature: 0.2
       # Optional slot routing. Unconfigured slots use default-client.
       # Add or change entries when some memory pipeline stages should use another client.
-      slots:
-        ITEM_EXTRACTION: openai
-        CONVERSATION_CHUNKER: openai
-        CAPTION_GENERATOR: openai
-        CONTEXT_COMMIT_DETECTOR: openai
-        INSIGHT_GENERATOR: openai
-        INSIGHT_GROUP_CLASSIFIER: openai
-        QUERY_EXPANDER: openai
-        LONG_QUERY_CONDENSER: openai
-        SUFFICIENCY_GATE: openai
-        INSIGHT_TYPE_ROUTER: openai
-        THREAD_ENRICHMENT: openai
+      slots: {}
     embedding:
       client: openai
       clients:
         openai:
           provider: openai
-          base-url: https://openrouter.ai/api
-          api-key: ${OPENAI_API_KEY:}
-          model: openai/text-embedding-3-small
   mcp:
     governance-enabled: ${MEMIND_MCP_GOVERNANCE_ENABLED:false}
     default-token-budget: ${MEMIND_MCP_DEFAULT_TOKEN_BUDGET:1800}

--- a/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
+++ b/memind-server/src/test/java/com/openmemind/ai/memory/server/configuration/MemindServerRuntimeConfigurationTest.java
@@ -33,6 +33,8 @@ import com.openmemind.ai.memory.core.builder.RawDataExtractionOptions;
 import com.openmemind.ai.memory.core.extraction.DefaultMemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.MemoryExtractor;
 import com.openmemind.ai.memory.core.extraction.insight.InsightLayer;
+import com.openmemind.ai.memory.core.extraction.insight.generator.InsightGenerator;
+import com.openmemind.ai.memory.core.extraction.insight.generator.LlmInsightGenerator;
 import com.openmemind.ai.memory.core.extraction.insight.scheduler.InsightBuildScheduler;
 import com.openmemind.ai.memory.core.extraction.insight.tree.BubbleTrackerStore;
 import com.openmemind.ai.memory.core.extraction.insight.tree.InsightTreeReorganizer;
@@ -41,6 +43,7 @@ import com.openmemind.ai.memory.core.extraction.item.graph.ItemGraphMaterializer
 import com.openmemind.ai.memory.core.extraction.rawdata.RawContentProcessor;
 import com.openmemind.ai.memory.core.extraction.rawdata.RawContentProcessorRegistry;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.RawContent;
+import com.openmemind.ai.memory.core.llm.ChatClientSlot;
 import com.openmemind.ai.memory.core.llm.StructuredChatClient;
 import com.openmemind.ai.memory.core.llm.rerank.NoopReranker;
 import com.openmemind.ai.memory.core.llm.rerank.Reranker;
@@ -62,6 +65,7 @@ import com.openmemind.ai.memory.core.tracing.ObservationContext;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingItemGraphMaterializer;
 import com.openmemind.ai.memory.core.tracing.decorator.TracingMemoryExtractor;
 import com.openmemind.ai.memory.core.vector.MemoryVector;
+import com.openmemind.ai.memory.plugin.ai.spring.autoconfigure.MemindChatClients;
 import com.openmemind.ai.memory.plugin.rawdata.audio.content.AudioContent;
 import com.openmemind.ai.memory.plugin.rawdata.audio.parser.TranscriptionAudioContentParser;
 import com.openmemind.ai.memory.plugin.rawdata.document.DocumentSemantics;
@@ -151,6 +155,47 @@ class MemindServerRuntimeConfigurationTest {
 
         assertThat(readField(reorganizer, "bubbleTracker", BubbleTrackerStore.class))
                 .isSameAs(customBubbleTracker);
+    }
+
+    @Test
+    void runtimeFactoryAppliesConfiguredChatClientsToBuilderSlots() {
+        var defaultClient = proxy(StructuredChatClient.class);
+        var insightClient = proxy(StructuredChatClient.class);
+        var configuredClients =
+                new MemindChatClients(
+                        "default",
+                        defaultClient,
+                        Map.of("default", defaultClient, "insight", insightClient),
+                        Map.of(ChatClientSlot.INSIGHT_GENERATOR, "insight"),
+                        Map.of(ChatClientSlot.INSIGHT_GENERATOR, insightClient));
+        var configuration = new MemindServerRuntimeConfiguration();
+
+        MemoryRuntimeFactory factory =
+                configuration.memoryRuntimeFactory(
+                        provider(MemindChatClients.class, configuredClients),
+                        emptyProvider(StructuredChatClient.class),
+                        provider(MemoryStore.class, memoryStore()),
+                        provider(MemoryBuffer.class, memoryBuffer()),
+                        provider(MemoryVector.class, proxy(MemoryVector.class)),
+                        emptyProvider(MemoryTextSearch.class),
+                        provider(Reranker.class, new NoopReranker()),
+                        emptyProvider(ContentParser.class),
+                        emptyProvider(RawDataPlugin.class),
+                        emptyProvider(ResourceFetcher.class),
+                        emptyProvider(BubbleTrackerStore.class),
+                        emptyProvider(MemoryObserver.class),
+                        emptyProvider(
+                                com.openmemind.ai.memory.core.metrics.MemoryMetricsRecorder.class));
+
+        Memory memory = factory.create(MemoryBuildOptions.defaults()).memory();
+        var extractor = underlyingExtractor((DefaultMemory) memory);
+        var insightLayer = readField(extractor, "insightStep", InsightLayer.class);
+        var scheduler = readField(insightLayer, "scheduler", InsightBuildScheduler.class);
+        var generator = readField(scheduler, "generator", InsightGenerator.class);
+
+        assertThat(generator).isInstanceOf(LlmInsightGenerator.class);
+        assertThat(readField(generator, "structuredChatClient", StructuredChatClient.class))
+                .isSameAs(insightClient);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Rework the Memind Spring AI starter so named chat and embedding clients can inherit Spring AI provider defaults while still supporting per-client overrides for base URL, API key, model, and common options.
- Build only the default chat client and slot-referenced chat clients, so optional/unreferenced clients can stay incomplete until a user routes a slot to them.
- Make a Memind-configured embedding model primary when present, while preserving the fallback behavior when users provide their own embedding/vector beans.
- Move server defaults to a two-layer model: `spring.ai.*` for provider defaults and `memind.ai.*` for client routing; add `.env.example`, Docker Compose fallbacks, and updated English/Chinese Quick Start docs.

## Testing
- `mvn -B -pl memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-ai-spring-ai-starter -Dlicense.skip=true test`
- `mvn -B -pl memind-server -am -Dtest=MemindServerApplicationTest,MemindServerRuntimeConfigurationTest -Dlicense.skip=true test`
- `mvn -B -pl memind-server -am -DskipTests -Dlicense.skip=true package`
- `git diff --check`
- `docker compose config`
- `env -u ... docker compose --env-file .env.example config`
- Started the packaged server jar with no real provider key and default placeholder configuration, then verified `curl -fsS http://localhost:18366/open/v1/health` returned `{"data":{"status":"UP","service":"memind-server"}}`.