### PR TITLE
fix: MySQL compatibility for JDBC plugin temporal writes

### DIFF
--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-core/src/main/java/com/openmemind/ai/memory/plugin/jdbc/internal/graph/JdbcGraphOperations.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-core/src/main/java/com/openmemind/ai/memory/plugin/jdbc/internal/graph/JdbcGraphOperations.java
@@ -32,6 +32,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -129,8 +130,8 @@ public class JdbcGraphOperations implements GraphOperations {
                     statement.setString(5, entity.displayName());
                     statement.setString(6, entity.entityType().name());
                     statement.setString(7, jsonCodec.toJson(entity.metadata()));
-                    statement.setString(8, formatInstant(entity.createdAt()));
-                    statement.setString(9, formatInstant(entity.updatedAt()));
+                    setTemporal(statement, 8, entity.createdAt());
+                    setTemporal(statement, 9, entity.updatedAt());
                 });
     }
 
@@ -164,7 +165,7 @@ public class JdbcGraphOperations implements GraphOperations {
                     statement.setString(5, mention.entityKey());
                     statement.setObject(6, mention.confidence());
                     statement.setString(7, jsonCodec.toJson(mention.metadata()));
-                    statement.setString(8, formatInstant(mention.createdAt()));
+                    setTemporal(statement, 8, mention.createdAt());
                 });
     }
 
@@ -250,7 +251,7 @@ public class JdbcGraphOperations implements GraphOperations {
                     statement.setString(6, link.linkType().name());
                     statement.setObject(7, link.strength());
                     statement.setString(8, jsonCodec.toJson(link.metadata()));
-                    statement.setString(9, formatInstant(link.createdAt()));
+                    setTemporal(statement, 9, link.createdAt());
                     statement.setString(10, link.relationCode());
                     statement.setString(11, link.evidenceSource());
                 });
@@ -287,8 +288,8 @@ public class JdbcGraphOperations implements GraphOperations {
                     statement.setString(6, alias.normalizedAlias());
                     statement.setInt(7, alias.evidenceCount());
                     statement.setString(8, jsonCodec.toJson(alias.metadata()));
-                    statement.setString(9, formatInstant(alias.createdAt()));
-                    statement.setString(10, formatInstant(alias.updatedAt()));
+                    setTemporal(statement, 9, alias.createdAt());
+                    setTemporal(statement, 10, alias.updatedAt());
                 });
     }
 
@@ -499,7 +500,7 @@ public class JdbcGraphOperations implements GraphOperations {
                 cooccurrence.rightEntityKey(),
                 cooccurrence.cooccurrenceCount(),
                 jsonCodec.toJson(cooccurrence.metadata()),
-                formatInstant(cooccurrence.updatedAt()));
+                cooccurrence.updatedAt());
     }
 
     private List<ItemEntityMention> listItemEntityMentions(
@@ -621,7 +622,7 @@ public class JdbcGraphOperations implements GraphOperations {
                 handle -> queryList(handle.getConnection(), sql, mapper::map, params));
     }
 
