### PR TITLE
feat(client): add fire-and-forget async pipeline endpoints

### DIFF
--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/MemindClient.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/MemindClient.java
@@ -26,6 +26,7 @@ import com.openmemind.ai.client.model.request.RetrieveMemoryRequest;
 import com.openmemind.ai.client.model.response.AddMessageResponse;
 import com.openmemind.ai.client.model.response.ExtractMemoryResponse;
 import com.openmemind.ai.client.model.response.HealthResponse;
+import com.openmemind.ai.client.model.response.OperationAccepted;
 import com.openmemind.ai.client.model.response.QueryMemoryItemsResponse;
 import com.openmemind.ai.client.model.response.QueryMemoryRawDataResponse;
 import com.openmemind.ai.client.model.response.RetrieveMemoryResponse;
@@ -132,6 +133,40 @@ public class MemindClient implements AutoCloseable {
                 "/open/v1/memory/raw-data/query",
                 Objects.requireNonNull(request, "request"),
                 new TypeReference<ApiResult<QueryMemoryRawDataResponse>>() {});
+    }
+
+    /**
+     * Fire-and-forget: submits a message to the async pipeline
+     * ({@code POST /open/v1/memory/async/add-message}).
+     *
+     * <p>The server buffers the message and returns 202 immediately; extraction is
+     * triggered asynchronously by the server's boundary detector. Unlike
+     * {@link #addMessageAsync(AddMessageRequest)}, this does not block waiting for the
+     * synchronous extraction path.
+     */
+    public CompletableFuture<Void> submitMessageAsync(AddMessageRequest request) {
+        ensureOpen();
+        return httpClient.post(
+                        "/open/v1/memory/async/add-message",
+                        Objects.requireNonNull(request, "request"),
+                        new TypeReference<ApiResult<OperationAccepted>>() {})
+                .thenApply(ignored -> null);
+    }
+
+    /**
+     * Fire-and-forget: submits a commit to the async pipeline
+     * ({@code POST /open/v1/memory/async/commit}).
+     *
+     * <p>Returns 202 immediately; extraction runs asynchronously server-side. Use this to
+     * avoid blocking on long LLM-driven extraction (the sync commit can exceed HTTP timeouts).
+     */
+    public CompletableFuture<Void> submitCommitAsync(CommitMemoryRequest request) {
+        ensureOpen();
+        return httpClient.post(
+                        "/open/v1/memory/async/commit",
+                        Objects.requireNonNull(request, "request"),
+                        new TypeReference<ApiResult<OperationAccepted>>() {})
+                .thenApply(ignored -> null);
     }
 
     public CompletableFuture<HealthResponse> healthAsync() {

--- a/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/model/response/OperationAccepted.java
+++ b/memind-clients/java/memind-client/src/main/java/com/openmemind/ai/client/model/response/OperationAccepted.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.openmemind.ai.client.model.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Response payload of the async /open/v1/memory/async/* endpoints (HTTP 202). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OperationAccepted(String operationId, String status, String mode) {}


### PR DESCRIPTION
Add fire-and-forget async pipeline endpoints to the Java client.

- MemindClient: new async entrypoints for pipeline operations (create/execute) that return immediately.
- OperationAccepted response model for the accepted-task result.

Relates to: https://github.com/openmemind/memind/pull/132