### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/memind-clients/java/pom.xml
+++ b/memind-clients/java/pom.xml
@@ -65,7 +65,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <revision>0.2.0-SNAPSHOT</revision>
+        <revision>0.2.0</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/memind-dependencies/pom.xml
+++ b/memind-dependencies/pom.xml
@@ -56,7 +56,7 @@
     </issueManagement>
 
     <properties>
-        <revision>0.2.0-SNAPSHOT</revision>
+        <revision>0.2.0</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>

--- a/memind-server/src/main/resources/application.yml
+++ b/memind-server/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
       server:
         enabled: ${MEMIND_MCP_ENABLED:true}
         name: memind-mcp-server
-        version: ${MEMIND_MCP_SERVER_VERSION:0.2.0-SNAPSHOT}
+        version: ${MEMIND_MCP_SERVER_VERSION:0.2.0}
         type: SYNC
         protocol: STATELESS
         request-timeout: ${MEMIND_MCP_REQUEST_TIMEOUT:30s}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </modules>
 
     <properties>
-        <revision>0.2.0-SNAPSHOT</revision>
+        <revision>0.2.0</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>


### PR DESCRIPTION
## memind Version

0.2.0

## Description

Prepare the project for the stable 0.2.0 release by:

- setting the root Maven reactor revision to 0.2.0
- setting the dependency BOM revision to 0.2.0
- setting the Java client revision to 0.2.0
- setting the MCP server default version to 0.2.0

Release notes, including migration guidance for breaking changes: #136

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Release preparation

## Related Issue

Closes #136

## Checklist

- [x] Code formatting passes for modules configured with Spotless
- [x] Checkstyle passes
- [x] All tests are passing (`mvnd test`)
- [x] CI-equivalent build passes (`mvnd clean install -Dmaven.test.skip=true`)
- [x] Related version metadata has been updated
- [x] Code is ready for review

## Verification

- Root, BOM, and Java client Maven versions each resolve to 0.2.0
- Full 36-module test reactor: BUILD SUCCESS
- Full 36-module CI-equivalent install reactor: BUILD SUCCESS
- `git diff --check`: passed