-    private static <T> List<T> queryList(
+    private <T> List<T> queryList(
             Connection connection, String sql, ResultSetMapper<T> mapper, Object... params) {
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             setParams(statement, params);
@@ -637,7 +638,7 @@ public class JdbcGraphOperations implements GraphOperations {
         }
     }
 
-    private static int executeUpdate(Connection connection, String sql, Object... params) {
+    private int executeUpdate(Connection connection, String sql, Object... params) {
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             setParams(statement, params);
             return statement.executeUpdate();
@@ -659,10 +660,28 @@ public class JdbcGraphOperations implements GraphOperations {
         }
     }
 
-    private static void setParams(PreparedStatement statement, Object... params)
+    private void setParams(PreparedStatement statement, Object... params)
             throws SQLException {
         for (int i = 0; i < params.length; i++) {
-            statement.setObject(i + 1, params[i]);
+            if (params[i] instanceof Instant instant) {
+                setTemporal(statement, i + 1, instant);
+            } else {
+                statement.setObject(i + 1, params[i]);
+            }
+        }
+    }
+
+    /**
+     * Binds an {@link Instant} timestamp. SQLite stores it as TEXT (ISO-8601); MySQL
+     * DATETIME / PostgreSQL TIMESTAMPTZ reject the ISO string with nanosecond precision
+     * ('Incorrect datetime value'), so use the standard JDBC {@link Timestamp} there.
+     */
+    private void setTemporal(PreparedStatement statement, int index, Instant instant)
+            throws SQLException {
+        if (dialect == JdbcGraphDialect.SQLITE) {
+            statement.setString(index, instant == null ? null : instant.toString());
+        } else {
+            statement.setTimestamp(index, instant == null ? null : Timestamp.from(instant));
         }
     }
 
@@ -906,10 +925,6 @@ public class JdbcGraphOperations implements GraphOperations {
 
     private static String placeholders(int count) {
         return String.join(", ", java.util.Collections.nCopies(count, "?"));
-    }
-
-    private static String formatInstant(Instant instant) {
-        return instant == null ? null : instant.toString();
     }
 
     private static Instant parseInstant(String value) {

--- a/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-core/src/main/java/com/openmemind/ai/memory/plugin/jdbc/internal/jdbi/JdbiTemporalSupport.java
+++ b/memind-plugins/memind-plugin-jdbc/memind-plugin-jdbc-core/src/main/java/com/openmemind/ai/memory/plugin/jdbc/internal/jdbi/JdbiTemporalSupport.java
@@ -13,6 +13,7 @@
  */
 package com.openmemind.ai.memory.plugin.jdbc.internal.jdbi;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 import org.jdbi.v3.core.Jdbi;
@@ -34,7 +35,7 @@ final class JdbiTemporalSupport {
                     if (value instanceof Instant instant) {
                         return Optional.of(
                                 (position, statement, context) ->
-                                        statement.setString(position, instant.toString()));
+                                        statement.setTimestamp(position, Timestamp.from(instant)));
                     }
                     return Optional.empty();
                 };
@@ -45,6 +46,7 @@ final class JdbiTemporalSupport {
         if (value.chars().allMatch(Character::isDigit)) {
             return Instant.ofEpochMilli(Long.parseLong(value));
         }
-        return Instant.parse(value);
+        String normalized = value.contains("T") ? value : value.replace(' ', 'T') + "Z";
+        return Instant.parse(normalized.endsWith("Z") ? normalized : normalized + "Z");
     }
 }

--- a/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/handler/InstantTypeHandler.java
+++ b/memind-plugins/memind-plugin-spring-boot-starters/memind-plugin-mybatis-plus-starter/src/main/java/com/openmemind/ai/memory/plugin/store/mybatis/handler/InstantTypeHandler.java
@@ -17,19 +17,23 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
 
 /**
- * MyBatis TypeHandler: Converts Java {@link Instant} to and from SQLite TEXT column.
+ * MyBatis TypeHandler: Converts Java {@link Instant} to and from SQL temporal columns.
  *
- * <p>Writing: {@code Instant} → ISO-8601 string (e.g. {@code 2024-01-01T12:00:00Z})<br>
- * Reading: ISO-8601 string → {@code Instant}
+ * <p>Writing: {@link Instant} → {@link Timestamp} (standard JDBC).<br>
+ * Reading: accepts ISO-8601 (with {@code Z}), {@code yyyy-MM-dd HH:mm:ss[.SSS]} (space-separated,
+ * treated as UTC), or epoch millis.
  *
- * <p>Solves the problem that SQLite JDBC cannot directly parse epoch milliseconds to Timestamp.
- *
+ * <p>Previously wrote {@code Instant.toString()} (ISO-8601 with {@code Z} + nanosecond precision)
+ * as a String — SQLite TEXT and PostgreSQL TIMESTAMPTZ tolerated it, but MySQL {@code DATETIME}
+ * rejects it ({@code Incorrect datetime value}). Using {@code setTimestamp} is portable across all
+ * three drivers.
  */
 @MappedTypes(Instant.class)
 public class InstantTypeHandler extends BaseTypeHandler<Instant> {
@@ -37,7 +41,7 @@ public class InstantTypeHandler extends BaseTypeHandler<Instant> {
     @Override
     public void setNonNullParameter(
             PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType) throws SQLException {
-        ps.setString(i, parameter.toString());
+        ps.setTimestamp(i, Timestamp.from(parameter));
     }
 
     @Override

--- a/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/MemoryAdminService.java
+++ b/memind-server/src/main/java/com/openmemind/ai/memory/server/service/memory/MemoryAdminService.java
@@ -65,7 +65,9 @@ public class MemoryAdminService {
 
         Long total =
                 jdbcTemplate.queryForObject(
-                        "SELECT COUNT(*) FROM (SELECT memory_id " + where + " GROUP BY memory_id)",
+                        "SELECT COUNT(*) FROM (SELECT memory_id "
+                                + where
+                                + " GROUP BY memory_id) memory_count",
                         Long.class,
                         args.toArray());
         long totalItems = total == null ? 0 : total;


### PR DESCRIPTION
fix JDBC 插件时间字段写入与 admin memory 查询的 MySQL 兼容问题