### PR TITLE
chore: migrate project code to Jackson 3

### DIFF
--- a/memind-clients/java/memind-client/pom.xml
+++ b/memind-clients/java/memind-client/pom.xml
@@ -33,12 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/MemindClient.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/MemindClient.java
@@ -13,7 +13,7 @@
  */
 package com.openmemind.ai.client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 import com.openmemind.ai.client.exception.MemindClientException;
 import com.openmemind.ai.client.internal.ApiResult;
 import com.openmemind.ai.client.internal.MemindHttpClient;

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/exception/MemindApiException.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/exception/MemindApiException.java
@@ -13,7 +13,7 @@
  */
 package com.openmemind.ai.client.exception;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class MemindApiException extends MemindClientException {
 

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/ErrorResult.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/ErrorResult.java
@@ -14,7 +14,7 @@
 package com.openmemind.ai.client.internal;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record ErrorResult(ApiError error) {

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/MemindHttpClient.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/MemindHttpClient.java
@@ -14,14 +14,15 @@
 package com.openmemind.ai.client.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.openmemind.ai.client.exception.MemindApiException;
 import com.openmemind.ai.client.exception.MemindConnectionException;
 import com.openmemind.ai.client.exception.MemindTimeoutException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
@@ -56,12 +57,7 @@ public class MemindHttpClient implements AutoCloseable {
                 HttpClient.newBuilder()
                         .connectTimeout(Objects.requireNonNull(connectTimeout, "connectTimeout"))
                         .build();
-        this.objectMapper =
-                new ObjectMapper()
-                        .registerModule(new JavaTimeModule())
-                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        this.objectMapper = createObjectMapper();
     }
 
     public <T> CompletableFuture<T> get(String path, TypeReference<ApiResult<T>> responseType) {
@@ -80,7 +76,7 @@ public class MemindHttpClient implements AutoCloseable {
                             .build();
             log.debug("POST {}", request.uri());
             return sendAsync(request, responseType);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             return CompletableFuture.failedFuture(
                     new MemindConnectionException("Failed to serialize request body", e));
         }
@@ -140,7 +136,7 @@ public class MemindHttpClient implements AutoCloseable {
             throw toApiException(status, body, requestId(response));
         } catch (MemindApiException e) {
             throw e;
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new MemindApiException(
                     status,
                     "parse_error",
@@ -150,8 +146,7 @@ public class MemindHttpClient implements AutoCloseable {
         }
     }
 
-    private MemindApiException toApiException(int status, byte[] body, String requestId)
-            throws IOException {
+    private MemindApiException toApiException(int status, byte[] body, String requestId) {
         ErrorResult errorResult = objectMapper.readValue(body, ErrorResult.class);
         ErrorResult.ApiError error = errorResult.error();
         if (error == null) {
@@ -167,6 +162,19 @@ public class MemindHttpClient implements AutoCloseable {
 
     public ObjectMapper getObjectMapper() {
         return objectMapper;
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper =
+                JsonMapper.builder()
+                        .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .changeDefaultPropertyInclusion(
+                                inclusion ->
+                                        inclusion.withValueInclusion(
+                                                JsonInclude.Include.NON_NULL))
+                        .build();
+        return mapper;
     }
 
     @Override

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/RawContentSerializer.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/internal/RawContentSerializer.java
@@ -13,27 +13,27 @@
  */
 package com.openmemind.ai.client.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.openmemind.ai.client.model.common.ConversationContent;
 import com.openmemind.ai.client.model.common.MapRawContent;
 import com.openmemind.ai.client.model.common.RawContent;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class RawContentSerializer extends JsonSerializer<RawContent> {
+public class RawContentSerializer extends ValueSerializer<RawContent> {
 
     @Override
-    public void serialize(RawContent value, JsonGenerator gen, SerializerProvider provider)
-            throws IOException {
+    public void serialize(RawContent value, JsonGenerator gen, SerializationContext context)
+            throws JacksonException {
         gen.writeStartObject();
-        gen.writeStringField("type", value.type());
+        gen.writeStringProperty("type", value.type());
 
         if (value instanceof ConversationContent conv) {
-            gen.writeObjectField("messages", conv.getMessages());
+            context.defaultSerializeProperty("messages", conv.getMessages(), gen);
         } else if (value instanceof MapRawContent map) {
             for (var entry : map.getProperties().entrySet()) {
-                gen.writeObjectField(entry.getKey(), entry.getValue());
+                context.defaultSerializeProperty(entry.getKey(), entry.getValue(), gen);
             }
         }
 

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/model/common/RawContent.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/model/common/RawContent.java
@@ -13,7 +13,7 @@
  */
 package com.openmemind.ai.client.model.common;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.openmemind.ai.client.internal.RawContentSerializer;
 
 @JsonSerialize(using = RawContentSerializer.class)

--- a/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/internal/MemindHttpClientTest.java
+++ b/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/internal/MemindHttpClientTest.java
@@ -28,7 +28,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.openmemind.ai.client.exception.MemindApiException;

--- a/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/model/common/MessageTest.java
+++ b/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/model/common/MessageTest.java
@@ -15,18 +15,16 @@ package com.openmemind.ai.client.model.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class MessageTest {
 
     private final ObjectMapper mapper =
-            new ObjectMapper()
-                    .registerModule(new JavaTimeModule())
-                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
 
     @Test
     void userMessage_serializesCorrectly() throws Exception {

--- a/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/model/common/RawContentSerializerTest.java
+++ b/memind-clients/java/memind-client/src/test/java/com/openmemind/ai/client/model/common/RawContentSerializerTest.java
@@ -15,9 +15,9 @@ package com.openmemind.ai.client.model.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 class RawContentSerializerTest {
 
     private final ObjectMapper mapper =
-            new ObjectMapper()
-                    .registerModule(new JavaTimeModule())
-                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
 
     @Test
     void conversationContent_serializesWithRegisteredTypeField() throws Exception {

--- a/memind-evaluation/pom.xml
+++ b/memind-evaluation/pom.xml
@@ -72,10 +72,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/checkpoint/CheckpointStore.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/checkpoint/CheckpointStore.java
@@ -13,8 +13,6 @@
  */
 package com.openmemind.ai.memory.evaluation.checkpoint;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openmemind.ai.memory.evaluation.adapter.model.SearchResult;
 import com.openmemind.ai.memory.evaluation.pipeline.Stage;
 import com.openmemind.ai.memory.evaluation.pipeline.model.AnswerResult;
@@ -28,6 +26,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Evaluation checkpoint persistence storage, responsible for reading and writing JSON files for checkpoint / search / answer stages
@@ -64,7 +65,7 @@ public class CheckpointStore {
                         state.completedAddConvIds().size(),
                         state.completedStages().size());
                 return state;
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read checkpoint, starting fresh: {}", e.getMessage());
             }
         }
@@ -86,7 +87,7 @@ public class CheckpointStore {
         try {
             CheckpointState state = mapper.readValue(path.toFile(), CheckpointState.class);
             return state.isStageCompleted(stage.name());
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.warn("Failed to read checkpoint: {}", e.getMessage());
             return false;
         }
@@ -98,7 +99,7 @@ public class CheckpointStore {
         if (Files.exists(path)) {
             try {
                 state = mapper.readValue(path.toFile(), CheckpointState.class);
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read checkpoint, creating new: {}", e.getMessage());
                 state = new CheckpointState();
             }
@@ -117,7 +118,7 @@ public class CheckpointStore {
             try {
                 return mapper.readValue(
                         path.toFile(), new TypeReference<Map<String, List<SearchResult>>>() {});
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read search checkpoint: {}", e.getMessage());
             }
         }
@@ -140,7 +141,7 @@ public class CheckpointStore {
             try {
                 return mapper.readValue(
                         path.toFile(), new TypeReference<Map<String, AnswerResult>>() {});
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read answer checkpoint: {}", e.getMessage());
             }
         }
@@ -162,7 +163,7 @@ public class CheckpointStore {
         if (Files.exists(path)) {
             try {
                 return mapper.readValue(path.toFile(), new TypeReference<List<SearchResult>>() {});
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read search results: {}", e.getMessage());
             }
         }
@@ -178,7 +179,7 @@ public class CheckpointStore {
         if (Files.exists(path)) {
             try {
                 return mapper.readValue(path.toFile(), new TypeReference<List<AnswerResult>>() {});
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.warn("Failed to read answer results: {}", e.getMessage());
             }
         }
@@ -204,7 +205,7 @@ public class CheckpointStore {
             mapper.writeValue(tmp.toFile(), data);
             Files.move(
                     tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
+        } catch (IOException | JacksonException e) {
             log.error("Failed to save file {}: {}", path, e.getMessage());
         } finally {
             lock.unlock();

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/config/EvaluationConfiguration.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/config/EvaluationConfiguration.java
@@ -13,18 +13,16 @@
  */
 package com.openmemind.ai.memory.evaluation.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.openmemind.ai.memory.evaluation.checkpoint.CheckpointStore;
 import io.netty.channel.ChannelOption;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Evaluation-specific infrastructure configuration.
@@ -36,12 +34,6 @@ import reactor.netty.resources.ConnectionProvider;
 public class EvaluationConfiguration {
 
     // ─── Infrastructure ─────────────────────────────
-
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper().registerModule(new JavaTimeModule());
-    }
 
     @Bean
     public CheckpointStore checkpointStore(ObjectMapper mapper, EvaluationProperties props) {

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/converter/LongMemEvalConverter.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/converter/LongMemEvalConverter.java
@@ -13,8 +13,6 @@
  */
 package com.openmemind.ai.memory.evaluation.dataset.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -29,6 +27,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Convert LongMemEval format dataset to LoCoMo JSON format

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/converter/PersonaMemConverter.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/converter/PersonaMemConverter.java
@@ -13,9 +13,6 @@
  */
 package com.openmemind.ai.memory.evaluation.dataset.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,6 +27,9 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Convert raw PersonaMem files into the map-root LoCoMo-compatible shape that memind-evaluation
@@ -114,8 +114,8 @@ public class PersonaMemConverter implements DatasetConverter {
                     continue;
                 }
                 JsonNode root = objectMapper.readTree(line);
-                root.fields()
-                        .forEachRemaining(
+                root.properties()
+                        .forEach(
                                 entry ->
                                         contexts.put(
                                                 entry.getKey(),

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/loader/LoCoMoDatasetLoader.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/dataset/loader/LoCoMoDatasetLoader.java
@@ -13,15 +13,12 @@
  */
 package com.openmemind.ai.memory.evaluation.dataset.loader;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openmemind.ai.memory.evaluation.dataset.DatasetLoadOptions;
 import com.openmemind.ai.memory.evaluation.dataset.DatasetLoader;
 import com.openmemind.ai.memory.evaluation.dataset.model.EvalConversation;
 import com.openmemind.ai.memory.evaluation.dataset.model.EvalDataset;
 import com.openmemind.ai.memory.evaluation.dataset.model.EvalMessage;
 import com.openmemind.ai.memory.evaluation.dataset.model.QAPair;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -35,6 +32,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * LoCoMo dataset loader, parses multi-session conversations and QA pairs, supports three-level timestamp fallback and content truncation
@@ -79,8 +79,8 @@ public class LoCoMoDatasetLoader implements DatasetLoader {
                     idx++;
                 }
             } else {
-                root.fields()
-                        .forEachRemaining(
+                root.properties()
+                        .forEach(
                                 entry -> {
                                     String convId = entry.getKey();
                                     JsonNode convNode = entry.getValue();
@@ -96,7 +96,7 @@ public class LoCoMoDatasetLoader implements DatasetLoader {
             }
 
             return new EvalDataset(options.datasetName(), conversations, qaPairs);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException("Failed to load LoCoMo dataset from " + dataPath, e);
         }
     }

--- a/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/report/ReportWriter.java
+++ b/memind-evaluation/src/main/java/com/openmemind/ai/memory/evaluation/report/ReportWriter.java
@@ -13,7 +13,6 @@
  */
 package com.openmemind.ai.memory.evaluation.report;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openmemind.ai.memory.evaluation.adapter.model.SearchResult;
 import com.openmemind.ai.memory.evaluation.pipeline.PipelineConfig;
 import com.openmemind.ai.memory.evaluation.pipeline.model.AnswerResult;
@@ -29,6 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Write evaluation results to report.txt (human-readable) and eval_results.json (machine-readable).

--- a/memind-examples/memind-example-java/pom.xml
+++ b/memind-examples/memind-example-java/pom.xml
@@ -83,11 +83,6 @@
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.19.2</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleDataLoader.java
+++ b/memind-examples/memind-example-java/src/main/java/com/openmemind/ai/memory/example/java/support/ExampleDataLoader.java
@@ -13,8 +13,6 @@
  */
 package com.openmemind.ai.memory.example.java.support;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openmemind.ai.memory.core.extraction.rawdata.content.conversation.message.Message;
 import com.openmemind.ai.memory.plugin.rawdata.toolcall.model.ToolCallRecord;
 import java.io.InputStream;
@@ -24,6 +22,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Loads shared example data from the repository-level data directory.


### PR DESCRIPTION
## Summary
- Migrate remaining project-owned Jackson runtime APIs in the Java client, evaluation module, and Java example from Jackson 2 packages to Jackson 3 `tools.jackson.*` packages.
- Replace Jackson 2 mapper setup patterns with Jackson 3 `JsonMapper`/`DateTimeFeature` APIs and updated `JsonNode` iteration where needed.
- Remove direct Jackson 2 datatype/runtime dependencies from the migrated modules while retaining annotation usage.

## Test Plan
- [x] `mvn test`
- [x] `rg -n "com\\.fasterxml\\.jackson\\.(core|databind|datatype|module|dataformat)" --glob "*.java"`
- [x] `git diff --check`

Closes #129
